### PR TITLE
Resolve actual SHA of PR base branch

### DIFF
--- a/src/bors/handlers/workflow.rs
+++ b/src/bors/handlers/workflow.rs
@@ -21,7 +21,14 @@ pub(super) async fn handle_workflow_started(
         payload.commit_sha
     );
 
-    let Some(build) = db.find_build(&payload.repository, payload.branch.clone(), payload.commit_sha.clone()).await? else {
+    let Some(build) = db
+        .find_build(
+            &payload.repository,
+            payload.branch.clone(),
+            payload.commit_sha.clone(),
+        )
+        .await?
+    else {
         tracing::warn!("Build for workflow not found");
         return Ok(());
     };
@@ -92,8 +99,12 @@ async fn try_complete_build<Client: RepositoryClient>(
             payload.branch.clone(),
             payload.commit_sha.clone(),
         )
-        .await? else {
-        tracing::warn!("Received check suite finished for an unknown build: {}", payload.commit_sha);
+        .await?
+    else {
+        tracing::warn!(
+            "Received check suite finished for an unknown build: {}",
+            payload.commit_sha
+        );
         return Ok(());
     };
 

--- a/src/bors/mod.rs
+++ b/src/bors/mod.rs
@@ -23,6 +23,9 @@ pub use handlers::handle_bors_event;
 pub trait RepositoryClient {
     fn repository(&self) -> &GithubRepoName;
 
+    /// Return the current SHA of the given branch.
+    async fn get_branch_sha(&mut self, name: &str) -> anyhow::Result<CommitSha>;
+
     /// Resolve a pull request from this repository by it's number.
     async fn get_pull_request(&mut self, pr: PullRequestNumber) -> anyhow::Result<PullRequest>;
 

--- a/src/github/api/client.rs
+++ b/src/github/api/client.rs
@@ -39,6 +39,24 @@ impl RepositoryClient for GithubRepositoryClient {
         self.name()
     }
 
+    async fn get_branch_sha(&mut self, name: &str) -> anyhow::Result<CommitSha> {
+        // https://docs.github.com/en/rest/branches/branches?apiVersion=2022-11-28#get-a-branch
+        let response = self
+            .client
+            ._get(
+                self.client.base_url.join(&format!(
+                    "/repos/{}/{}/branches/{name}",
+                    self.repo_name.owner(),
+                    self.repo_name.name(),
+                ))?,
+                None::<&()>,
+            )
+            .await?;
+        let branch: octocrab::models::repos::Branch =
+            response.json().await.context("Cannot deserialize branch")?;
+        Ok(CommitSha(branch.commit.sha))
+    }
+
     async fn get_pull_request(&mut self, pr: PullRequestNumber) -> anyhow::Result<PullRequest> {
         let pr = self
             .client

--- a/src/github/webhook.rs
+++ b/src/github/webhook.rs
@@ -141,7 +141,7 @@ where
 
 fn parse_webhook_event(request: Parts, body: &[u8]) -> anyhow::Result<Option<BorsEvent>> {
     let Some(event_type) = request.headers.get("x-github-event") else {
-         return Err(anyhow::anyhow!("x-github-event header not found"));
+        return Err(anyhow::anyhow!("x-github-event header not found"));
     };
 
     tracing::trace!(
@@ -311,10 +311,7 @@ fn parse_pr_comment(
 
 fn parse_repository_name(repository: &Repository) -> anyhow::Result<GithubRepoName> {
     let repo_name = &repository.name;
-    let Some(repo_owner) = repository
-        .owner
-        .as_ref()
-        .map(|u| &u.login) else {
+    let Some(repo_owner) = repository.owner.as_ref().map(|u| &u.login) else {
         return Err(anyhow::anyhow!("Owner for repo {repo_name} is missing"));
     };
     Ok(GithubRepoName::new(repo_owner, repo_name))
@@ -331,7 +328,10 @@ fn verify_gh_signature(
     let Some(signature) = headers.get("x-hub-signature-256").map(|v| v.as_bytes()) else {
         return false;
     };
-    let Some(signature) = signature.get(b"sha256=".len()..).and_then(|v| hex::decode(v).ok()) else {
+    let Some(signature) = signature
+        .get(b"sha256=".len()..)
+        .and_then(|v| hex::decode(v).ok())
+    else {
         return false;
     };
 

--- a/src/tests/github.rs
+++ b/src/tests/github.rs
@@ -11,7 +11,7 @@ pub struct PR {
     head_label: String,
     #[builder(default = "self.default_head()")]
     head: GHBranch,
-    #[builder(default = "self.default_base()")]
+    #[builder(default = "default_base_branch()")]
     base: GHBranch,
     #[builder(default = "\"PR title\".to_string()")]
     title: String,
@@ -49,13 +49,13 @@ impl PRBuilder {
             .sha("pr-sha".to_string())
             .create()
     }
+}
 
-    fn default_base(&self) -> GHBranch {
-        BranchBuilder::default()
-            .name("main-branch".to_string())
-            .sha("main-sha".to_string())
-            .create()
-    }
+pub fn default_base_branch() -> GHBranch {
+    BranchBuilder::default()
+        .name("main-branch".to_string())
+        .sha("main-sha".to_string())
+        .create()
 }
 
 #[derive(Builder)]


### PR DESCRIPTION
Before, the SHA was taken out of `pr.base.sha`, but that commit SHA might not be updated.