### PR TITLE
chore: bump rust version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.70 as base
+FROM rust:1.76 as base
 
 ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 


### PR DESCRIPTION
The current rust version in Dockerfile is too old, make it incompatible with cargo chef