### PR TITLE
feat: try last parent

### DIFF
--- a/database/entity/src/build.rs
+++ b/database/entity/src/build.rs
@@ -12,6 +12,7 @@ pub struct Model {
     pub commit_sha: String,
     pub status: String,
     pub created_at: DateTime,
+    pub parent: String,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/database/migration/src/lib.rs
+++ b/database/migration/src/lib.rs
@@ -3,6 +3,7 @@ pub use sea_orm_migration::prelude::*;
 mod m20230505_165859_create_build;
 mod m20230506_075859_create_pr;
 mod m20230506_102008_create_workflow;
+mod m20240312_053916_add_parent_to_build;
 
 pub struct Migrator;
 
@@ -13,6 +14,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20230505_165859_create_build::Migration),
             Box::new(m20230506_075859_create_pr::Migration),
             Box::new(m20230506_102008_create_workflow::Migration),
+            Box::new(m20240312_053916_add_parent_to_build::Migration),
         ]
     }
 }

--- a/database/migration/src/m20240312_053916_add_parent_to_build.rs
+++ b/database/migration/src/m20240312_053916_add_parent_to_build.rs
@@ -1,0 +1,37 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Build::Table)
+                    .add_column(ColumnDef::new(Build::Parent).string().not_null())
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Replace the sample below with your own migration scripts
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Build::Table)
+                    .drop_column(Build::Parent)
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+/// Learn more at https://docs.rs/sea-query#iden
+#[derive(Iden)]
+pub enum Build {
+    Table,
+    Parent,
+}

--- a/src/bors/command/mod.rs
+++ b/src/bors/command/mod.rs
@@ -2,6 +2,12 @@ mod parser;
 use crate::github::CommitSha;
 pub use parser::{CommandParseError, CommandParser};
 
+#[derive(Clone, Debug, PartialEq)]
+pub enum Parent {
+    CommitSha(CommitSha),
+    Last,
+}
+
 /// Bors command specified by a user.
 #[derive(Debug, PartialEq)]
 pub enum BorsCommand {
@@ -12,7 +18,7 @@ pub enum BorsCommand {
     /// Perform a try build.
     Try {
         /// Parent commit which should be used as the merge base.
-        parent: Option<CommitSha>,
+        parent: Option<Parent>,
     },
     /// Cancel a try build.
     TryCancel,

--- a/src/bors/command/mod.rs
+++ b/src/bors/command/mod.rs
@@ -2,9 +2,12 @@ mod parser;
 use crate::github::CommitSha;
 pub use parser::{CommandParseError, CommandParser};
 
+/// Type of parent allowed in a try build
 #[derive(Clone, Debug, PartialEq)]
 pub enum Parent {
+    /// Regular commit sha: parent="<sha>"
     CommitSha(CommitSha),
+    /// Use last build's parent: parent="last"
     Last,
 }
 

--- a/src/bors/handlers/trybuild.rs
+++ b/src/bors/handlers/trybuild.rs
@@ -427,6 +427,8 @@ mod tests {
             &[
                 "ea9c1b050cc8b420c2c211d2177811e564a4dc60",
                 &default_merge_sha(),
+                "ea9c1b050cc8b420c2c211d2177811e564a4dc60",
+                &default_merge_sha(),
             ],
         );
     }

--- a/src/bors/handlers/trybuild.rs
+++ b/src/bors/handlers/trybuild.rs
@@ -65,7 +65,7 @@ pub(super) async fn command_try_build<Client: RepositoryClient>(
                     repo.client
                         .post_comment(
                             pr.number,
-                            ":exclamation: There was no previous build. Please set an explicit parent or remove the parent option to use a default value.",
+                            ":exclamation: There was no previous build. Please set an explicit parent or remove the `parent=last` argument to use the default parent.",
                         )
                     .await?;
                     return Ok(());
@@ -438,7 +438,7 @@ mod tests {
         state.comment("@bors try parent=last").await;
         state.client().check_comments(
             default_pr_number(),
-            &[":exclamation: There was no previous build. Please set an explicit parent or remove the parent option to use a default value."],
+            &[":exclamation: There was no previous build. Please set an explicit parent or remove the `parent=last` argument to use the default parent."],
         );
     }
 

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -33,11 +33,13 @@ pub enum BuildStatus {
 }
 
 /// Represents a single (merged) commit.
+#[derive(Debug)]
 pub struct BuildModel {
     pub id: PrimaryKey,
     pub repository: String,
     pub branch: String,
     pub commit_sha: String,
+    pub parent: String,
     pub status: BuildStatus,
     pub created_at: DateTime<Utc>,
 }
@@ -105,6 +107,7 @@ pub trait DbClient {
         pr: PullRequestModel,
         branch: String,
         commit_sha: CommitSha,
+        parent: CommitSha,
     ) -> anyhow::Result<()>;
 
     /// Finds a build row by its repository, commit SHA and branch.

--- a/src/database/sea_orm_client.rs
+++ b/src/database/sea_orm_client.rs
@@ -89,11 +89,13 @@ impl DbClient for SeaORMClient {
         pr: PullRequestModel,
         branch: String,
         commit_sha: CommitSha,
+        parent: CommitSha,
     ) -> anyhow::Result<()> {
         let build = build::ActiveModel {
             repository: Set(pr.repository.clone()),
             branch: Set(branch),
             commit_sha: Set(commit_sha.0),
+            parent: Set(parent.0),
             status: Set(build_status_to_db(BuildStatus::Pending).to_string()),
             ..Default::default()
         };
@@ -291,6 +293,7 @@ fn build_from_db(model: build::Model) -> BuildModel {
         repository: model.repository,
         branch: model.branch,
         commit_sha: model.commit_sha,
+        parent: model.parent,
         status: build_status_from_db(model.status),
         created_at: datetime_from_db(model.created_at),
     }

--- a/src/tests/state.rs
+++ b/src/tests/state.rs
@@ -359,7 +359,16 @@ impl RepositoryClient for TestRepositoryClient {
     }
 
     async fn set_branch_to_sha(&mut self, branch: &str, sha: &CommitSha) -> anyhow::Result<()> {
-        self.add_branch_sha(branch, &sha.0);
+        let branch_history = self.branch_history.entry(branch.to_string()).or_default();
+        let position = branch_history.iter().position(|s| s == sha);
+        match position {
+            None => branch_history.push(sha.clone()),
+            Some(p) => {
+                let (his, _) = branch_history.split_at(p + 1);
+                let his = his.to_vec();
+                self.branch_history.insert(branch.to_string(), his);
+            }
+        }
         Ok(())
     }
 

--- a/src/tests/state.rs
+++ b/src/tests/state.rs
@@ -359,16 +359,7 @@ impl RepositoryClient for TestRepositoryClient {
     }
 
     async fn set_branch_to_sha(&mut self, branch: &str, sha: &CommitSha) -> anyhow::Result<()> {
-        let branch_history = self.branch_history.entry(branch.to_string()).or_default();
-        let position = branch_history.iter().position(|s| s == sha);
-        match position {
-            None => branch_history.push(sha.clone()),
-            Some(p) => {
-                let (his, _) = branch_history.split_at(p + 1);
-                let his = his.to_vec();
-                self.branch_history.insert(branch.to_string(), his);
-            }
-        }
+        self.add_branch_sha(branch, &sha.0);
         Ok(())
     }
 


### PR DESCRIPTION
# What

Implement `@bors try parent=last`, to use the last build parent as base.
Will post a comment to explain if no last build was found, and postpone.

Fixes: https://github.com/rust-lang/bors/issues/29