### PR TITLE
Add test for running the Docker image on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,3 +61,10 @@ jobs:
           context: .
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          tags: bors
+          load: true
+      - name: Run Docker image
+        run: |
+          # Check that the service starts
+          docker run bors &
+          timeout 20 bash -c 'until nc -z localhost 8080; do sleep 1; done'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,4 @@ jobs:
           tags: bors
           load: true
       - name: Run Docker image
-        run: |
-          # Check that the service starts
-          docker run bors &
-          timeout 20 bash -c 'until nc -z localhost 8080; do sleep 1; done'
+        run: docker run bors --help

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ COPY database database
 
 RUN cargo build --release
 
-FROM ubuntu:20.04 as runtime
+FROM ubuntu:22.04 as runtime
 
 WORKDIR /
 


### PR DESCRIPTION
The bot now fails in Docker (wrong `OpenSSL` version), this should help catch issues like this in the future. 