### PR TITLE
Temporarily disable concurrency of bors

### DIFF
--- a/src/github/server.rs
+++ b/src/github/server.rs
@@ -74,16 +74,14 @@ pub fn create_bors_process(
             let state = state.clone();
             let ctx = ctx.clone();
 
-            tokio::spawn(async move {
-                let span = tracing::info_span!("Event");
-                tracing::debug!("Received event: {event:#?}");
-                if let Err(error) = handle_bors_event(event, state, ctx)
-                    .instrument(span.clone())
-                    .await
-                {
-                    span.log_error(error);
-                }
-            });
+            let span = tracing::info_span!("Event");
+            tracing::debug!("Received event: {event:#?}");
+            if let Err(error) = handle_bors_event(event, state, ctx)
+                .instrument(span.clone())
+                .await
+            {
+                span.log_error(error);
+            }
         }
     };
     (tx, service)


### PR DESCRIPTION
For now, bors does not perform any locking of per-repository GitHub API operations, which share a common resource (e.g. the try branches). This means that it is open to race conditions. Until such locking is introduced, we should handle commands serially.

The code is now prepared for concurrent execution (with `Arc`s etc.), so disabling/enabling concurrency is a matter of such a one-line change, which is great.