### PR TITLE
feat: add metadata to comment

### DIFF
--- a/src/bors/comment.rs
+++ b/src/bors/comment.rs
@@ -1,0 +1,49 @@
+use serde::Serialize;
+
+use crate::github::CommitSha;
+
+/// A comment that can be posted to a pull request.
+pub struct Comment {
+    text: String,
+    metadata: Option<CommentMetadata>,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "type")]
+pub enum CommentMetadata {
+    TryBuildCompleted { merge_sha: String },
+}
+
+impl Comment {
+    pub fn new(text: String) -> Self {
+        Self {
+            text,
+            metadata: None,
+        }
+    }
+
+    pub fn render(&self) -> String {
+        if let Some(metadata) = &self.metadata {
+            return format!(
+                "{}\n<!-- homu: {} -->",
+                self.text,
+                serde_json::to_string(metadata).unwrap()
+            );
+        }
+        self.text.clone()
+    }
+}
+
+pub fn try_build_succeeded_comment(workflow_list: String, commit_sha: CommitSha) -> Comment {
+    Comment {
+        text: format!(
+            r#":sunny: Try build successful
+{}
+Build commit: {} (`{}`)"#,
+            workflow_list, commit_sha, commit_sha
+        ),
+        metadata: Some(CommentMetadata::TryBuildCompleted {
+            merge_sha: commit_sha.to_string(),
+        }),
+    }
+}

--- a/src/bors/handlers/trybuild.rs
+++ b/src/bors/handlers/trybuild.rs
@@ -568,6 +568,7 @@ mod tests {
         :sunny: Try build successful
         - [workflow-2](https://workflow-2.com) :white_check_mark:
         Build commit: merge2 (`merge2`)
+        <!-- homu: {"type":"TryBuildCompleted","merge_sha":"merge2"} -->
         "###);
     }
 

--- a/src/bors/handlers/workflow.rs
+++ b/src/bors/handlers/workflow.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use crate::bors::comment::try_build_succeeded_comment;
 use crate::bors::event::{CheckSuiteCompleted, WorkflowCompleted, WorkflowStarted};
 use crate::bors::handlers::is_bors_observed_branch;
 use crate::bors::handlers::labels::handle_label_trigger;
@@ -180,12 +181,7 @@ async fn try_complete_build<Client: RepositoryClient>(
     let message = if !has_failure {
         tracing::info!("Workflow succeeded");
 
-        Comment::new(format!(
-            r#":sunny: Try build successful
-{}
-Build commit: {} (`{}`)"#,
-            workflow_list, payload.commit_sha, payload.commit_sha
-        ))
+        try_build_succeeded_comment(workflow_list, payload.commit_sha)
     } else {
         tracing::info!("Workflow failed");
         Comment::new(format!(
@@ -337,6 +333,7 @@ mod tests {
         :sunny: Try build successful
         - [workflow-1](https://workflow-1.com) :white_check_mark:
         Build commit: sha-merged (`sha-merged`)
+        <!-- homu: {"type":"TryBuildCompleted","merge_sha":"sha-merged"} -->
         "###
         );
     }
@@ -401,6 +398,7 @@ mod tests {
         - [workflow-1](https://workflow-1.com) :white_check_mark:
         - [workflow-2](https://workflow-2.com) :white_check_mark:
         Build commit: sha-merged (`sha-merged`)
+        <!-- homu: {"type":"TryBuildCompleted","merge_sha":"sha-merged"} -->
         "###);
     }
 
@@ -473,6 +471,7 @@ mod tests {
         :sunny: Try build successful
         - [workflow-name](https://workflow-name-1) :white_check_mark:
         Build commit: sha-merged (`sha-merged`)
+        <!-- homu: {"type":"TryBuildCompleted","merge_sha":"sha-merged"} -->
         "###);
     }
 

--- a/src/bors/mod.rs
+++ b/src/bors/mod.rs
@@ -1,4 +1,5 @@
 mod command;
+pub mod comment;
 mod context;
 pub mod event;
 mod handlers;
@@ -14,6 +15,7 @@ use crate::config::RepositoryConfig;
 use crate::github::{CommitSha, GithubRepoName, MergeError, PullRequest, PullRequestNumber};
 use crate::permissions::UserPermissions;
 pub use command::CommandParser;
+pub use comment::Comment;
 pub use context::BorsContext;
 pub use handlers::handle_bors_event;
 
@@ -104,18 +106,4 @@ pub struct RepositoryState<Client: RepositoryClient> {
     pub client: Client,
     pub permissions: ArcSwap<UserPermissions>,
     pub config: ArcSwap<RepositoryConfig>,
-}
-
-/// A comment that can be posted to a pull request.
-pub struct Comment {
-    text: String,
-}
-impl Comment {
-    pub fn new(text: String) -> Self {
-        Self { text }
-    }
-
-    pub fn render(&self) -> &str {
-        &self.text
-    }
 }


### PR DESCRIPTION
Fixes #58
We have much more unique comment than we do metadata, so instead of a dedicated Comment Struct for each type of comments, I created a Metadata struct for each type of Metadata