### PR TITLE
tests: ping comment with wiremock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,6 +144,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -269,9 +279,9 @@ checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
@@ -333,6 +343,7 @@ dependencies = [
  "anyhow",
  "arc-swap",
  "axum",
+ "base64 0.22.1",
  "chrono",
  "clap",
  "derive_builder",
@@ -361,6 +372,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "wiremock",
 ]
 
 [[package]]
@@ -623,6 +635,24 @@ dependencies = [
  "quote",
  "syn 2.0.52",
 ]
+
+[[package]]
+name = "deadpool"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb84100978c1c7b37f09ed3ce3e5f843af02c2a2c431bae5b19230dad2c1b490"
+dependencies = [
+ "async-trait",
+ "deadpool-runtime",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "der"
@@ -1625,7 +1655,7 @@ checksum = "a6d07f2ea5f11065486c5d66e7fa592833038377c8b55c0b8694a624732fee32"
 dependencies = [
  "arc-swap",
  "async-trait",
- "base64 0.22.0",
+ "base64 0.22.1",
  "bytes",
  "cfg-if",
  "chrono",
@@ -3725,6 +3755,30 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec874e1eef0df2dcac546057fe5e29186f09c378181cd7b635b4b7bcc98e9d81"
+dependencies = [
+ "assert-json-diff",
+ "async-trait",
+ "base64 0.21.7",
+ "deadpool",
+ "futures",
+ "http 1.1.0",
+ "http-body-util",
+ "hyper 1.2.0",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,8 @@ migration = { path = "database/migration" }
 [dev-dependencies]
 insta = "1.26"
 derive_builder = "0.20.0"
+wiremock = "0.6.0"
+base64 = "0.22.1"
 
 [profile.release]
 debug = 1

--- a/src/bin/bors.rs
+++ b/src/bin/bors.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use anyhow::Context;
 use bors::{
     create_app, create_bors_process, create_github_client, BorsContext, BorsGlobalEvent,
-    CommandParser, SeaORMClient, ServerState, WebhookSecret,
+    CommandParser, SeaORMClient, ServerState, TeamApiClient, WebhookSecret,
 };
 use clap::Parser;
 use sea_orm::{ConnectOptions, Database};
@@ -79,12 +79,14 @@ fn try_main(opts: Opts) -> anyhow::Result<()> {
     let client = runtime.block_on(async move {
         create_github_client(opts.app_id.into(), opts.private_key.into_bytes().into())
     })?;
+    let team_api_client = TeamApiClient::default();
 
     let ctx = runtime
         .block_on(BorsContext::new(
             CommandParser::new(opts.cmd_prefix),
             Arc::new(db),
             Arc::new(client),
+            team_api_client,
         ))
         .context("Cannot initialize bors context")?;
     let (repository_tx, global_tx, bors_process) = create_bors_process(ctx);

--- a/src/bors/context.rs
+++ b/src/bors/context.rs
@@ -1,4 +1,7 @@
-use crate::{bors::command::CommandParser, database::DbClient, github::GithubRepoName};
+use crate::{
+    bors::command::CommandParser, database::DbClient, github::GithubRepoName,
+    permissions::TeamApiClient,
+};
 use std::{
     collections::HashMap,
     sync::{Arc, RwLock},
@@ -11,6 +14,7 @@ pub struct BorsContext<Client: RepositoryClient> {
     pub db: Arc<dyn DbClient>,
     pub repository_loader: Arc<dyn RepositoryLoader<Client>>,
     pub repositories: RwLock<HashMap<GithubRepoName, Arc<RepositoryState<Client>>>>,
+    pub team_api_client: TeamApiClient,
 }
 
 impl<Client: RepositoryClient> BorsContext<Client> {
@@ -18,14 +22,19 @@ impl<Client: RepositoryClient> BorsContext<Client> {
         parser: CommandParser,
         db: Arc<dyn DbClient>,
         global_client: Arc<dyn RepositoryLoader<Client>>,
+        team_api_client: TeamApiClient,
     ) -> anyhow::Result<Self> {
         let repositories = global_client.load_repositories().await?;
+        for name in repositories.keys() {
+            team_api_client.fetch_permissions(name).await?;
+        }
         let repositories = RwLock::new(repositories);
         Ok(Self {
             parser,
             db,
             repository_loader: global_client,
             repositories,
+            team_api_client,
         })
     }
 }

--- a/src/bors/handlers/ping.rs
+++ b/src/bors/handlers/ping.rs
@@ -17,15 +17,12 @@ pub(super) async fn command_ping<Client: RepositoryClient>(
 
 #[cfg(test)]
 mod tests {
-    use crate::tests::event::default_pr_number;
-    use crate::tests::state::ClientBuilder;
+    use crate::tests::tester::BorsTester;
 
     #[tokio::test]
     async fn test_ping() {
-        let state = ClientBuilder::default().create_state().await;
-        state.comment("@bors ping").await;
-        state
-            .client()
-            .check_comments(default_pr_number(), &["Pong 🏓!"]);
+        let mut tester = BorsTester::new().await;
+        tester.comment("@bors ping").await;
+        tester.check_comments(&["Pong 🏓!"]).await;
     }
 }

--- a/src/bors/mod.rs
+++ b/src/bors/mod.rs
@@ -14,7 +14,6 @@ use octocrab::models::RunId;
 use crate::bors::event::PullRequestComment;
 use crate::config::RepositoryConfig;
 use crate::github::{CommitSha, GithubRepoName, MergeError, PullRequest, PullRequestNumber};
-use crate::permissions::UserPermissions;
 pub use command::CommandParser;
 pub use comment::Comment;
 pub use context::BorsContext;
@@ -101,6 +100,5 @@ pub struct CheckSuite {
 pub struct RepositoryState<Client: RepositoryClient> {
     pub repository: GithubRepoName,
     pub client: Client,
-    pub permissions: ArcSwap<UserPermissions>,
     pub config: ArcSwap<RepositoryConfig>,
 }

--- a/src/github/api/mod.rs
+++ b/src/github/api/mod.rs
@@ -11,7 +11,6 @@ use client::GithubRepositoryClient;
 
 use crate::bors::{RepositoryClient, RepositoryState};
 use crate::github::GithubRepoName;
-use crate::permissions::load_permissions;
 
 pub mod client;
 pub(crate) mod operations;
@@ -152,14 +151,9 @@ async fn create_repo_state(
         }
     };
 
-    let permissions = load_permissions(&name)
-        .await
-        .map_err(|error| anyhow::anyhow!("Could not load permissions for {name}: {error:?}"))?;
-
     Ok(RepositoryState {
         repository: name,
         client,
         config: ArcSwap::new(Arc::new(config)),
-        permissions: ArcSwap::new(Arc::new(permissions)),
     })
 }

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -8,7 +8,7 @@ use url::Url;
 pub mod api;
 mod labels;
 pub mod server;
-mod webhook;
+pub mod webhook;
 
 pub use api::operations::MergeError;
 pub use labels::{LabelModification, LabelTrigger};

--- a/src/github/webhook.rs
+++ b/src/github/webhook.rs
@@ -331,7 +331,7 @@ fn parse_repository_name(repository: &Repository) -> anyhow::Result<GithubRepoNa
     Ok(GithubRepoName::new(repo_owner, repo_name))
 }
 
-type HmacSha256 = Hmac<Sha256>;
+pub type HmacSha256 = Hmac<Sha256>;
 
 /// Verifies that the request is properly signed by GitHub with SHA-256 and the passed `secret`.
 fn verify_gh_signature(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub use github::{
     server::{create_app, create_bors_process, ServerState},
     WebhookSecret,
 };
+pub use permissions::TeamApiClient;
 
 #[cfg(test)]
 mod tests;

--- a/src/permissions.rs
+++ b/src/permissions.rs
@@ -1,5 +1,8 @@
+use std::collections::{HashMap, HashSet};
+use std::sync::RwLock;
+
 use octocrab::models::UserId;
-use std::collections::HashSet;
+use serde::{Deserialize, Serialize};
 
 use crate::github::GithubRepoName;
 
@@ -30,45 +33,94 @@ impl UserPermissions {
     }
 }
 
-pub async fn load_permissions(repo: &GithubRepoName) -> anyhow::Result<UserPermissions> {
-    tracing::info!("Reloading permissions for repository {repo}");
-
-    let review_users = load_users_from_team_api(repo.name(), PermissionType::Review)
-        .await
-        .map_err(|error| anyhow::anyhow!("Cannot load review users: {error:?}"))?;
-
-    let try_users = load_users_from_team_api(repo.name(), PermissionType::Try)
-        .await
-        .map_err(|error| anyhow::anyhow!("Cannot load try users: {error:?}"))?;
-    Ok(UserPermissions {
-        review_users,
-        try_users,
-    })
+#[derive(Deserialize, Serialize)]
+pub(crate) struct UserPermissionsResponse {
+    pub(crate) github_ids: HashSet<UserId>,
 }
 
-#[derive(serde::Deserialize)]
-struct UserPermissionsResponse {
-    github_ids: HashSet<UserId>,
+pub struct TeamApiClient {
+    base_url: String,
+    permissions: RwLock<HashMap<GithubRepoName, UserPermissions>>,
 }
 
-/// Loads users that are allowed to perform try/review from the Rust Team API.
-async fn load_users_from_team_api(
-    repository_name: &str,
-    permission: PermissionType,
-) -> anyhow::Result<HashSet<UserId>> {
-    let permission = match permission {
-        PermissionType::Review => "review",
-        PermissionType::Try => "try",
-    };
+impl TeamApiClient {
+    pub fn new(base_url: Option<&str>) -> Self {
+        let permissions = RwLock::new(HashMap::new());
+        if let Some(base_url) = base_url {
+            Self {
+                base_url: base_url.to_string(),
+                permissions,
+            }
+        } else {
+            Self {
+                base_url: "https://team-api.infra.rust-lang.org".to_string(),
+                permissions,
+            }
+        }
+    }
 
-    let normalized_name = repository_name.replace("-", "_");
-    let url = format!("https://team-api.infra.rust-lang.org/v1/permissions/bors.{normalized_name}.{permission}.json");
-    let users = reqwest::get(url)
-        .await
-        .and_then(|res| res.error_for_status())
-        .map_err(|error| anyhow::anyhow!("Cannot load users from team API: {error:?}"))?
-        .json::<UserPermissionsResponse>()
-        .await
-        .map_err(|error| anyhow::anyhow!("Cannot deserialize users from team API: {error:?}"))?;
-    Ok(users.github_ids)
+    pub fn has_permission(
+        &self,
+        repo: &GithubRepoName,
+        user_id: &UserId,
+        permission: PermissionType,
+    ) -> bool {
+        let permissions = self.permissions.read().unwrap();
+        permissions
+            .get(repo)
+            .is_some_and(|permissions| permissions.has_permission(user_id, permission))
+    }
+
+    pub async fn fetch_permissions(&self, repo: &GithubRepoName) -> anyhow::Result<()> {
+        tracing::info!("Reloading permissions for repository {repo}");
+
+        let review_users = self
+            .load_users(repo.name(), PermissionType::Review)
+            .await
+            .map_err(|error| anyhow::anyhow!("Cannot load review users: {error:?}"))?;
+
+        let try_users = self
+            .load_users(repo.name(), PermissionType::Try)
+            .await
+            .map_err(|error| anyhow::anyhow!("Cannot load try users: {error:?}"))?;
+        self.permissions
+            .write()
+            .unwrap()
+            .insert(repo.clone(), UserPermissions::new(review_users, try_users));
+        Ok(())
+    }
+
+    /// Loads users that are allowed to perform try/review from the Rust Team API.
+    async fn load_users(
+        &self,
+        repository_name: &str,
+        permission: PermissionType,
+    ) -> anyhow::Result<HashSet<UserId>> {
+        let permission = match permission {
+            PermissionType::Review => "review",
+            PermissionType::Try => "try",
+        };
+
+        let normalized_name = repository_name.replace('-', "_");
+        let url = format!(
+            "{}/v1/permissions/bors.{normalized_name}.{permission}.json",
+            self.base_url
+        );
+        let users = reqwest::get(url)
+            .await
+            .and_then(|res| res.error_for_status())
+            .map_err(|error| anyhow::anyhow!("Cannot load users from team API: {error:?}"))?
+            .json::<UserPermissionsResponse>()
+            .await
+            .map_err(|error| {
+                anyhow::anyhow!("Cannot deserialize users from team API: {error:?}")
+            })?;
+        Ok(users.github_ids)
+    }
+}
+
+impl Default for TeamApiClient {
+    fn default() -> Self {
+        Self::new(None)
+    }
 }

--- a/src/tests/mocks/app.rs
+++ b/src/tests/mocks/app.rs
@@ -5,10 +5,7 @@ use wiremock::{
     Mock, MockServer, ResponseTemplate,
 };
 
-use super::{
-    permission::Permissions,
-    user::{default_user, Author},
-};
+use super::user::{default_user, Author};
 
 #[derive(Serialize)]
 struct App {
@@ -97,3 +94,6 @@ pub(super) async fn setup_app_installation_token_mock(mock_server: &MockServer) 
         .mount(mock_server)
         .await;
 }
+
+#[derive(Serialize)]
+pub(crate) struct Permissions {}

--- a/src/tests/mocks/app.rs
+++ b/src/tests/mocks/app.rs
@@ -1,0 +1,99 @@
+use serde::Serialize;
+use url::Url;
+use wiremock::{
+    matchers::{method, path, path_regex},
+    Mock, MockServer, ResponseTemplate,
+};
+
+use super::{
+    permission::Permissions,
+    user::{default_user, Author},
+};
+
+#[derive(Serialize)]
+struct App {
+    pub(crate) id: u64,
+    node_id: String,
+    owner: Author,
+    name: String,
+    external_url: Url,
+    html_url: Url,
+    permissions: Permissions,
+    events: Vec<String>,
+}
+
+impl Default for App {
+    fn default() -> Self {
+        App {
+            id: 1,
+            node_id: "".to_string(),
+            owner: default_user(),
+            name: "test".to_string(),
+            // same as bors user html_url
+            html_url: "https://test-bors.bot.com".parse().unwrap(),
+            external_url: "https://test-bors.bot.com".parse().unwrap(),
+            permissions: Permissions {},
+            events: vec!["*".to_string()],
+        }
+    }
+}
+
+pub(super) async fn setup_app_mock(mock_server: &MockServer) {
+    Mock::given(method("GET"))
+        .and(path("/app"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(App::default()))
+        .mount(mock_server)
+        .await;
+}
+
+#[derive(Serialize)]
+pub(crate) struct Installation {
+    pub(crate) id: u64,
+    node_id: String,
+    account: Author,
+    permissions: Permissions,
+    events: Vec<String>,
+}
+
+impl Default for Installation {
+    fn default() -> Self {
+        Installation {
+            id: 1,
+            node_id: "".to_string(),
+            account: default_user(),
+            permissions: Permissions {},
+            events: vec!["*".to_string()],
+        }
+    }
+}
+
+pub(super) async fn setup_app_installation_mock(mock_server: &MockServer) {
+    Mock::given(method("GET"))
+        .and(path("/app/installations"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(vec![Installation::default()]))
+        .mount(mock_server)
+        .await;
+}
+
+#[derive(Serialize)]
+pub(crate) struct InstallationToken {
+    token: String,
+    permissions: Permissions,
+}
+
+impl Default for InstallationToken {
+    fn default() -> Self {
+        InstallationToken {
+            token: "test".to_string(),
+            permissions: Permissions {},
+        }
+    }
+}
+
+pub(super) async fn setup_app_installation_token_mock(mock_server: &MockServer) {
+    Mock::given(method("POST"))
+        .and(path_regex("^/app/installations/\\d+/access_tokens$"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(InstallationToken::default()))
+        .mount(mock_server)
+        .await;
+}

--- a/src/tests/mocks/issue.rs
+++ b/src/tests/mocks/issue.rs
@@ -1,0 +1,290 @@
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+use serde::{Deserialize, Serialize};
+use url::Url;
+use wiremock::{
+    matchers::{method, path},
+    Mock, MockServer, Request, ResponseTemplate,
+};
+
+use super::{
+    repository::Repository,
+    user::{default_user, Author},
+};
+
+#[derive(Serialize)]
+struct Issue {
+    id: u64,
+    node_id: String,
+    user: Author,
+    url: Url,
+    pull_request: PullRequestLink,
+    repository_url: Url,
+    labels_url: Url,
+    comments_url: Url,
+    events_url: Url,
+    html_url: Url,
+    number: u64,
+    state: IssueState,
+    title: String,
+    labels: Vec<Label>,
+    assignees: Vec<Author>,
+    author_association: String,
+    locked: bool,
+    comments: u32,
+    created_at: chrono::DateTime<chrono::Utc>,
+    updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+impl Default for Issue {
+    fn default() -> Self {
+        Issue {
+            id: 1,
+            node_id: "".to_string(),
+            user: default_user(),
+            pull_request: PullRequestLink::default(),
+            url: "https://test.com".parse().unwrap(),
+            repository_url: "https://test.com".parse().unwrap(),
+            labels_url: "https://test.com".parse().unwrap(),
+            comments_url: "https://test.com".parse().unwrap(),
+            events_url: "https://test.com".parse().unwrap(),
+            html_url: "https://test.com".parse().unwrap(),
+            number: default_pr_number(),
+            state: IssueState::Open,
+            title: "test".to_string(),
+            labels: vec![Label::default()],
+            assignees: vec![default_user()],
+            author_association: "test".to_string(),
+            locked: false,
+            comments: 1,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        }
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "lowercase")]
+enum IssueState {
+    Open,
+}
+
+#[derive(Serialize)]
+struct PullRequestLink {
+    url: Url,
+    html_url: Url,
+    diff_url: Url,
+    patch_url: Url,
+}
+
+impl Default for PullRequestLink {
+    fn default() -> Self {
+        PullRequestLink {
+            url: "https://test.com".parse().unwrap(),
+            html_url: "https://test.com".parse().unwrap(),
+            diff_url: "https://test.com".parse().unwrap(),
+            patch_url: "https://test.com".parse().unwrap(),
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct Comment {
+    id: u64,
+    node_id: String,
+    body: String,
+    user: Author,
+    url: String,
+    html_url: String,
+    created_at: chrono::DateTime<chrono::Utc>,
+}
+
+impl Comment {
+    pub(crate) fn new(comment_body: &str) -> Self {
+        Self {
+            id: 1,
+            node_id: "".to_string(),
+            body: comment_body.to_string(),
+            user: default_user(),
+            url: "https://test.com".to_string(),
+            html_url: "https://test.com".to_string(),
+            created_at: chrono::Utc::now(),
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub(crate) struct IssueCommentEventPayload {
+    action: IssueCommentEventAction,
+    issue: Issue,
+    comment: Comment,
+    repository: Repository,
+}
+
+impl IssueCommentEventPayload {
+    pub(crate) fn new(comment_body: &str) -> Self {
+        Self {
+            action: IssueCommentEventAction::Created,
+            issue: Issue::default(),
+            comment: Comment::new(comment_body),
+            repository: Repository::default(),
+        }
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "lowercase")]
+enum IssueCommentEventAction {
+    Created,
+}
+
+#[derive(Serialize)]
+struct Label {
+    id: u64,
+    node_id: String,
+    url: Url,
+    name: String,
+    color: String,
+    default: bool,
+}
+
+impl Default for Label {
+    fn default() -> Self {
+        Label {
+            id: 1,
+            node_id: "".to_string(),
+            url: "https://test.com".parse().unwrap(),
+            name: "test".to_string(),
+            color: "000000".to_string(),
+            default: false,
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct PullRequest {
+    url: String,
+    id: u64,
+    title: String,
+    body: String,
+
+    /// The pull request number.  Note that GitHub's REST API
+    /// considers every pull-request an issue with the same number.
+    number: u64,
+
+    head: Box<Head>,
+    base: Box<Base>,
+}
+
+impl Default for PullRequest {
+    fn default() -> Self {
+        PullRequest {
+            url: "https://test.com".to_string(),
+            id: 1,
+            title: "test".to_string(),
+            body: "test".to_string(),
+            number: default_pr_number(),
+            head: Box::new(Head {
+                label: "test".to_string(),
+                ref_field: "test".to_string(),
+                sha: "test".to_string(),
+            }),
+            base: Box::new(Base {
+                ref_field: "test".to_string(),
+                sha: "test".to_string(),
+            }),
+        }
+    }
+}
+
+pub(super) async fn setup_pull_request_mock(mock_server: &MockServer) {
+    let repo = Repository::default();
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/repos/{}/{}/pulls/{}",
+            repo.owner.login.to_lowercase(),
+            repo.name.to_lowercase(),
+            default_pr_number()
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(PullRequest::default()))
+        .mount(mock_server)
+        .await;
+}
+
+#[derive(Serialize)]
+struct Head {
+    label: String,
+    #[serde(rename = "ref")]
+    ref_field: String,
+    sha: String,
+}
+
+#[derive(Serialize)]
+struct Base {
+    #[serde(rename = "ref")]
+    ref_field: String,
+    sha: String,
+}
+
+fn default_pr_number() -> u64 {
+    1
+}
+
+pub(crate) struct InMemoryIssue {
+    comments: Arc<Mutex<HashMap<u64, Vec<String>>>>,
+}
+
+impl InMemoryIssue {
+    pub(crate) async fn check_comments(&self, expected_comments: &[&str]) -> bool {
+        let pr_number = default_pr_number();
+        // retry every 25ms until the comments are available or 1 second has passed
+        for _ in 0..40 {
+            {
+                let comments = self.comments.lock().unwrap();
+                if let Some(comments) = comments.get(&pr_number) {
+                    if comments.len() == expected_comments.len() {
+                        return expected_comments
+                            .iter()
+                            .zip(comments.iter())
+                            .all(|(expected, actual)| expected == actual);
+                    }
+                }
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        false
+    }
+}
+
+pub(super) async fn setup_create_comment_mock(mock_server: &MockServer) -> InMemoryIssue {
+    let repo = Repository::default();
+    let comments = Arc::new(Mutex::new(HashMap::new()));
+    let comments_clone = comments.clone();
+    Mock::given(method("POST"))
+        .and(path(format!(
+            "/repos/{}/{}/issues/{}/comments",
+            repo.owner.login.to_lowercase(),
+            repo.name.to_lowercase(),
+            default_pr_number()
+        )))
+        .respond_with(move |req: &Request| {
+            let comment: CommentCreatePayload = req.body_json().unwrap();
+            let mut comments = comments_clone.lock().unwrap();
+            comments
+                .entry(1)
+                .or_insert_with(Vec::new)
+                .push(comment.body.clone());
+            ResponseTemplate::new(201).set_body_json(Comment::new(comment.body.as_str()))
+        })
+        .mount(mock_server)
+        .await;
+    InMemoryIssue { comments }
+}
+
+#[derive(Deserialize)]
+struct CommentCreatePayload {
+    body: String,
+}

--- a/src/tests/mocks/mod.rs
+++ b/src/tests/mocks/mod.rs
@@ -8,6 +8,7 @@ use wiremock::MockServer;
 
 use app::*;
 use issue::*;
+use permission::*;
 use repository::*;
 
 pub(super) async fn setup_mock(mock_server: &MockServer) -> InMemoryIssue {
@@ -17,6 +18,7 @@ pub(super) async fn setup_mock(mock_server: &MockServer) -> InMemoryIssue {
     setup_repositories_mock(mock_server).await;
     setup_repository_config_mock(mock_server).await;
     setup_pull_request_mock(mock_server).await;
+    setup_team_api_mock(mock_server).await;
     setup_create_comment_mock(mock_server).await
 }
 

--- a/src/tests/mocks/mod.rs
+++ b/src/tests/mocks/mod.rs
@@ -1,0 +1,50 @@
+pub(super) mod app;
+pub(super) mod issue;
+pub(super) mod permission;
+pub(super) mod repository;
+pub(super) mod user;
+
+use wiremock::MockServer;
+
+use app::*;
+use issue::*;
+use repository::*;
+
+pub(super) async fn setup_mock(mock_server: &MockServer) -> InMemoryIssue {
+    setup_app_mock(mock_server).await;
+    setup_app_installation_mock(mock_server).await;
+    setup_app_installation_token_mock(mock_server).await;
+    setup_repositories_mock(mock_server).await;
+    setup_repository_config_mock(mock_server).await;
+    setup_pull_request_mock(mock_server).await;
+    setup_create_comment_mock(mock_server).await
+}
+
+pub(super) const PRIVATE_KEY: &str = r###"-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDa2WIpKFzkeys9
+R1Mn+kCM+UVAFT47QK98iTcXIG982rXPYdL2+jtzUoUc7irfZnScIiFmO8U2O2Nm
+nchI/bjdceGGxyCt04PdYVgYpUWfqp2rbiqi6V6L39j23zxGUbf8chQsviW7HuCl
+B105H/DQdhuHDmhOOWBg1Hv+uepp0pF86WPiz4/Ez9uNmIsoJps2pvOIi8nf/8k2
+iRClRynYbE8495rD5ZGRHRkPG4wXYoKv/iH8Q7+kO+72sBk0oqmkEoUdUz+itQOB
+CnWZWBC5vXb+vopw30vRZi0FNoArzN5WH2pXUKuFYkIIBWb9Aq6TDmsjPPth/VCb
+DBaSJuM7AgMBAAECggEAOFkERyiXUlTMO0jkBkUO3b1IsUlG7qanCF+kCZZWXkVJ
+zo2XbfPb3sN+doZ0D3UnzROUmegFzQLZgxBZA0IgmRO7R6J5rYfqSdPIhP/4vzWE
+xyDkZXHE4CrQiC/OKyTbRGpy+1oyCM3YdWVCAXVR4bqnN8zj2lA3mnbbPijMTFZr
+B67VdKF16qp9L2A8cEKdEHs+m86l/y6ySSpHHOLFCZblUDjeb2dqTg7DWod1Ughj
+kj8FbyeNQovn0KMH3qkdYOAxC+paJaKYdd680ewKO1i+zbI6bauoUUZsLzKwdh5M
+FrQhVpZ9Gc0Rroyyp85WMCCy1eyyHo732RuN0qyicQKBgQDg9+5p4XVVlcObjnHi
+adfviAYxNbXu1T3S8Yejvva8c75ImHeo9pt0X4yUsnLuqflmM8UbzBbn8+PbXfux
+rXiZPxl7wR7kDkKpmTwsTFOxYB2CgC4qetlcylG1kGSgckbz2dYYMmmK6ZauMBlU
+dHfzaGJ8aUC2R/ZLl0ZxQVNNNQKBgQD5CV3vybh+RUCfm6qm6lGAs1ONFjjliwkQ
+CE/bTGspBq37WlhWaeO+I3BkqivozlQ92jcGwxQq8oDhvEieucqDyYjUvp1Pxt1e
+LT3gLy1kq1pREBI1bB1zCK1HpGn8eigIcuB8nOE+4tMUeKQNH++mhta7MgcSOoH9
+4hIQgzAsrwKBgDnS4D/syGjoJq/8C/+jLvKNZvINGSc7PjnTBQcslWTY5ybnsZIH
+WOuvh4XM3EfF/qmrUtWTPqv9/yoqXQBNUzsogddSSytZEv9euJ22PKjRyKP7aGJY
+0zfLdPcTFxo6ZUxWSHZNtt0Srz00db5EdXRl9zJ9JznzAzZoup1vqgalAoGANRmw
+M+7ZLeNqUh4JFyojUsPp7s1sOFWbCxYaoPH8b3UDJ/Mtns9ZRjOcRXqbfjpwb/fV
+f9WcuUOYA4n4GhAXhF42lNZICLiofuo6pVCp5ys6SMqad1WkOeEBwaLnDnSlkJee
+EjQJOzV2OIk4waurl+BsbOHP7C0Zhp7rpyWx4fUCgYEAp/4UceUfbJZGa8CcWZ8F
+7M0LU9Q+tGPkP2W87zkzP82PF0bQCPT3dBP0ZduDchacrF0bqEcvMLWKwwUSNvkx
+3VafpHjFw+fMUjcIkQk0VfdbRD5fLDQpJy6hUVq6A+duSqTvlhE8DFAdBAC3VZ9k
+34PVnCZP7HB3k2eBSpDp4vk=
+-----END PRIVATE KEY-----"###;

--- a/src/tests/mocks/permission.rs
+++ b/src/tests/mocks/permission.rs
@@ -1,4 +1,26 @@
-use serde::Serialize;
+use std::collections::HashSet;
 
-#[derive(Serialize)]
-pub(crate) struct Permissions {}
+use wiremock::{
+    matchers::{method, path_regex},
+    Mock, MockServer, ResponseTemplate,
+};
+
+use crate::permissions::UserPermissionsResponse;
+
+use super::repository::Repository;
+
+pub(super) async fn setup_team_api_mock(mock_server: &MockServer) {
+    let permissions = UserPermissionsResponse {
+        github_ids: HashSet::new(),
+    };
+    let repository = Repository::default();
+    Mock::given(method("GET"))
+        // regex that match the path "^/v1/permissions/bors.{normalized_name}.{permission}.json$"
+        .and(path_regex(format!(
+            r"^/v1/permissions/bors.{}.(review|try)\.json$",
+            repository.name
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(permissions))
+        .mount(&mock_server)
+        .await;
+}

--- a/src/tests/mocks/permission.rs
+++ b/src/tests/mocks/permission.rs
@@ -1,0 +1,4 @@
+use serde::Serialize;
+
+#[derive(Serialize)]
+pub(crate) struct Permissions {}

--- a/src/tests/mocks/repository.rs
+++ b/src/tests/mocks/repository.rs
@@ -1,0 +1,116 @@
+use base64::Engine;
+use serde::Serialize;
+use url::Url;
+use wiremock::{
+    matchers::{method, path, path_regex},
+    Mock, MockServer, ResponseTemplate,
+};
+
+use super::user::{default_user, Author};
+
+#[derive(Serialize)]
+pub(super) struct Repository {
+    id: u64,
+    pub(crate) name: String,
+    url: Url,
+    pub(crate) owner: Author,
+}
+
+impl Default for Repository {
+    fn default() -> Self {
+        Repository {
+            id: 1,
+            name: "test".to_string(),
+            url: "https://test.com".parse().unwrap(),
+            owner: default_user(),
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct Repositories {
+    total_count: u64,
+    repositories: Vec<Repository>,
+}
+
+impl Default for Repositories {
+    fn default() -> Self {
+        Repositories {
+            total_count: 1,
+            repositories: vec![Repository::default()],
+        }
+    }
+}
+
+pub(super) async fn setup_repositories_mock(mock_server: &MockServer) {
+    Mock::given(method("GET"))
+        .and(path("/installation/repositories"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(Repositories::default()))
+        .mount(mock_server)
+        .await;
+}
+
+#[derive(Serialize)]
+struct Content {
+    name: String,
+    path: String,
+    sha: String,
+    encoding: Option<String>,
+    content: Option<String>,
+    size: i64,
+    url: String,
+    r#type: String,
+    #[serde(rename = "_links")]
+    links: ContentLinks,
+}
+
+const RUST_BORS_TOML: &str = r###"
+timeout = 3600
+
+[labels]
+try = ["+foo", "-bar"]
+try_succeed = ["+foobar", "+foo", "+baz"]
+try_failed = []
+"###;
+
+impl Default for Content {
+    fn default() -> Self {
+        let content = base64::prelude::BASE64_STANDARD.encode(RUST_BORS_TOML);
+        Content {
+            name: "test".to_string(),
+            path: "test".to_string(),
+            sha: "test".to_string(),
+            encoding: Some("base64".to_string()),
+            content: Some(content),
+            size: 1,
+            url: "https://test.com".to_string(),
+            r#type: "file".to_string(),
+            links: ContentLinks {
+                _self: "https://test.com".parse().unwrap(),
+            },
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct ContentLinks {
+    #[serde(rename = "self")]
+    _self: Url,
+}
+
+impl Default for ContentLinks {
+    fn default() -> Self {
+        ContentLinks {
+            _self: "https://test.com".parse().unwrap(),
+        }
+    }
+}
+
+pub(super) async fn setup_repository_config_mock(mock_server: &MockServer) {
+    Mock::given(method("GET"))
+        // regex to match all repositories at /repos/:owner/:repo/contents/rust-bors.toml
+        .and(path_regex(r"^/repos/[^/]+/[^/]+/contents/rust-bors.toml$"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(Content::default()))
+        .mount(mock_server)
+        .await;
+}

--- a/src/tests/mocks/user.rs
+++ b/src/tests/mocks/user.rs
@@ -1,0 +1,103 @@
+use serde::Serialize;
+use url::Url;
+
+#[derive(Serialize)]
+pub(crate) struct Author {
+    pub(crate) login: String,
+    id: u64,
+    node_id: String,
+    avatar_url: Url,
+    gravatar_id: String,
+    url: Url,
+    html_url: Url,
+    followers_url: Url,
+    following_url: Url,
+    gists_url: Url,
+    starred_url: Url,
+    subscriptions_url: Url,
+    organizations_url: Url,
+    repos_url: Url,
+    events_url: Url,
+    received_events_url: Url,
+    r#type: String,
+    site_admin: bool,
+}
+
+#[allow(dead_code)]
+pub(crate) fn test_bors_user() -> Author {
+    Author {
+        id: 517237103,
+        login: "bors".to_string(),
+        node_id: "MDQ6VXNlcjE=".to_string(),
+        avatar_url: "https://github.com/images/error/octocat_happy.gif"
+            .parse()
+            .unwrap(),
+        gravatar_id: "".to_string(),
+        url: "https://api.github.com/users/bors".parse().unwrap(),
+        html_url: "https://test-bors.bot.com".parse().unwrap(),
+        followers_url: "https://api.github.com/users/bors/followers"
+            .parse()
+            .unwrap(),
+        following_url: "https://api.github.com/users/bors/following{/other_user}"
+            .parse()
+            .unwrap(),
+        gists_url: "https://api.github.com/users/bors/gists{/gist_id}"
+            .parse()
+            .unwrap(),
+        starred_url: "https://api.github.com/users/bors/starred{/owner}{/repo}"
+            .parse()
+            .unwrap(),
+        subscriptions_url: "https://api.github.com/users/bors/subscriptions"
+            .parse()
+            .unwrap(),
+        organizations_url: "https://api.github.com/users/bors/orgs".parse().unwrap(),
+        repos_url: "https://api.github.com/users/bors/repos".parse().unwrap(),
+        events_url: "https://api.github.com/users/bors/events{/privacy}"
+            .parse()
+            .unwrap(),
+        received_events_url: "https://api.github.com/users/bors/received_events"
+            .parse()
+            .unwrap(),
+        r#type: "User".to_string(),
+        site_admin: false,
+    }
+}
+
+pub(crate) fn default_user() -> Author {
+    Author {
+        id: 4539057,
+        login: "Kobzol".to_string(),
+        node_id: "MDQ6VXNlcjQ1MzkwNTc=".to_string(),
+        avatar_url: "https://avatars.githubusercontent.com/u/4539057?v=4"
+            .parse()
+            .unwrap(),
+        gravatar_id: "".to_string(),
+        url: "https://api.github.com/users/Kobzol".parse().unwrap(),
+        html_url: "https://github.com/Kobzol".parse().unwrap(),
+        followers_url: "https://api.github.com/users/Kobzol/followers"
+            .parse()
+            .unwrap(),
+        following_url: "https://api.github.com/users/Kobzol/following{/other_user}"
+            .parse()
+            .unwrap(),
+        gists_url: "https://api.github.com/users/Kobzol/gists{/gist_id}"
+            .parse()
+            .unwrap(),
+        starred_url: "https://api.github.com/users/Kobzol/starred{/owner}{/repo}"
+            .parse()
+            .unwrap(),
+        subscriptions_url: "https://api.github.com/users/Kobzol/subscriptions"
+            .parse()
+            .unwrap(),
+        organizations_url: "https://api.github.com/users/Kobzol/orgs".parse().unwrap(),
+        repos_url: "https://api.github.com/users/Kobzol/repos".parse().unwrap(),
+        events_url: "https://api.github.com/users/Kobzol/events{/privacy}"
+            .parse()
+            .unwrap(),
+        received_events_url: "https://api.github.com/users/Kobzol/received_events"
+            .parse()
+            .unwrap(),
+        r#type: "User".to_string(),
+        site_admin: false,
+    }
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -2,4 +2,6 @@ pub(crate) mod database;
 pub(crate) mod event;
 pub(crate) mod github;
 pub(crate) mod io;
+pub(crate) mod mocks;
 pub(crate) mod state;
+pub(crate) mod tester;

--- a/src/tests/tester.rs
+++ b/src/tests/tester.rs
@@ -9,7 +9,7 @@ use wiremock::MockServer;
 
 use crate::{
     create_app, create_bors_process, github::webhook::HmacSha256, BorsContext, CommandParser,
-    ServerState, WebhookSecret,
+    ServerState, TeamApiClient, WebhookSecret,
 };
 
 use super::{
@@ -34,11 +34,13 @@ impl BorsTester {
 
         let db = create_test_db().await;
         let client = create_test_github_client(&mock_server);
+        let team_api_client = TeamApiClient::new(Some(mock_server.uri().as_str()));
 
         let ctx = BorsContext::new(
             CommandParser::new("@bors".to_string()),
             Arc::new(db),
             Arc::new(client),
+            team_api_client,
         )
         .await
         .unwrap();

--- a/src/tests/tester.rs
+++ b/src/tests/tester.rs
@@ -1,0 +1,120 @@
+use std::sync::Arc;
+
+use axum::Router;
+use hmac::Mac;
+use http::{HeaderValue, Method, Request};
+use octocrab::{Octocrab, OctocrabBuilder};
+use tower::Service;
+use wiremock::MockServer;
+
+use crate::{
+    create_app, create_bors_process, github::webhook::HmacSha256, BorsContext, CommandParser,
+    ServerState, WebhookSecret,
+};
+
+use super::{
+    database::create_test_db,
+    mocks::{
+        self,
+        issue::{InMemoryIssue, IssueCommentEventPayload},
+    },
+};
+
+const WEBHOOK_SECRET: &str = "ABCDEF";
+
+pub(crate) struct BorsTester {
+    in_memory_mock: InMemoryIssue,
+    app: Router,
+}
+
+impl BorsTester {
+    pub(crate) async fn new() -> Self {
+        let mock_server = MockServer::start().await;
+        let in_memory_mock = mocks::setup_mock(&mock_server).await;
+
+        let db = create_test_db().await;
+        let client = create_test_github_client(&mock_server);
+
+        let ctx = BorsContext::new(
+            CommandParser::new("@bors".to_string()),
+            Arc::new(db),
+            Arc::new(client),
+        )
+        .await
+        .unwrap();
+
+        let (repository_tx, global_tx, bors_process) = create_bors_process(ctx);
+
+        let state = ServerState::new(
+            repository_tx,
+            global_tx,
+            WebhookSecret::new(WEBHOOK_SECRET.to_string()),
+        );
+        let app = create_app(state);
+        tokio::spawn(bors_process);
+        Self {
+            app,
+            in_memory_mock,
+        }
+    }
+
+    pub(crate) async fn comment(&mut self, body: &str) {
+        let comment = IssueCommentEventPayload::new(body);
+        let webhook_request = self
+            .create_webhook_request(
+                serde_json::to_string(&comment).unwrap().as_str(),
+                "issue_comment",
+            )
+            .await;
+        self.send_webhook(webhook_request).await;
+    }
+
+    pub(crate) async fn check_comments(&self, expected_comments: &[&str]) {
+        assert!(self.in_memory_mock.check_comments(expected_comments).await);
+    }
+
+    async fn create_webhook_request(&self, body: &str, event: &str) -> Request<axum::body::Body> {
+        let body_length = body.len();
+        let secret = WEBHOOK_SECRET.to_string();
+        let new_from_slice = HmacSha256::new_from_slice(secret.as_bytes());
+        let mut mac = new_from_slice.expect("Cannot create HMAC key");
+        mac.update(body.as_bytes());
+        let hash = mac.finalize().into_bytes();
+        let hash = hex::encode(hash);
+        let signature = format!("sha256={hash}");
+
+        Request::builder()
+            .uri("/github")
+            .method(Method::POST)
+            .header("content-type", HeaderValue::from_static("application-json"))
+            .header(
+                "content-length",
+                HeaderValue::from_str(&body_length.to_string()).unwrap(),
+            )
+            .header("x-github-event", HeaderValue::from_str(event).unwrap())
+            .header(
+                "x-hub-signature-256",
+                HeaderValue::from_str(&signature).unwrap(),
+            )
+            .body(axum::body::Body::from(body.to_owned()))
+            .unwrap()
+    }
+
+    async fn send_webhook(&mut self, request: Request<axum::body::Body>) {
+        let service =
+            <axum::Router as tower::ServiceExt<Request<axum::body::Body>>>::ready(&mut self.app)
+                .await
+                .unwrap();
+        service.call(request).await.unwrap();
+    }
+}
+
+fn create_test_github_client(mock_server: &MockServer) -> Octocrab {
+    let key = jsonwebtoken::EncodingKey::from_rsa_pem(mocks::PRIVATE_KEY.as_bytes()).unwrap();
+    OctocrabBuilder::new()
+        .base_uri(mock_server.uri())
+        .unwrap()
+        .app(6.into(), key)
+        .build()
+        .unwrap()
+}


### PR DESCRIPTION
This took so longgg!

This PR introduces BorsTester struct, which coordinates the set up of all the dependencies for Bors and mocks all outgoing Github requests with wiremock.

The old test infrastructure still remains, as I intended to gradually replace the tests for other handlers in subsequent PRs.