### PR TITLE
build: install fixed sqlx-cli version with Just

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,2 +1,5 @@
 install-tools:
   cargo install sqlx-cli@0.7.4 --no-default-features --features native-tls,postgres
+
+prepare:
+  cargo sqlx prepare -- --tests

--- a/justfile
+++ b/justfile
@@ -1,0 +1,2 @@
+install-tools:
+  cargo install sqlx-cli@0.7.4 --no-default-features --features native-tls,postgres


### PR DESCRIPTION
Add `justfile` including a recipe to install development tools, allowing all environments to share the same sqlx-cli version.
Also include a recipe to prepare `.sqlx` directory