### PR TITLE
Simplify docker-compose.yml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,16 +2,9 @@ version: '3.7'
 services:
   db:
     image: postgres:16
-    volumes:
-      - db_data:/var/lib/postgresql/data
     environment:
       POSTGRES_USER: bors
       POSTGRES_PASSWORD: bors
       POSTGRES_DB: bors
     ports:
       - "5432:5432"
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
-      interval: 10s
-      timeout: 5s
-      retries: 5


### PR DESCRIPTION
I don't think that we need health checks, and the volume was not working for me locally. Explicit volume should not be needed, `docker-compose up` should remember the latest state, unless you clear docker temporary artifacts.

CC @vohoanglong0107