### PR TITLE
tests: mock app and repositories retrieval

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -224,9 +234,9 @@ checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
@@ -265,6 +275,7 @@ dependencies = [
  "anyhow",
  "arc-swap",
  "axum",
+ "base64 0.22.1",
  "chrono",
  "clap",
  "derive_builder",
@@ -290,6 +301,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "wiremock",
 ]
 
 [[package]]
@@ -500,6 +512,24 @@ dependencies = [
  "quote",
  "syn 2.0.52",
 ]
+
+[[package]]
+name = "deadpool"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb84100978c1c7b37f09ed3ce3e5f843af02c2a2c431bae5b19230dad2c1b490"
+dependencies = [
+ "async-trait",
+ "deadpool-runtime",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "der"
@@ -1443,7 +1473,7 @@ checksum = "a6d07f2ea5f11065486c5d66e7fa592833038377c8b55c0b8694a624732fee32"
 dependencies = [
  "arc-swap",
  "async-trait",
- "base64 0.22.0",
+ "base64 0.22.1",
  "bytes",
  "cfg-if",
  "chrono",
@@ -3153,6 +3183,30 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec874e1eef0df2dcac546057fe5e29186f09c378181cd7b635b4b7bcc98e9d81"
+dependencies = [
+ "assert-json-diff",
+ "async-trait",
+ "base64 0.21.7",
+ "deadpool",
+ "futures",
+ "http 1.1.0",
+ "http-body-util",
+ "hyper 1.2.0",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,8 @@ itertools = "0.12.1"
 [dev-dependencies]
 insta = "1.26"
 derive_builder = "0.20.0"
+wiremock = "0.6.0"
+base64 = "0.22.1"
 
 [profile.release]
 debug = 1

--- a/src/bors/handlers/ping.rs
+++ b/src/bors/handlers/ping.rs
@@ -19,13 +19,18 @@ pub(super) async fn command_ping<Client: RepositoryClient>(
 mod tests {
     use crate::tests::event::default_pr_number;
     use crate::tests::state::ClientBuilder;
+    use crate::tests::tester::BorsTester;
 
     #[sqlx::test]
     async fn test_ping(pool: sqlx::PgPool) {
-        let state = ClientBuilder::default().pool(pool).create_state().await;
+        let state = ClientBuilder::default()
+            .pool(pool.clone())
+            .create_state()
+            .await;
         state.comment("@bors ping").await;
         state
             .client()
             .check_comments(default_pr_number(), &["Pong 🏓!"]);
+        let _ = BorsTester::new(pool).await;
     }
 }

--- a/src/tests/mocks/app.rs
+++ b/src/tests/mocks/app.rs
@@ -1,0 +1,105 @@
+use serde::Serialize;
+use url::Url;
+use wiremock::{
+    matchers::{method, path, path_regex},
+    Mock, MockServer, ResponseTemplate,
+};
+
+use super::user::{default_user, User};
+
+/// Handles all app related requests
+#[derive(Default)]
+pub(crate) struct AppHandler {}
+
+impl AppHandler {
+    pub(super) async fn mount(&self, mock_server: &MockServer) {
+        Mock::given(method("GET"))
+            .and(path("/app"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(App::default()))
+            .mount(mock_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/app/installations"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(vec![Installation::default()]))
+            .mount(mock_server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path_regex("^/app/installations/\\d+/access_tokens$"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(InstallationToken::default()))
+            .mount(mock_server)
+            .await;
+    }
+}
+
+/// Represents an app on GitHub
+/// Returns type for the `GET /app` endpoint
+#[derive(Serialize)]
+struct App {
+    pub(crate) id: u64,
+    node_id: String,
+    owner: User,
+    name: String,
+    external_url: Url,
+    html_url: Url,
+    permissions: Permissions,
+    events: Vec<String>,
+}
+
+impl Default for App {
+    fn default() -> Self {
+        App {
+            id: 1,
+            node_id: "".to_string(),
+            owner: default_user(),
+            name: "test".to_string(),
+            // same as bors user html_url
+            html_url: "https://test-bors.bot.com".parse().unwrap(),
+            external_url: "https://test-bors.bot.com".parse().unwrap(),
+            permissions: Permissions {},
+            events: vec!["*".to_string()],
+        }
+    }
+}
+
+/// Represents an installation of an app on GitHub
+/// Returns type for the `GET /app/installations` endpoint
+#[derive(Serialize)]
+pub(crate) struct Installation {
+    pub(crate) id: u64,
+    node_id: String,
+    account: User,
+    permissions: Permissions,
+    events: Vec<String>,
+}
+
+impl Default for Installation {
+    fn default() -> Self {
+        Installation {
+            id: 1,
+            node_id: "".to_string(),
+            account: default_user(),
+            permissions: Permissions {},
+            events: vec!["*".to_string()],
+        }
+    }
+}
+
+/// Represents an installation token for an app on GitHub
+/// Returns type for the `POST /app/installations/{installation_id}/access_tokens` endpoint
+#[derive(Serialize)]
+pub(crate) struct InstallationToken {
+    token: String,
+    permissions: Permissions,
+}
+
+impl Default for InstallationToken {
+    fn default() -> Self {
+        InstallationToken {
+            token: "test".to_string(),
+            permissions: Permissions {},
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub(crate) struct Permissions {}

--- a/src/tests/mocks/mod.rs
+++ b/src/tests/mocks/mod.rs
@@ -1,0 +1,56 @@
+mod app;
+mod repository;
+mod user;
+
+use wiremock::MockServer;
+
+use app::*;
+use repository::*;
+
+pub(crate) struct GithubMockServer {
+    mock_server: MockServer,
+}
+
+impl GithubMockServer {
+    pub(crate) async fn start() -> Self {
+        let mock_server = MockServer::start().await;
+        let repos = RepositoriesHandler::default();
+        let app = AppHandler::default();
+        repos.mount(&mock_server).await;
+        app.mount(&mock_server).await;
+        Self { mock_server }
+    }
+
+    pub(crate) fn uri(&self) -> String {
+        self.mock_server.uri()
+    }
+}
+
+pub(super) const PRIVATE_KEY: &str = r###"-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDa2WIpKFzkeys9
+R1Mn+kCM+UVAFT47QK98iTcXIG982rXPYdL2+jtzUoUc7irfZnScIiFmO8U2O2Nm
+nchI/bjdceGGxyCt04PdYVgYpUWfqp2rbiqi6V6L39j23zxGUbf8chQsviW7HuCl
+B105H/DQdhuHDmhOOWBg1Hv+uepp0pF86WPiz4/Ez9uNmIsoJps2pvOIi8nf/8k2
+iRClRynYbE8495rD5ZGRHRkPG4wXYoKv/iH8Q7+kO+72sBk0oqmkEoUdUz+itQOB
+CnWZWBC5vXb+vopw30vRZi0FNoArzN5WH2pXUKuFYkIIBWb9Aq6TDmsjPPth/VCb
+DBaSJuM7AgMBAAECggEAOFkERyiXUlTMO0jkBkUO3b1IsUlG7qanCF+kCZZWXkVJ
+zo2XbfPb3sN+doZ0D3UnzROUmegFzQLZgxBZA0IgmRO7R6J5rYfqSdPIhP/4vzWE
+xyDkZXHE4CrQiC/OKyTbRGpy+1oyCM3YdWVCAXVR4bqnN8zj2lA3mnbbPijMTFZr
+B67VdKF16qp9L2A8cEKdEHs+m86l/y6ySSpHHOLFCZblUDjeb2dqTg7DWod1Ughj
+kj8FbyeNQovn0KMH3qkdYOAxC+paJaKYdd680ewKO1i+zbI6bauoUUZsLzKwdh5M
+FrQhVpZ9Gc0Rroyyp85WMCCy1eyyHo732RuN0qyicQKBgQDg9+5p4XVVlcObjnHi
+adfviAYxNbXu1T3S8Yejvva8c75ImHeo9pt0X4yUsnLuqflmM8UbzBbn8+PbXfux
+rXiZPxl7wR7kDkKpmTwsTFOxYB2CgC4qetlcylG1kGSgckbz2dYYMmmK6ZauMBlU
+dHfzaGJ8aUC2R/ZLl0ZxQVNNNQKBgQD5CV3vybh+RUCfm6qm6lGAs1ONFjjliwkQ
+CE/bTGspBq37WlhWaeO+I3BkqivozlQ92jcGwxQq8oDhvEieucqDyYjUvp1Pxt1e
+LT3gLy1kq1pREBI1bB1zCK1HpGn8eigIcuB8nOE+4tMUeKQNH++mhta7MgcSOoH9
+4hIQgzAsrwKBgDnS4D/syGjoJq/8C/+jLvKNZvINGSc7PjnTBQcslWTY5ybnsZIH
+WOuvh4XM3EfF/qmrUtWTPqv9/yoqXQBNUzsogddSSytZEv9euJ22PKjRyKP7aGJY
+0zfLdPcTFxo6ZUxWSHZNtt0Srz00db5EdXRl9zJ9JznzAzZoup1vqgalAoGANRmw
+M+7ZLeNqUh4JFyojUsPp7s1sOFWbCxYaoPH8b3UDJ/Mtns9ZRjOcRXqbfjpwb/fV
+f9WcuUOYA4n4GhAXhF42lNZICLiofuo6pVCp5ys6SMqad1WkOeEBwaLnDnSlkJee
+EjQJOzV2OIk4waurl+BsbOHP7C0Zhp7rpyWx4fUCgYEAp/4UceUfbJZGa8CcWZ8F
+7M0LU9Q+tGPkP2W87zkzP82PF0bQCPT3dBP0ZduDchacrF0bqEcvMLWKwwUSNvkx
+3VafpHjFw+fMUjcIkQk0VfdbRD5fLDQpJy6hUVq6A+duSqTvlhE8DFAdBAC3VZ9k
+34PVnCZP7HB3k2eBSpDp4vk=
+-----END PRIVATE KEY-----"###;

--- a/src/tests/mocks/mod.rs
+++ b/src/tests/mocks/mod.rs
@@ -26,7 +26,7 @@ impl GithubMockServer {
     }
 }
 
-pub(super) const PRIVATE_KEY: &str = r###"-----BEGIN PRIVATE KEY-----
+pub(super) const GITHUB_MOCK_PRIVATE_KEY: &str = r###"-----BEGIN PRIVATE KEY-----
 MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDa2WIpKFzkeys9
 R1Mn+kCM+UVAFT47QK98iTcXIG982rXPYdL2+jtzUoUc7irfZnScIiFmO8U2O2Nm
 nchI/bjdceGGxyCt04PdYVgYpUWfqp2rbiqi6V6L39j23zxGUbf8chQsviW7HuCl

--- a/src/tests/mocks/repository.rs
+++ b/src/tests/mocks/repository.rs
@@ -1,0 +1,138 @@
+use base64::Engine;
+use serde::Serialize;
+use url::Url;
+use wiremock::{
+    matchers::{method, path},
+    Mock, MockServer, ResponseTemplate,
+};
+
+use crate::github::GithubRepoName;
+
+use super::user::{default_user, User};
+
+/// Handles all repositories related requests
+pub(super) struct RepositoriesHandler {
+    repos: Vec<GithubRepoName>,
+}
+
+impl RepositoriesHandler {
+    pub(super) fn new(name: Vec<GithubRepoName>) -> Self {
+        Self { repos: name }
+    }
+
+    pub(super) async fn mount(&self, mock_server: &MockServer) {
+        Mock::given(method("GET"))
+            .and(path("/installation/repositories"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(Repositories::default()))
+            .mount(mock_server)
+            .await;
+
+        for repo in &self.repos {
+            Mock::given(method("GET"))
+                .and(path(format!("/repos/{}/contents/rust-bors.toml", repo)))
+                .respond_with(ResponseTemplate::new(200).set_body_json(Content::default()))
+                .mount(mock_server)
+                .await;
+        }
+    }
+}
+
+impl Default for RepositoriesHandler {
+    fn default() -> Self {
+        Self::new(vec![GithubRepoName::new("owner", "repo")])
+    }
+}
+
+/// Represents all repositories for an installation
+/// Returns type for the `GET /installation/repositories` endpoint
+#[derive(Serialize)]
+struct Repositories {
+    total_count: u64,
+    repositories: Vec<Repository>,
+}
+
+impl Default for Repositories {
+    fn default() -> Self {
+        Repositories {
+            total_count: 1,
+            repositories: vec![Repository::default()],
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub(super) struct Repository {
+    id: u64,
+    pub(crate) name: String,
+    url: Url,
+    pub(crate) owner: User,
+}
+
+impl Default for Repository {
+    fn default() -> Self {
+        Repository {
+            id: 1,
+            name: "test".to_string(),
+            url: "https://test.com".parse().unwrap(),
+            owner: default_user(),
+        }
+    }
+}
+
+/// Represents a file in a GitHub repository
+/// returns type for the `GET /repos/{owner}/{repo}/contents/{path}` endpoint
+#[derive(Serialize)]
+struct Content {
+    name: String,
+    path: String,
+    sha: String,
+    encoding: Option<String>,
+    content: Option<String>,
+    size: i64,
+    url: String,
+    r#type: String,
+    #[serde(rename = "_links")]
+    links: ContentLinks,
+}
+
+#[derive(Serialize)]
+struct ContentLinks {
+    #[serde(rename = "self")]
+    _self: Url,
+}
+
+impl Default for ContentLinks {
+    fn default() -> Self {
+        ContentLinks {
+            _self: "https://test.com".parse().unwrap(),
+        }
+    }
+}
+
+const RUST_BORS_TOML: &str = r###"
+timeout = 3600
+
+[labels]
+try = ["+foo", "-bar"]
+try_succeed = ["+foobar", "+foo", "+baz"]
+try_failed = []
+"###;
+
+impl Default for Content {
+    fn default() -> Self {
+        let content = base64::prelude::BASE64_STANDARD.encode(RUST_BORS_TOML);
+        Content {
+            name: "test".to_string(),
+            path: "test".to_string(),
+            sha: "test".to_string(),
+            encoding: Some("base64".to_string()),
+            content: Some(content),
+            size: 1,
+            url: "https://test.com".to_string(),
+            r#type: "file".to_string(),
+            links: ContentLinks {
+                _self: "https://test.com".parse().unwrap(),
+            },
+        }
+    }
+}

--- a/src/tests/mocks/user.rs
+++ b/src/tests/mocks/user.rs
@@ -1,0 +1,63 @@
+use serde::Serialize;
+use url::Url;
+
+#[derive(Serialize)]
+pub(crate) struct User {
+    pub(crate) login: String,
+    id: u64,
+    node_id: String,
+    avatar_url: Url,
+    gravatar_id: String,
+    url: Url,
+    html_url: Url,
+    followers_url: Url,
+    following_url: Url,
+    gists_url: Url,
+    starred_url: Url,
+    subscriptions_url: Url,
+    organizations_url: Url,
+    repos_url: Url,
+    events_url: Url,
+    received_events_url: Url,
+    r#type: String,
+    site_admin: bool,
+}
+
+pub(crate) fn default_user() -> User {
+    User {
+        id: 4539057,
+        login: "Kobzol".to_string(),
+        node_id: "MDQ6VXNlcjQ1MzkwNTc=".to_string(),
+        avatar_url: "https://avatars.githubusercontent.com/u/4539057?v=4"
+            .parse()
+            .unwrap(),
+        gravatar_id: "".to_string(),
+        url: "https://api.github.com/users/Kobzol".parse().unwrap(),
+        html_url: "https://github.com/Kobzol".parse().unwrap(),
+        followers_url: "https://api.github.com/users/Kobzol/followers"
+            .parse()
+            .unwrap(),
+        following_url: "https://api.github.com/users/Kobzol/following{/other_user}"
+            .parse()
+            .unwrap(),
+        gists_url: "https://api.github.com/users/Kobzol/gists{/gist_id}"
+            .parse()
+            .unwrap(),
+        starred_url: "https://api.github.com/users/Kobzol/starred{/owner}{/repo}"
+            .parse()
+            .unwrap(),
+        subscriptions_url: "https://api.github.com/users/Kobzol/subscriptions"
+            .parse()
+            .unwrap(),
+        organizations_url: "https://api.github.com/users/Kobzol/orgs".parse().unwrap(),
+        repos_url: "https://api.github.com/users/Kobzol/repos".parse().unwrap(),
+        events_url: "https://api.github.com/users/Kobzol/events{/privacy}"
+            .parse()
+            .unwrap(),
+        received_events_url: "https://api.github.com/users/Kobzol/received_events"
+            .parse()
+            .unwrap(),
+        r#type: "User".to_string(),
+        site_admin: false,
+    }
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -2,4 +2,6 @@ pub(crate) mod database;
 pub(crate) mod event;
 pub(crate) mod github;
 pub(crate) mod io;
+pub(crate) mod mocks;
 pub(crate) mod state;
+pub(crate) mod tester;

--- a/src/tests/tester.rs
+++ b/src/tests/tester.rs
@@ -10,7 +10,7 @@ use crate::{
 
 use super::{
     database::MockedDBClient,
-    mocks::{GithubMockServer, PRIVATE_KEY},
+    mocks::{GithubMockServer, GITHUB_MOCK_PRIVATE_KEY},
 };
 
 const WEBHOOK_SECRET: &str = "ABCDEF";
@@ -49,7 +49,7 @@ impl BorsTester {
 }
 
 fn create_test_github_client(mock_server: &GithubMockServer) -> Octocrab {
-    let key = jsonwebtoken::EncodingKey::from_rsa_pem(PRIVATE_KEY.as_bytes()).unwrap();
+    let key = jsonwebtoken::EncodingKey::from_rsa_pem(GITHUB_MOCK_PRIVATE_KEY.as_bytes()).unwrap();
     OctocrabBuilder::new()
         .base_uri(mock_server.uri())
         .unwrap()

--- a/src/tests/tester.rs
+++ b/src/tests/tester.rs
@@ -1,0 +1,59 @@
+use std::sync::Arc;
+
+use axum::Router;
+use octocrab::{Octocrab, OctocrabBuilder};
+use sqlx::PgPool;
+
+use crate::{
+    create_app, create_bors_process, BorsContext, CommandParser, ServerState, WebhookSecret,
+};
+
+use super::{
+    database::MockedDBClient,
+    mocks::{GithubMockServer, PRIVATE_KEY},
+};
+
+const WEBHOOK_SECRET: &str = "ABCDEF";
+
+pub(crate) struct BorsTester {
+    #[allow(dead_code)]
+    app: Router,
+}
+
+impl BorsTester {
+    pub(crate) async fn new(pool: PgPool) -> Self {
+        let mock_server = GithubMockServer::start().await;
+
+        let client = create_test_github_client(&mock_server);
+        let db = MockedDBClient::new(pool);
+
+        let ctx = BorsContext::new(
+            CommandParser::new("@bors".to_string()),
+            Arc::new(db),
+            Arc::new(client),
+        )
+        .await
+        .unwrap();
+
+        let (repository_tx, global_tx, bors_process) = create_bors_process(ctx);
+
+        let state = ServerState::new(
+            repository_tx,
+            global_tx,
+            WebhookSecret::new(WEBHOOK_SECRET.to_string()),
+        );
+        let app = create_app(state);
+        tokio::spawn(bors_process);
+        Self { app }
+    }
+}
+
+fn create_test_github_client(mock_server: &GithubMockServer) -> Octocrab {
+    let key = jsonwebtoken::EncodingKey::from_rsa_pem(PRIVATE_KEY.as_bytes()).unwrap();
+    OctocrabBuilder::new()
+        .base_uri(mock_server.uri())
+        .unwrap()
+        .app(6.into(), key)
+        .build()
+        .unwrap()
+}


### PR DESCRIPTION
This PR initiates the HTTP mocking implementation mentioned in #93, by mocking the following route:
- GET /app
- GET /app/installations
- GET /installation/repositories
- POST /app/installations/{...}/access_tokens
- GET /repos/{owner}/{name}/contents/rust-bors.toml

I'd like to include team permission retrieval in this PR as well, but since it will involve some degree of refactoring, it's worth a dedicated PR in my opinion.