### PR TITLE
test: mock comment creation api

### DIFF
--- a/src/bors/handlers/ping.rs
+++ b/src/bors/handlers/ping.rs
@@ -17,7 +17,10 @@ pub(super) async fn command_ping<Client: RepositoryClient>(
 
 #[cfg(test)]
 mod tests {
+    use tracing_test::traced_test;
+
     use crate::tests::event::default_pr_number;
+    use crate::tests::mocks::BorsBuilder;
     use crate::tests::state::ClientBuilder;
 
     #[sqlx::test]
@@ -32,15 +35,14 @@ mod tests {
             .check_comments(default_pr_number(), &["Pong 🏓!"]);
     }
 
-    // Failing tests - needs comment and PR endpoints to be implemented
-    // #[traced_test]
-    // #[sqlx::test]
-    // async fn test_ping2(pool: sqlx::PgPool) {
-    //     BorsBuilder::new(pool)
-    //         .run_test(|mut tester| async {
-    //             tester.comment("@bors ping").await;
-    //             Ok(tester)
-    //         })
-    //         .await;
-    // }
+    #[traced_test]
+    #[sqlx::test]
+    async fn test_ping2(pool: sqlx::PgPool) {
+        BorsBuilder::new(pool)
+            .run_test(|mut tester| async {
+                tester.comment("@bors ping").await;
+                Ok(tester)
+            })
+            .await;
+    }
 }

--- a/src/database/client.rs
+++ b/src/database/client.rs
@@ -36,7 +36,6 @@ impl DbClient for PgDbClient {
         if let Some(pr) = get_pull_request(&self.pool, repo, pr_number).await? {
             return Ok(pr);
         }
-        println!("Creating PR");
         create_pull_request(&self.pool, repo, pr_number).await?;
         let pr = get_pull_request(&self.pool, repo, pr_number)
             .await?

--- a/src/tests/mocks/comment.rs
+++ b/src/tests/mocks/comment.rs
@@ -10,6 +10,7 @@ use crate::tests::event::default_pr_number;
 use crate::tests::mocks::repository::{GitHubRepository, Repo};
 use crate::tests::mocks::user::{GitHubUser, User};
 
+#[derive(Clone, Debug)]
 pub struct Comment {
     repo: GithubRepoName,
     pr: u64,
@@ -123,7 +124,7 @@ struct GitHubIssue {
 
 // Copied from octocrab, since its version if #[non_exhaustive]
 #[derive(Serialize)]
-struct GitHubComment {
+pub(super) struct GitHubComment {
     id: CommentId,
     node_id: String,
     url: Url,
@@ -133,6 +134,24 @@ struct GitHubComment {
     body_html: Option<String>,
     user: GitHubUser,
     created_at: chrono::DateTime<chrono::Utc>,
+}
+
+impl From<Comment> for GitHubComment {
+    fn from(value: Comment) -> Self {
+        let time = Utc::now();
+        let url = Url::parse("https://foo.bar").unwrap();
+        Self {
+            id: CommentId(1),
+            node_id: "1".to_string(),
+            url: url.clone(),
+            html_url: url,
+            body: Some(value.content.clone()),
+            body_text: Some(value.content.clone()),
+            body_html: Some(value.content.clone()),
+            user: value.author.into(),
+            created_at: time,
+        }
+    }
 }
 
 // Copied from octocrab, since its version if #[non_exhaustive]

--- a/src/tests/mocks/mod.rs
+++ b/src/tests/mocks/mod.rs
@@ -17,6 +17,7 @@ mod bors;
 mod comment;
 mod github;
 mod permissions;
+mod pull_request;
 mod repository;
 mod user;
 mod webhook;
@@ -47,7 +48,7 @@ impl Default for World {
     }
 }
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct Permissions {
     pub users: HashMap<User, Vec<PermissionType>>,
 }

--- a/src/tests/mocks/pull_request.rs
+++ b/src/tests/mocks/pull_request.rs
@@ -1,0 +1,126 @@
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+use serde::{Deserialize, Serialize};
+use wiremock::{
+    matchers::{method, path},
+    Mock, MockServer, Request, ResponseTemplate,
+};
+
+use super::{
+    comment::{Comment, GitHubComment},
+    Repo,
+};
+
+/// Handles all repositories related requests
+/// Only handle one PR for now, since bors don't create PRs itself
+#[derive(Default)]
+pub(super) struct PullRequestsHandler {
+    repo: Repo,
+    number: u64,
+    comments: Arc<Mutex<HashMap<u64, Vec<Comment>>>>,
+}
+
+impl PullRequestsHandler {
+    pub(super) fn new(repo: Repo) -> Self {
+        PullRequestsHandler {
+            repo,
+            number: default_pr_number(),
+            comments: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+    pub(super) async fn mount(&self, mock_server: &MockServer) {
+        Mock::given(method("GET"))
+            .and(path(format!(
+                "/repos/{}/pulls/{}",
+                self.repo.name, self.number
+            )))
+            .respond_with(ResponseTemplate::new(200).set_body_json(GitHubPullRequest::default()))
+            .mount(mock_server)
+            .await;
+
+        let comments = self.comments.clone();
+        Mock::given(method("POST"))
+            .and(path(format!(
+                "/repos/{}/issues/{}/comments",
+                self.repo.name, self.number
+            )))
+            .respond_with(move |req: &Request| {
+                let comment_payload: CommentCreatePayload = req.body_json().unwrap();
+                let comment: Comment = comment_payload.into();
+                let mut comments = comments.lock().unwrap();
+                comments.entry(1).or_default().push(comment.clone());
+                ResponseTemplate::new(201).set_body_json(GitHubComment::from(comment))
+            })
+            .mount(mock_server)
+            .await;
+    }
+}
+
+#[derive(Serialize)]
+struct GitHubPullRequest {
+    url: String,
+    id: u64,
+    title: String,
+    body: String,
+
+    /// The pull request number.  Note that GitHub's REST API
+    /// considers every pull-request an issue with the same number.
+    number: u64,
+
+    head: Box<Head>,
+    base: Box<Base>,
+}
+
+impl Default for GitHubPullRequest {
+    fn default() -> Self {
+        GitHubPullRequest {
+            url: "https://test.com".to_string(),
+            id: 1,
+            title: format!("PR #{}", default_pr_number()),
+            body: "test".to_string(),
+            number: default_pr_number(),
+            head: Box::new(Head {
+                label: "test".to_string(),
+                ref_field: "test".to_string(),
+                sha: "test".to_string(),
+            }),
+            base: Box::new(Base {
+                ref_field: "test".to_string(),
+                sha: "test".to_string(),
+            }),
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct Head {
+    label: String,
+    #[serde(rename = "ref")]
+    ref_field: String,
+    sha: String,
+}
+
+#[derive(Serialize)]
+struct Base {
+    #[serde(rename = "ref")]
+    ref_field: String,
+    sha: String,
+}
+
+fn default_pr_number() -> u64 {
+    1
+}
+
+#[derive(Deserialize)]
+struct CommentCreatePayload {
+    body: String,
+}
+
+impl From<CommentCreatePayload> for Comment {
+    fn from(payload: CommentCreatePayload) -> Self {
+        Comment::new(payload.body.as_str())
+    }
+}

--- a/src/tests/mocks/repository.rs
+++ b/src/tests/mocks/repository.rs
@@ -11,8 +11,12 @@ use wiremock::{
 
 use crate::tests::mocks::{Permissions, World};
 
-use super::user::{GitHubUser, User};
+use super::{
+    pull_request::PullRequestsHandler,
+    user::{GitHubUser, User},
+};
 
+#[derive(Clone)]
 pub struct Repo {
     pub name: GithubRepoName,
     pub permissions: Permissions,
@@ -87,6 +91,9 @@ impl RepositoriesHandler {
             .await;
 
         for repo in world.repos.values() {
+            PullRequestsHandler::new(repo.to_owned())
+                .mount(mock_server)
+                .await;
             Mock::given(method("GET"))
                 .and(path(format!(
                     "/repos/{}/contents/rust-bors.toml",

--- a/src/tests/mocks/user.rs
+++ b/src/tests/mocks/user.rs
@@ -1,7 +1,7 @@
 use serde::Serialize;
 use url::Url;
 
-#[derive(Eq, PartialEq, Hash, Clone)]
+#[derive(Eq, PartialEq, Hash, Clone, Debug)]
 pub struct User {
     pub github_id: u64,
     pub name: String,


### PR DESCRIPTION
This PR implements mocking for the following endpoints:
- GET /repos/{owner}/{name}/pulls/{number}
- POST /repos/{owner}/{name}/issues/{number}/comments

With this, we can now test bors using the comment webhook.