### PR TITLE
Add a CI job for deploying to production

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,9 +8,11 @@ on:
 concurrency: deploy
 
 jobs:
-  deploy:
+  deploy-to-staging:
     name: Deploy
     runs-on: ubuntu-latest
+    environment: staging
+    concurrency: staging
     permissions:
       id-token: write
       contents: read
@@ -22,6 +24,44 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: arn:aws:iam::392478027976:role/gha-access
+          aws-region: us-east-2
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - uses: docker/setup-buildx-action@v2
+      - name: Build and tag the Docker image
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REPOSITORY: bors
+          IMAGE_TAG: latest
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          tags: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.IMAGE_TAG }}
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Kick ECS to deploy new version
+        run: aws ecs update-service --service bors --cluster bors --force-new-deployment
+  deploy-to-production:
+    name: Deploy
+    runs-on: ubuntu-latest
+    environment: production
+    concurrency: production
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: arn:aws:iam::351621253146:role/gha-access
           aws-region: us-east-2
 
       - name: Login to Amazon ECR


### PR DESCRIPTION
This PR adds a CI job for deploying the bot to production. It works like this:
1) After a push to `main`, the bot is automatically deployed to the `staging` environment (this was pre-existing)
2) After a push to `main`, a workflow for deploying the bot to the `production` environment is started. This environment should be (manually) configured in this repo, so that it needs a review from someone (a bors admin, or multiple people).

The deployment history can be seen at https://github.com/rust-lang/bors/deployments, where admins can also approve the deployments.

Note that I have just copy-pasted the job from the staging environment for now. I'm not actually sure what should be changed to switch from staging to production - probably this: `arn:aws:iam::392478027976:role/gha-access`? I found (from some simpleinfra cache) that `392478027976` is the ID of the `bors-staging` account, but I'm not sure how to find this ID for the bors production account (it is not committed in simpleinfra, as far as I know).