### PR TITLE
refactor: unify ways to get repository name

### DIFF
--- a/src/bors/handlers/mod.rs
+++ b/src/bors/handlers/mod.rs
@@ -139,7 +139,7 @@ pub async fn handle_bors_global_event(
             futures::future::join_all(repos.into_iter().map(|repo| {
                 let repo = Arc::clone(&repo);
                 async {
-                    let subspan = tracing::info_span!("Repo", repo = repo.repository.to_string());
+                    let subspan = tracing::info_span!("Repo", repo = repo.repository().to_string());
                     refresh_repository(repo, Arc::clone(&db), team_api_client)
                         .instrument(subspan)
                         .await
@@ -249,8 +249,8 @@ async fn reload_repos(
     let reloaded_repos = repo_loader.load_repositories(team_api_client).await?;
     let mut repositories = ctx.repositories.write().unwrap();
     for repo in repositories.values() {
-        if !reloaded_repos.contains_key(&repo.repository) {
-            tracing::warn!("Repository {} was not reloaded", repo.repository);
+        if !reloaded_repos.contains_key(repo.repository()) {
+            tracing::warn!("Repository {} was not reloaded", repo.repository());
         }
     }
     for (name, repo) in reloaded_repos {

--- a/src/bors/handlers/refresh.rs
+++ b/src/bors/handlers/refresh.rs
@@ -29,7 +29,7 @@ pub async fn refresh_repository(
 }
 
 async fn cancel_timed_out_builds(repo: &RepositoryState, db: &PgDbClient) -> anyhow::Result<()> {
-    let running_builds = db.get_running_builds(&repo.repository).await?;
+    let running_builds = db.get_running_builds(repo.repository()).await?;
     tracing::info!("Found {} running build(s)", running_builds.len());
 
     let timeout = repo.config.load().timeout;
@@ -67,12 +67,12 @@ async fn reload_permission(
     team_api_client: &TeamApiClient,
 ) -> anyhow::Result<()> {
     let permissions = team_api_client
-        .load_permissions(&repo.repository)
+        .load_permissions(repo.repository())
         .await
         .with_context(|| {
             format!(
                 "Could not load permissions for repository {}",
-                repo.repository
+                repo.repository()
             )
         })?;
     repo.permissions.store(Arc::new(permissions));

--- a/src/bors/mod.rs
+++ b/src/bors/mod.rs
@@ -60,8 +60,13 @@ pub struct CheckSuite {
 /// Can be used to query permissions for the repository, and also to perform various
 /// actions using the stored client.
 pub struct RepositoryState {
-    pub repository: GithubRepoName,
     pub client: GithubRepositoryClient,
     pub permissions: ArcSwap<UserPermissions>,
     pub config: ArcSwap<RepositoryConfig>,
+}
+
+impl RepositoryState {
+    pub fn repository(&self) -> &GithubRepoName {
+        self.client.repository()
+    }
 }

--- a/src/github/api/mod.rs
+++ b/src/github/api/mod.rs
@@ -143,12 +143,7 @@ async fn create_repo_state(
 ) -> anyhow::Result<RepositoryState> {
     tracing::info!("Found repository {name}");
 
-    let client = GithubRepositoryClient {
-        app,
-        client: repo_client,
-        repo_name: name.clone(),
-        repository: repo,
-    };
+    let client = GithubRepositoryClient::new(app, repo_client, name.clone(), repo);
 
     let permissions = team_api_client
         .load_permissions(&name)
@@ -168,7 +163,6 @@ async fn create_repo_state(
     };
 
     Ok(RepositoryState {
-        repository: name,
         client,
         config: ArcSwap::new(Arc::new(config)),
         permissions: ArcSwap::new(Arc::new(permissions)),


### PR DESCRIPTION
We currently have several methods to retrieve the repository name, which makes it a little bit confusing when deciding which one to use. This PR clean them up and adjust some visibility modifier along the way.