### PR TITLE
fix: ignore clippy warning on variant's size

### DIFF
--- a/src/bors/event.rs
+++ b/src/bors/event.rs
@@ -38,6 +38,7 @@ pub enum BorsGlobalEvent {
 }
 
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum BorsEvent {
     /// An event that happen per repository basis.
     Repository(BorsRepositoryEvent),


### PR DESCRIPTION
The global event variant is rarely used (compare to the per repository event), so there won't be much improvement if we try to fix this.