### PR TITLE
refactor: allow more information for pull request creation

### DIFF
--- a/src/bors/handlers/trybuild.rs
+++ b/src/bors/handlers/trybuild.rs
@@ -42,7 +42,7 @@ pub(super) async fn command_try_build(
     }
 
     let pr_model = db
-        .get_or_create_pull_request(repo.client.repository(), pr.number)
+        .get_or_create_pull_request(repo.client.repository(), pr)
         .await
         .context("Cannot find or create PR")?;
 
@@ -152,7 +152,7 @@ pub(super) async fn command_try_cancel(
 
     let pr_number: PullRequestNumber = pr.number;
     let pr = db
-        .get_or_create_pull_request(repo.client.repository(), pr_number)
+        .get_or_create_pull_request(repo.client.repository(), pr)
         .await?;
 
     let Some(build) = get_pending_build(pr) else {
@@ -638,11 +638,9 @@ mod tests {
             tester.expect_comments(1).await;
             let pr = tester
                 .db()
-                .get_or_create_pull_request(
-                    &default_repo_name(),
-                    PullRequestNumber(default_pr_number()),
-                )
-                .await?;
+                .get_pull_request(&default_repo_name(), PullRequestNumber(default_pr_number()))
+                .await?
+                .unwrap();
             assert_eq!(pr.try_build.unwrap().status, BuildStatus::Cancelled);
             Ok(tester)
         })

--- a/src/database/operations.rs
+++ b/src/database/operations.rs
@@ -6,6 +6,7 @@ use crate::database::BuildStatus;
 use crate::database::WorkflowModel;
 use crate::github::CommitSha;
 use crate::github::GithubRepoName;
+use crate::github::PullRequest;
 use crate::github::PullRequestNumber;
 
 use super::BuildModel;
@@ -56,12 +57,12 @@ WHERE pr.repository = $1
 pub(crate) async fn create_pull_request(
     executor: impl PgExecutor<'_>,
     repo: &GithubRepoName,
-    pr_number: PullRequestNumber,
+    pr: &PullRequest,
 ) -> anyhow::Result<()> {
     sqlx::query!(
         "INSERT INTO pull_request (repository, number) VALUES ($1, $2) ON CONFLICT DO NOTHING",
         repo.to_string(),
-        pr_number.0 as i32
+        pr.number.0 as i32
     )
     .execute(executor)
     .await?;


### PR DESCRIPTION
# Context

I'm working on un-approving pr whenever new commits were pushed against the branch, but it requires adding a branch column to `pull_request` table. New pr creation will need branch information, so I made this refactor to make the changes easier