### PR TITLE
chore: check licenses and vulnerability

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,21 @@
+name: Security audit
+
+on:
+  schedule:
+    # Runs at 00:00 UTC everyday
+    - cron: "0 0 * * *"
+  push:
+    branches:
+      - main
+    paths:
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+  pull_request:
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - uses: EmbarkStudios/cargo-deny-action@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "bors"
 version = "0.1.0"
 edition = "2024"
 rust-version = "1.88.0"
+license = "MIT OR Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,19 @@
+[graph]
+exclude-dev = true
+
+[advisories]
+unmaintained = "none"
+
+[licenses]
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "ISC",
+    "Unicode-3.0",
+    "BSD-3-Clause",
+    "Zlib",
+    "CDLA-Permissive-2.0"
+]
+
+[bans]
+multiple-versions = "allow"


### PR DESCRIPTION
Close https://github.com/rust-lang/bors/issues/123

I generated the default file with `cargo deny init` and then I edited `[licenses]` and `[[licenses.clarify]]` taken from [here](https://github.com/briansmith/ring/blob/7c0024abaf4fd59250c9b79cc41a029aa0ef3497/deny.toml#L14).