### PR TITLE
chore(renovate): don't update patches

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,4 +5,13 @@
     ":maintainLockFilesMonthly",
     "docker:disable",
   ],
+  packageRules: [
+    {
+      matchCategories: ["rust"],
+      updateTypes: ["patch"],
+      // Disable patch updates for single dependencies because patches
+      // are updated periodically with lockfile maintainance.
+      enabled: false,
+    },
+  ],
 }


### PR DESCRIPTION
Close #153 

This should prevent Cargo.lock updates from `a.b.c` to `a.b.(c+1)`.

From my understanding, unfortunately disabling `minor` as well means that we'll stop get updates from `0.x.y` to `0.(x+1).0`, so I haven't disabled minor.

However ideally we want to disable updates from `a.b.c` to `a.(b+1).0`. Maybe something we can investigate further in the future.