### PR TITLE
chore(renovate): enable security updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,4 +14,12 @@
       enabled: false,
     },
   ],
+  // Receive any update that fixes security vulnerabilities.
+  // We need this because we disabled "patch" updates for Rust.
+  // Note: You need to enable "Dependabot alerts" in "Code security" GitHub
+  // Settings to receive security updates.
+  // See https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts
+  vulnerabilityAlerts: {
+    enabled: true,
+  },
 }


### PR DESCRIPTION
Related to https://github.com/rust-lang/bors/pull/154#issuecomment-2361009772

Tested in https://github.com/MarcoIeni/renovate-playground/pull/12

I already edited the required github setting

<img width="809" alt="image" src="https://github.com/user-attachments/assets/5f55bca7-4709-48ac-a5d3-18c95519b6dd">


