### PR TITLE
chore(deps): update secrecy 0.8.0 -> 0.10.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,7 +291,7 @@ dependencies = [
  "parking_lot",
  "regex",
  "reqwest",
- "secrecy",
+ "secrecy 0.10.3",
  "serde",
  "serde_json",
  "sha2",
@@ -1423,7 +1423,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project",
- "secrecy",
+ "secrecy 0.8.0",
  "serde",
  "serde_json",
  "serde_path_to_error",
@@ -1947,6 +1947,15 @@ name = "secrecy"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
 dependencies = [
  "zeroize",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ http = "1.1.0"
 sha2 = "0.10"
 hmac = "0.12"
 hex = "0.4"
-secrecy = "0.8"
+secrecy = "0.10.3"
 
 # Database
 sqlx = { version = "0.8.1", features = ["runtime-tokio", "tls-rustls", "postgres", "chrono"] }

--- a/src/bin/bors.rs
+++ b/src/bin/bors.rs
@@ -86,7 +86,7 @@ fn try_main(opts: Opts) -> anyhow::Result<()> {
         let client = create_github_client(
             opts.app_id.into(),
             "https://api.github.com".to_string(),
-            opts.private_key.into_bytes().into(),
+            opts.private_key.into(),
         )?;
         let repos = RepositoryLoader::new(client.clone())
             .load_repositories(&team_api)

--- a/src/github/api/mod.rs
+++ b/src/github/api/mod.rs
@@ -5,7 +5,7 @@ use anyhow::Context;
 use arc_swap::ArcSwap;
 use octocrab::models::{App, AppId, InstallationRepositories, Repository};
 use octocrab::Octocrab;
-use secrecy::{ExposeSecret, SecretVec};
+use secrecy::{ExposeSecret, SecretString};
 
 use client::GithubRepositoryClient;
 
@@ -23,9 +23,9 @@ fn base_github_html_url() -> &'static str {
 pub fn create_github_client(
     app_id: AppId,
     github_url: String,
-    private_key: SecretVec<u8>,
+    private_key: SecretString,
 ) -> anyhow::Result<Octocrab> {
-    let key = jsonwebtoken::EncodingKey::from_rsa_pem(private_key.expose_secret().as_ref())
+    let key = jsonwebtoken::EncodingKey::from_rsa_pem(private_key.expose_secret().as_bytes())
         .context("Could not encode private key")?;
 
     Octocrab::builder()

--- a/src/github/webhook.rs
+++ b/src/github/webhook.rs
@@ -35,7 +35,7 @@ impl WebhookSecret {
     }
 
     pub fn expose(&self) -> &str {
-        self.0.expose_secret().as_str()
+        self.0.expose_secret()
     }
 }
 

--- a/src/tests/mocks/github.rs
+++ b/src/tests/mocks/github.rs
@@ -85,7 +85,7 @@ impl GitHubMockServer {
         create_github_client(
             default_app_id().into(),
             self.mock_server.uri(),
-            GITHUB_MOCK_PRIVATE_KEY.as_bytes().to_vec().into(),
+            GITHUB_MOCK_PRIVATE_KEY.into(),
         )
         .unwrap()
     }


### PR DESCRIPTION
I diffed the actual crates.io contents via

```bash
curl -L https://crates.io/api/v1/crates/secrecy/${VERSION}/download | tar -xf -
```

with `VERSION` as `0.8.0` and `0.10.3`, then
diffing via git. It revealed nothing suspicious,
with changes as claimed per their CHANGELOG.md.

0.10.0 had some breaking changes. `Secret<T>` is
no longer a thing, instead there's `SecretBox<T>`. It turned out secrecy usage in bors is limited,
and private keys are fed as PEM-encoded `String`s. For this, there's `SecretString`, which is just an alias for `SecretBox<str>`. Accepting it and
converting to bytes in `create_github_client`
simplifies code at the call sites a bit.