### PR TITLE
Do not run CI on the `main` branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,6 @@
 name: Test
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
   merge_group:
 


### PR DESCRIPTION
It shouldn't be needed, since we use merge groups.