### PR TITLE
chore(ci): remove deprecated actions-rs actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,3 @@
-## Based on https://github.com/actions-rs/meta/blob/master/recipes/quickstart.md
 name: Test
 
 on:
@@ -30,14 +29,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: 1.80.0
-          override: true
           components: clippy, rustfmt
-
-      - uses: Swatinem/rust-cache@v2
 
       - name: Install sqlx-cli
         run: cargo install sqlx-cli@0.7.4 --no-default-features --features native-tls,postgres
@@ -49,28 +44,17 @@ jobs:
         run: cargo sqlx prepare --check -- --tests
 
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --all --all-targets
+        run: cargo build --workspace --all-targets
 
       - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all
+        run: cargo test --workspace
 
       - name: Lint code
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all
+        run: cargo clippy --workspace
 
       - name: Check formatting
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all --check
+
   docker:
     name: Test Docker
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install stable toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.80.0
+          toolchain: 1.82.0
           components: clippy, rustfmt
 
       - name: Install sqlx-cli

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.80 AS base
+FROM rust:1.82 AS base
 
 ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -19,9 +19,6 @@ impl TestSyncMarker {
     pub async fn sync(&self) {
         self.get().sync().await;
     }
-    pub fn hits(&self) -> usize {
-        self.get().hits()
-    }
 
     fn get(&self) -> &TestSyncMarkerInner {
         self.inner
@@ -56,9 +53,5 @@ impl TestSyncMarkerInner {
     /// Wait until code has encountered this location.
     pub async fn sync(&self) {
         self.rx.lock().await.recv().await.unwrap();
-    }
-
-    pub fn hits(&self) -> usize {
-        self.hits.load(Ordering::SeqCst)
     }
 }


### PR DESCRIPTION
Here's why I chose `actions-rust-lang/setup-rust-toolchain`:
- automatically setup `Swatinem/rust-cache@v2`.
- respects `rust-toolchain` file in case we add it in the future
- it has a [problem matcher](https://github.com/actions-rust-lang/setup-rust-toolchain/blob/main/rust.json)
- it has the `toolchain` field, which decouples the version of the action from the rust toolchain version. I.e. I think `action/action@stable` isn't great, because you can't pin the action commit.