### PR TITLE
feat: add github client dedicated for ci

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,10 +53,10 @@ sqlx = { version = "0.8.1", features = ["runtime-tokio", "tls-rustls", "postgres
 chrono = "0.4"
 
 itertools = "0.13.0"
+derive_builder = "0.20.0"
 
 [dev-dependencies]
 insta = "1.26"
-derive_builder = "0.20.0"
 wiremock = "0.6.0"
 base64 = "0.22.1"
 tracing-test = "0.2.4"

--- a/src/bors/command/parser.rs
+++ b/src/bors/command/parser.rs
@@ -22,6 +22,7 @@ enum CommandPart<'a> {
     KeyValue { key: &'a str, value: &'a str },
 }
 
+#[derive(Clone)]
 pub struct CommandParser {
     prefix: String,
 }

--- a/src/bors/context.rs
+++ b/src/bors/context.rs
@@ -3,27 +3,24 @@ use std::{
     sync::{Arc, RwLock},
 };
 
-use crate::{bors::command::CommandParser, github::GithubRepoName, PgDbClient};
+use derive_builder::Builder;
+use octocrab::Octocrab;
+
+use crate::{bors::command::CommandParser, github::GithubRepoName, PgDbClient, TeamApiClient};
 
 use super::RepositoryState;
 
+#[derive(Builder)]
 pub struct BorsContext {
     pub parser: CommandParser,
     pub db: Arc<PgDbClient>,
+    #[builder(field(
+        ty = "HashMap<GithubRepoName, Arc<RepositoryState>>",
+        build = "RwLock::new(self.repositories.clone())"
+    ))]
     pub repositories: RwLock<HashMap<GithubRepoName, Arc<RepositoryState>>>,
-}
-
-impl BorsContext {
-    pub fn new(
-        parser: CommandParser,
-        db: Arc<PgDbClient>,
-        repositories: HashMap<GithubRepoName, Arc<RepositoryState>>,
-    ) -> Self {
-        let repositories = RwLock::new(repositories);
-        Self {
-            parser,
-            db,
-            repositories,
-        }
-    }
+    pub gh_app_client: Octocrab,
+    #[builder(default)]
+    pub ci_client: Option<Octocrab>,
+    pub team_api_client: TeamApiClient,
 }

--- a/src/bors/mod.rs
+++ b/src/bors/mod.rs
@@ -3,6 +3,7 @@ use arc_swap::ArcSwap;
 pub use command::CommandParser;
 pub use comment::Comment;
 pub use context::BorsContext;
+pub use context::BorsContextBuilder;
 #[cfg(test)]
 pub use handlers::WAIT_FOR_REFRESH;
 pub use handlers::{handle_bors_global_event, handle_bors_repository_event};

--- a/src/github/api/mod.rs
+++ b/src/github/api/mod.rs
@@ -36,6 +36,17 @@ pub fn create_github_client(
         .context("Could not create octocrab builder")
 }
 
+pub fn create_github_client_from_access_token(
+    github_url: String,
+    access_token: SecretString,
+) -> anyhow::Result<Octocrab> {
+    Octocrab::builder()
+        .base_uri(github_url)?
+        .user_access_token(access_token)
+        .build()
+        .context("Could not create octocrab builder")
+}
+
 /// Loads repositories that are connected to the given GitHub App client.
 /// The anyhow::Result<RepositoryState> is intended, because we wanted to have
 /// a hard error when the repos fail to load when the bot starts, but only log

--- a/src/github/server.rs
+++ b/src/github/server.rs
@@ -2,7 +2,7 @@ use crate::bors::event::BorsEvent;
 use crate::bors::{handle_bors_global_event, handle_bors_repository_event, BorsContext};
 use crate::github::webhook::GitHubWebhook;
 use crate::github::webhook::WebhookSecret;
-use crate::{BorsGlobalEvent, BorsRepositoryEvent, TeamApiClient};
+use crate::{BorsGlobalEvent, BorsRepositoryEvent};
 
 use anyhow::Error;
 use axum::extract::State;
@@ -10,7 +10,6 @@ use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::routing::{get, post};
 use axum::Router;
-use octocrab::Octocrab;
 use std::future::Future;
 use std::sync::Arc;
 use tokio::sync::mpsc;
@@ -83,8 +82,6 @@ pub async fn github_webhook_handler(
 /// them.
 pub fn create_bors_process(
     ctx: BorsContext,
-    gh_client: Octocrab,
-    team_api: TeamApiClient,
 ) -> (
     mpsc::Sender<BorsRepositoryEvent>,
     mpsc::Sender<BorsGlobalEvent>,
@@ -104,7 +101,7 @@ pub fn create_bors_process(
         {
             tokio::join!(
                 consume_repository_events(ctx.clone(), repository_rx),
-                consume_global_events(ctx.clone(), global_rx, gh_client, team_api)
+                consume_global_events(ctx.clone(), global_rx)
             );
         }
         // In real execution, the bot runs forever. If there is something that finishes
@@ -116,7 +113,7 @@ pub fn create_bors_process(
                 _ = consume_repository_events(ctx.clone(), repository_rx) => {
                     tracing::error!("Repository event handling process has ended");
                 }
-                _ = consume_global_events(ctx.clone(), global_rx, gh_client, team_api) => {
+                _ = consume_global_events(ctx.clone(), global_rx) => {
                     tracing::error!("Global event handling process has ended");
                 }
             }
@@ -146,15 +143,13 @@ async fn consume_repository_events(
 async fn consume_global_events(
     ctx: Arc<BorsContext>,
     mut global_rx: mpsc::Receiver<BorsGlobalEvent>,
-    gh_client: Octocrab,
-    team_api: TeamApiClient,
 ) {
     while let Some(event) = global_rx.recv().await {
         let ctx = ctx.clone();
 
         let span = tracing::info_span!("GlobalEvent");
         tracing::debug!("Received global event: {event:#?}");
-        if let Err(error) = handle_bors_global_event(event, ctx, &gh_client, &team_api)
+        if let Err(error) = handle_bors_global_event(event, ctx)
             .instrument(span.clone())
             .await
         {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,10 +8,14 @@ mod github;
 mod permissions;
 mod utils;
 
-pub use bors::{event::BorsGlobalEvent, event::BorsRepositoryEvent, BorsContext, CommandParser};
+pub use bors::{
+    event::BorsGlobalEvent, event::BorsRepositoryEvent, BorsContext, BorsContextBuilder,
+    CommandParser,
+};
 pub use database::PgDbClient;
 pub use github::{
     api::create_github_client,
+    api::create_github_client_from_access_token,
     api::load_repositories,
     server::{create_app, create_bors_process, ServerState},
     WebhookSecret,

--- a/src/permissions.rs
+++ b/src/permissions.rs
@@ -37,6 +37,7 @@ pub(crate) struct UserPermissionsResponse {
     github_ids: HashSet<UserId>,
 }
 
+#[derive(Clone)]
 pub struct TeamApiClient {
     base_url: String,
 }


### PR DESCRIPTION
# What

This PR adds a new github client to interact with CI repo.

# Why

The CI repo for Rust belongs to a different organization than the original repo, since we can't create a fork of a repo inside the same organization. However, Github doesn't support cross-orgs operations with Github App. We have to use another mechanism to authenticate with the CI repo.

# How

This PR introduces a new Github client, authenticated with Personal Access Token. This is the same method used by homu ([ref](https://github.com/rust-lang/homu/blob/master/cfg.production.toml#L7))