### PR TITLE
feat: track mergeability 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target/
 .env
+.DS_Store

--- a/.sqlx/query-44415582f7be15fa152e086db4e664a82180544d4152e616a77f5e50f9d75145.json
+++ b/.sqlx/query-44415582f7be15fa152e086db4e664a82180544d4152e616a77f5e50f9d75145.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\nSELECT\n    pr.id,\n    pr.repository as \"repository: GithubRepoName\",\n    pr.number as \"number!: i64\",\n    (\n        pr.approved_by,\n        pr.approved_sha\n    ) AS \"approval_status!: ApprovalStatus\",\n    pr.delegated,\n    pr.priority,\n    pr.base_branch,\n    pr.rollup as \"rollup: RollupMode\",\n    pr.created_at as \"created_at: DateTime<Utc>\",\n    build AS \"try_build: BuildModel\"\nFROM pull_request as pr\nLEFT JOIN build ON pr.build_id = build.id\nWHERE build.id = $1\n",
+  "query": "\n    SELECT\n        pr.id,\n        pr.repository as \"repository: GithubRepoName\",\n        pr.number as \"number!: i64\",\n        (\n            pr.approved_by,\n            pr.approved_sha\n        ) AS \"approval_status!: ApprovalStatus\",\n        pr.priority,\n        pr.rollup as \"rollup: RollupMode\",\n        pr.delegated,\n        pr.base_branch,\n        pr.mergeable_state as \"mergeable_state: MergeableState\",\n        pr.created_at as \"created_at: DateTime<Utc>\",\n        build AS \"try_build: BuildModel\"\n    FROM pull_request as pr\n    LEFT JOIN build ON pr.build_id = build.id\n    WHERE pr.repository = $1 AND\n          pr.number = $2\n    ",
   "describe": {
     "columns": [
       {
@@ -25,31 +25,36 @@
       },
       {
         "ordinal": 4,
-        "name": "delegated",
-        "type_info": "Bool"
-      },
-      {
-        "ordinal": 5,
         "name": "priority",
         "type_info": "Int4"
       },
       {
-        "ordinal": 6,
-        "name": "base_branch",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 7,
+        "ordinal": 5,
         "name": "rollup: RollupMode",
         "type_info": "Text"
       },
       {
+        "ordinal": 6,
+        "name": "delegated",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 7,
+        "name": "base_branch",
+        "type_info": "Text"
+      },
+      {
         "ordinal": 8,
+        "name": "mergeable_state: MergeableState",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
         "name": "created_at: DateTime<Utc>",
         "type_info": "Timestamptz"
       },
       {
-        "ordinal": 9,
+        "ordinal": 10,
         "name": "try_build: BuildModel",
         "type_info": {
           "Custom": {
@@ -92,7 +97,8 @@
     ],
     "parameters": {
       "Left": [
-        "Int4"
+        "Text",
+        "Int8"
       ]
     },
     "nullable": [
@@ -100,13 +106,14 @@
       false,
       false,
       null,
-      false,
+      true,
       true,
       false,
-      true,
+      false,
+      false,
       false,
       null
     ]
   },
-  "hash": "80d2c1b695162729675c566946a145a78feed990078fbd50a83ada38a225597d"
+  "hash": "44415582f7be15fa152e086db4e664a82180544d4152e616a77f5e50f9d75145"
 }

--- a/.sqlx/query-66b7cb451d49e670d814d89d2a66ba3dd5df162984ca29dfdb1e893b1afca7ce.json
+++ b/.sqlx/query-66b7cb451d49e670d814d89d2a66ba3dd5df162984ca29dfdb1e893b1afca7ce.json
@@ -1,0 +1,118 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\nSELECT\n    pr.id,\n    pr.repository as \"repository: GithubRepoName\",\n    pr.number as \"number!: i64\",\n    (\n        pr.approved_by,\n        pr.approved_sha\n    ) AS \"approval_status!: ApprovalStatus\",\n    pr.delegated,\n    pr.priority,\n    pr.base_branch,\n    pr.mergeable_state as \"mergeable_state: MergeableState\",\n    pr.rollup as \"rollup: RollupMode\",\n    pr.created_at as \"created_at: DateTime<Utc>\",\n    build AS \"try_build: BuildModel\"\nFROM pull_request as pr\nLEFT JOIN build ON pr.build_id = build.id\nWHERE build.id = $1\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "repository: GithubRepoName",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "number!: i64",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 3,
+        "name": "approval_status!: ApprovalStatus",
+        "type_info": "Record"
+      },
+      {
+        "ordinal": 4,
+        "name": "delegated",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 5,
+        "name": "priority",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 6,
+        "name": "base_branch",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "mergeable_state: MergeableState",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 8,
+        "name": "rollup: RollupMode",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "created_at: DateTime<Utc>",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 10,
+        "name": "try_build: BuildModel",
+        "type_info": {
+          "Custom": {
+            "name": "build",
+            "kind": {
+              "Composite": [
+                [
+                  "id",
+                  "Int4"
+                ],
+                [
+                  "repository",
+                  "Text"
+                ],
+                [
+                  "branch",
+                  "Text"
+                ],
+                [
+                  "commit_sha",
+                  "Text"
+                ],
+                [
+                  "status",
+                  "Text"
+                ],
+                [
+                  "parent",
+                  "Text"
+                ],
+                [
+                  "created_at",
+                  "Timestamptz"
+                ]
+              ]
+            }
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false,
+      true,
+      false,
+      false,
+      true,
+      false,
+      null
+    ]
+  },
+  "hash": "66b7cb451d49e670d814d89d2a66ba3dd5df162984ca29dfdb1e893b1afca7ce"
+}

--- a/.sqlx/query-b7827a8eb8b11c8d6751498aba4d62c28372f666fec43294ebe94dabf0f46923.json
+++ b/.sqlx/query-b7827a8eb8b11c8d6751498aba4d62c28372f666fec43294ebe94dabf0f46923.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE pull_request SET mergeable_state = $1 WHERE id = $2 AND repository = $3",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int4",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "b7827a8eb8b11c8d6751498aba4d62c28372f666fec43294ebe94dabf0f46923"
+}

--- a/.sqlx/query-eba0377c0959404d5d208aae9763a92186f2a784639b87661f4d1ce68cc995ea.json
+++ b/.sqlx/query-eba0377c0959404d5d208aae9763a92186f2a784639b87661f4d1ce68cc995ea.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n    SELECT\n        pr.id,\n        pr.repository as \"repository: GithubRepoName\",\n        pr.number as \"number!: i64\",\n        (\n            pr.approved_by,\n            pr.approved_sha\n        ) AS \"approval_status!: ApprovalStatus\",\n        pr.priority,\n        pr.rollup as \"rollup: RollupMode\",\n        pr.delegated,\n        pr.base_branch,\n        pr.created_at as \"created_at: DateTime<Utc>\",\n        build AS \"try_build: BuildModel\"\n    FROM pull_request as pr\n    LEFT JOIN build ON pr.build_id = build.id\n    WHERE pr.repository = $1 AND\n          pr.number = $2\n    ",
+  "query": "\n        WITH upserted_pr AS (\n            INSERT INTO pull_request (repository, number, base_branch, mergeable_state)\n            VALUES ($1, $2, $3, $4)\n            ON CONFLICT (repository, number)\n            DO UPDATE SET\n                base_branch = $3,\n                mergeable_state = $4\n            RETURNING *\n        )\n        SELECT\n            pr.id,\n            pr.repository as \"repository: GithubRepoName\",\n            pr.number as \"number!: i64\",\n            (\n                pr.approved_by,\n                pr.approved_sha\n            ) AS \"approval_status!: ApprovalStatus\",\n            pr.priority,\n            pr.rollup as \"rollup: RollupMode\",\n            pr.delegated,\n            pr.base_branch,\n            pr.mergeable_state as \"mergeable_state: MergeableState\",\n            pr.created_at as \"created_at: DateTime<Utc>\",\n            build AS \"try_build: BuildModel\"\n        FROM upserted_pr as pr\n        LEFT JOIN build ON pr.build_id = build.id\n        ",
   "describe": {
     "columns": [
       {
@@ -45,11 +45,16 @@
       },
       {
         "ordinal": 8,
+        "name": "mergeable_state: MergeableState",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
         "name": "created_at: DateTime<Utc>",
         "type_info": "Timestamptz"
       },
       {
-        "ordinal": 9,
+        "ordinal": 10,
         "name": "try_build: BuildModel",
         "type_info": {
           "Custom": {
@@ -93,7 +98,9 @@
     "parameters": {
       "Left": [
         "Text",
-        "Int8"
+        "Int8",
+        "Text",
+        "Text"
       ]
     },
     "nullable": [
@@ -106,8 +113,9 @@
       false,
       false,
       false,
-      null
+      false,
+      true
     ]
   },
-  "hash": "d6aed6aa0d89754e5dbe1fdafd3fbccb522960b2a1b81bba5fa197e9da710126"
+  "hash": "eba0377c0959404d5d208aae9763a92186f2a784639b87661f4d1ce68cc995ea"
 }

--- a/.sqlx/query-fdb7f932af60a3c579516e8ff8ed3866cce4fd88b2f41f78a5ddaa2489e796fb.json
+++ b/.sqlx/query-fdb7f932af60a3c579516e8ff8ed3866cce4fd88b2f41f78a5ddaa2489e796fb.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        UPDATE pull_request\n        SET mergeable_state = $1\n        WHERE repository = $2 AND base_branch = $3\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "fdb7f932af60a3c579516e8ff8ed3866cce4fd88b2f41f78a5ddaa2489e796fb"
+}

--- a/migrations/20250315140840_add_merge_state_to_pr.up.sql
+++ b/migrations/20250315140840_add_merge_state_to_pr.up.sql
@@ -1,0 +1,2 @@
+-- Add up migration script here
+ALTER TABLE pull_request ADD COLUMN mergeable_state TEXT NOT NULL DEFAULT 'unknown';

--- a/migrations/20250315140840_add_merge_to_pr.down.sql
+++ b/migrations/20250315140840_add_merge_to_pr.down.sql
@@ -1,0 +1,2 @@
+-- Add down migration script here
+ALTER TABLE pull_request DROP COLUMN mergeable_state;

--- a/src/bors/event.rs
+++ b/src/bors/event.rs
@@ -13,6 +13,9 @@ pub enum BorsRepositoryEvent {
     PullRequestEdited(PullRequestEdited),
     /// When a pull request is opened.
     PullRequestOpened(PullRequestOpened),
+    /// When there is a push to a branch. This includes when a commit is pushed, when a commit tag is pushed,
+    /// when a branch is deleted or when a tag is deleted.
+    PushToBranch(PushToBranch),
     /// A workflow run on Github Actions or a check run from external CI system has been started.
     WorkflowStarted(WorkflowStarted),
     /// A workflow run on Github Actions or a check run from external CI system has been completed.
@@ -29,6 +32,7 @@ impl BorsRepositoryEvent {
             BorsRepositoryEvent::PullRequestCommitPushed(payload) => &payload.repository,
             BorsRepositoryEvent::PullRequestEdited(payload) => &payload.repository,
             BorsRepositoryEvent::PullRequestOpened(payload) => &payload.repository,
+            BorsRepositoryEvent::PushToBranch(payload) => &payload.repository,
             BorsRepositoryEvent::WorkflowStarted(workflow) => &workflow.repository,
             BorsRepositoryEvent::WorkflowCompleted(workflow) => &workflow.repository,
             BorsRepositoryEvent::CheckSuiteCompleted(payload) => &payload.repository,
@@ -79,6 +83,12 @@ pub struct PullRequestEdited {
 pub struct PullRequestOpened {
     pub repository: GithubRepoName,
     pub pull_request: PullRequest,
+}
+
+#[derive(Debug)]
+pub struct PushToBranch {
+    pub repository: GithubRepoName,
+    pub branch: String,
 }
 
 #[derive(Debug)]

--- a/src/bors/handlers/info.rs
+++ b/src/bors/handlers/info.rs
@@ -12,7 +12,12 @@ pub(super) async fn command_info(
 ) -> anyhow::Result<()> {
     // Geting PR info from database
     let pr_model = db
-        .get_or_create_pull_request(repo.client.repository(), pr.number, &pr.base.name)
+        .get_or_create_pull_request(
+            repo.client.repository(),
+            pr.number,
+            &pr.base.name,
+            pr.mergeable_state.clone().into(),
+        )
         .await?;
 
     // Building the info message

--- a/src/bors/handlers/mod.rs
+++ b/src/bors/handlers/mod.rs
@@ -20,7 +20,8 @@ use crate::{load_repositories, PgDbClient, TeamApiClient};
 use anyhow::Context;
 use octocrab::Octocrab;
 use pr_events::{
-    handle_pull_request_edited, handle_pull_request_opened, handle_push_to_pull_request,
+    handle_pull_request_edited, handle_pull_request_opened, handle_push_to_branch,
+    handle_push_to_pull_request,
 };
 use review::{command_delegate, command_set_priority, command_set_rollup, command_undelegate};
 use tracing::Instrument;
@@ -143,6 +144,14 @@ pub async fn handle_bors_repository_event(
                 tracing::info_span!("Pull request opened", repo = payload.repository.to_string());
 
             handle_pull_request_opened(repo, db, payload)
+                .instrument(span.clone())
+                .await?;
+        }
+        BorsRepositoryEvent::PushToBranch(payload) => {
+            let span =
+                tracing::info_span!("Pushed to branch", repo = payload.repository.to_string());
+
+            handle_push_to_branch(repo, db, payload)
                 .instrument(span.clone())
                 .await?;
         }
@@ -435,7 +444,12 @@ async fn has_permission(
     }
 
     let pr_model = db
-        .get_or_create_pull_request(repo_state.repository(), pr.number, &pr.base.name)
+        .get_or_create_pull_request(
+            repo_state.repository(),
+            pr.number,
+            &pr.base.name,
+            pr.mergeable_state.clone().into(),
+        )
         .await?;
     let is_delegated = pr_model.delegated && author.id == pr.author.id;
 

--- a/src/bors/handlers/review.rs
+++ b/src/bors/handlers/review.rs
@@ -40,7 +40,12 @@ pub(super) async fn command_approve(
         sha: pr.head.sha.to_string(),
     };
     let pr_model = db
-        .get_or_create_pull_request(repo_state.repository(), pr.number, &pr.base.name)
+        .get_or_create_pull_request(
+            repo_state.repository(),
+            pr.number,
+            &pr.base.name,
+            pr.mergeable_state.clone().into(),
+        )
         .await?;
 
     db.approve(&pr_model, approval_info, priority, rollup)
@@ -63,7 +68,12 @@ pub(super) async fn command_unapprove(
         return Ok(());
     };
     let pr_model = db
-        .get_or_create_pull_request(repo_state.repository(), pr.number, &pr.base.name)
+        .get_or_create_pull_request(
+            repo_state.repository(),
+            pr.number,
+            &pr.base.name,
+            pr.mergeable_state.clone().into(),
+        )
         .await?;
 
     db.unapprove(&pr_model).await?;
@@ -85,7 +95,12 @@ pub(super) async fn command_set_priority(
         return Ok(());
     };
     let pr_model = db
-        .get_or_create_pull_request(repo_state.repository(), pr.number, &pr.base.name)
+        .get_or_create_pull_request(
+            repo_state.repository(),
+            pr.number,
+            &pr.base.name,
+            pr.mergeable_state.clone().into(),
+        )
         .await?;
 
     db.set_priority(&pr_model, priority).await
@@ -105,7 +120,12 @@ pub(super) async fn command_delegate(
     }
 
     let pr_model = db
-        .get_or_create_pull_request(repo_state.repository(), pr.number, &pr.base.name)
+        .get_or_create_pull_request(
+            repo_state.repository(),
+            pr.number,
+            &pr.base.name,
+            pr.mergeable_state.clone().into(),
+        )
         .await?;
 
     db.delegate(&pr_model).await?;
@@ -125,7 +145,12 @@ pub(super) async fn command_undelegate(
         return Ok(());
     }
     let pr_model = db
-        .get_or_create_pull_request(repo_state.repository(), pr.number, &pr.base.name)
+        .get_or_create_pull_request(
+            repo_state.repository(),
+            pr.number,
+            &pr.base.name,
+            pr.mergeable_state.clone().into(),
+        )
         .await?;
 
     db.undelegate(&pr_model).await
@@ -145,7 +170,12 @@ pub(super) async fn command_set_rollup(
         return Ok(());
     }
     let pr_model = db
-        .get_or_create_pull_request(repo_state.repository(), pr.number, &pr.base.name)
+        .get_or_create_pull_request(
+            repo_state.repository(),
+            pr.number,
+            &pr.base.name,
+            pr.mergeable_state.clone().into(),
+        )
         .await?;
 
     db.set_rollup(&pr_model, rollup).await

--- a/src/bors/handlers/trybuild.rs
+++ b/src/bors/handlers/trybuild.rs
@@ -55,7 +55,12 @@ pub(super) async fn command_try_build(
     // Create pr model based on CI repo, so we can retrieve the pr later when
     // the CI repo emits events
     let pr_model = db
-        .get_or_create_pull_request(repo.client.repository(), pr.number, &pr.base.name)
+        .get_or_create_pull_request(
+            repo.client.repository(),
+            pr.number,
+            &pr.base.name,
+            pr.mergeable_state.clone().into(),
+        )
         .await
         .context("Cannot find or create PR")?;
 
@@ -201,7 +206,12 @@ pub(super) async fn command_try_cancel(
 
     let pr_number: PullRequestNumber = pr.number;
     let pr = db
-        .get_or_create_pull_request(repo.client.repository(), pr_number, &pr.base.name)
+        .get_or_create_pull_request(
+            repo.client.repository(),
+            pr_number,
+            &pr.base.name,
+            pr.mergeable_state.clone().into(),
+        )
         .await?;
 
     let Some(build) = get_pending_build(pr) else {

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -1,5 +1,6 @@
 //! Contains definitions of common types (pull request, user, repository name) needed
 //! for working with (GitHub) repositories.
+use octocrab::models::pulls::MergeableState;
 use octocrab::models::UserId;
 use std::fmt::{Debug, Display, Formatter};
 use std::str::FromStr;
@@ -111,6 +112,7 @@ pub struct PullRequest {
     pub head: Branch,
     pub base: Branch,
     pub title: String,
+    pub mergeable_state: MergeableState,
     pub message: String,
     pub author: GithubUser,
 }
@@ -133,6 +135,7 @@ impl From<octocrab::models::pulls::PullRequest> for PullRequest {
             author: (*pr.user.unwrap()).into(),
             title: pr.title.unwrap_or_default(),
             message: pr.body.unwrap_or_default(),
+            mergeable_state: pr.mergeable_state.unwrap_or(MergeableState::Unknown),
         }
     }
 }

--- a/src/tests/mocks/bors.rs
+++ b/src/tests/mocks/bors.rs
@@ -31,9 +31,11 @@ use crate::{
 };
 
 use super::pull_request::{
-    GitHubPullRequest, GitHubPullRequestEventPayload, PullRequestChangeEvent,
+    default_mergeable_state, GitHubPullRequest, GitHubPullRequestEventPayload,
+    PullRequestChangeEvent,
 };
 use super::repository::default_branch_name;
+use super::GitHubPushEventPayload;
 
 pub struct BorsBuilder {
     world: World,
@@ -152,6 +154,7 @@ impl BorsTester {
                 &default_repo_name(),
                 PullRequestNumber(default_pr_number()),
                 &default_branch_name(),
+                default_mergeable_state(),
             )
             .await
     }
@@ -337,6 +340,11 @@ impl BorsTester {
             GitHubPullRequestEventPayload::new(pr_number, "synchronize".to_string(), None),
         )
         .await
+    }
+
+    pub async fn push_to_branch(&mut self) -> anyhow::Result<()> {
+        self.send_webhook("push", GitHubPushEventPayload::new("main"))
+            .await
     }
 
     async fn webhook_comment(&mut self, comment: Comment) -> anyhow::Result<()> {

--- a/src/tests/mocks/mod.rs
+++ b/src/tests/mocks/mod.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use octocrab::Octocrab;
 use parking_lot::Mutex;
+use pull_request::default_mergeable_state;
 use regex::Regex;
 use wiremock::matchers::{method, path_regex};
 use wiremock::{Mock, Request, ResponseTemplate};
@@ -19,6 +20,7 @@ pub use comment::Comment;
 pub use permissions::Permissions;
 pub use pull_request::default_pr_number;
 pub use pull_request::GitHubPullRequest;
+pub use pull_request::GitHubPushEventPayload;
 pub use pull_request::PullRequestChangeEvent;
 pub use repository::default_branch_name;
 pub use repository::default_branch_sha;
@@ -162,7 +164,12 @@ pub async fn assert_pr_approved_by(
 ) {
     let pr_in_db = tester
         .db()
-        .get_or_create_pull_request(&default_repo_name(), pr_number, &default_branch_name())
+        .get_or_create_pull_request(
+            &default_repo_name(),
+            pr_number,
+            &default_branch_name(),
+            default_mergeable_state(),
+        )
         .await
         .unwrap();
     assert_eq!(pr_in_db.approval_status.approver(), Some(approved_by));
@@ -174,7 +181,12 @@ pub async fn assert_pr_approved_by(
 pub async fn assert_pr_unapproved(tester: &BorsTester, pr_number: PullRequestNumber) {
     let pr_in_db = tester
         .db()
-        .get_or_create_pull_request(&default_repo_name(), pr_number, &default_branch_name())
+        .get_or_create_pull_request(
+            &default_repo_name(),
+            pr_number,
+            &default_branch_name(),
+            default_mergeable_state(),
+        )
         .await
         .unwrap();
     assert!(!pr_in_db.is_approved());

--- a/tests/data/webhook/security-advisory-published.json
+++ b/tests/data/webhook/security-advisory-published.json
@@ -1,0 +1,65 @@
+{
+    "action": "published",
+    "security_advisory": {
+        "ghsa_id": "GHSA-mrrh-fwg8-r2c3",
+        "cve_id": "CVE-2025-30066",
+        "summary": "tj-actions changed-files through 45.0.7 allows remote attackers to discover secrets by reading actions logs.",
+        "description": "tj-actions changed-files through 45.0.7 allows remote attackers to discover secrets by reading actions logs. (The tags v1 through v45.0.7 were not originally affected, but were modified by a threat actor to point at commit 0e58ed8, which contains the malicious updateFeatures code.)",
+        "severity": "high",
+        "identifiers": [
+            { "value": "GHSA-mrrh-fwg8-r2c3", "type": "GHSA" },
+            { "value": "CVE-2025-30066", "type": "CVE" }
+        ],
+        "references": [
+            { "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-30066" },
+            {
+                "url": "https://github.com/tj-actions/changed-files/issues/2463"
+            },
+            {
+                "url": "https://github.com/github/docs/blob/962a1c8dccb8c0f66548b324e5b921b5e4fbc3d6/content/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions.md?plain=1#L191-L193"
+            },
+            { "url": "https://news.ycombinator.com/item?id=43368870" },
+            {
+                "url": "https://semgrep.dev/blog/2025/popular-github-action-tj-actionschanged-files-is-compromised"
+            },
+            {
+                "url": "https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised"
+            },
+            {
+                "url": "https://github.com/chains-project/maven-lockfile/pull/1111"
+            },
+            { "url": "https://github.com/rackerlabs/genestack/pull/903" },
+            { "url": "https://news.ycombinator.com/item?id=43367987" },
+            {
+                "url": "https://web.archive.org/web/20250315060250/https://github.com/tj-actions/changed-files/issues/2463"
+            },
+            { "url": "https://github.com/advisories/GHSA-mrrh-fwg8-r2c3" }
+        ],
+        "published_at": "2025-03-15T06:30:34Z",
+        "updated_at": "2025-03-15T16:39:06Z",
+        "withdrawn_at": null,
+        "vulnerabilities": [
+            {
+                "package": {
+                    "ecosystem": "actions",
+                    "name": "tj-actions/changed-files"
+                },
+                "severity": "high",
+                "vulnerable_version_range": "<= 45.0.7",
+                "first_patched_version": null
+            }
+        ],
+        "cvss_severities": {
+            "cvss_v3": {
+                "vector_string": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N",
+                "score": 8.6
+            },
+            "cvss_v4": { "vector_string": null, "score": 0.0 }
+        },
+        "cvss": {
+            "vector_string": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N",
+            "score": 8.6
+        },
+        "cwes": [{ "cwe_id": "CWE-506", "name": "Embedded Malicious Code" }]
+    }
+}


### PR DESCRIPTION
Related issue: #218 

This PR tracks merge ability. It adds a new column: `merge_state`. 

**Homu Implementation**
- Mergeable status is tracked via the `mergeable` column in the `pull` table
- **On PR open / reopen / edit / push**: `mergeable` is set to `None` 
- **On PR edit**: `mergeable` is set to `None`  only if base branch has changed
- **On branch push event**: 
    - All PRs targeting the given branch have `merge_state` set to `None`
    - If still null, then wait 5s 
    - If still null, then add to queue 
- **Async**: all PRs with a `mergeable` of `None` are scheduled to refetch in a background task via a queue

**Proposed Implementation**
- Mergeable status is tracked via the `merge_state` column in the `pull_request` table
- **On PR open / reopen / push**: `merge_state` is set to `unknown` 
- **On PR edit**: `merge_state` is set based on payload value
    - The reason we don't do this only if base branch changes is because the payload value can actually be something else other than `unknown`, whereas with the other events it is **always** `unknown` (due to the nature of the events)
- **On branch push event**: all PRs targeting the given branch have `merge_state` set to `unknown`
- **Async**: needs further thought -> left for another PR 
