### PR TITLE
Refactor storage of `TreeState` in the DB

### DIFF
--- a/.sqlx/query-cc7019b45037e155c4ce8f0bad9df0dcbe339fb59f93aec8bb6d34719ee042d3.json
+++ b/.sqlx/query-cc7019b45037e155c4ce8f0bad9df0dcbe339fb59f93aec8bb6d34719ee042d3.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT id, name as \"name: GithubRepoName\", tree_state, treeclosed_src, created_at\n        FROM repository\n        WHERE name = $1\n        ",
+  "query": "\n        SELECT\n            id,\n            name as \"name: GithubRepoName\",\n            (\n                tree_state,\n                treeclosed_src\n            ) AS \"tree_state!: TreeState\",\n            created_at\n        FROM repository\n        WHERE name = $1\n        ",
   "describe": {
     "columns": [
       {
@@ -15,16 +15,11 @@
       },
       {
         "ordinal": 2,
-        "name": "tree_state",
-        "type_info": "Int4"
+        "name": "tree_state!: TreeState",
+        "type_info": "Record"
       },
       {
         "ordinal": 3,
-        "name": "treeclosed_src",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 4,
         "name": "created_at",
         "type_info": "Timestamptz"
       }
@@ -37,10 +32,9 @@
     "nullable": [
       false,
       false,
-      true,
-      true,
+      null,
       false
     ]
   },
-  "hash": "6d68067c7121438630d77590ed644d4bc654978836fe5ceda2f0041aeba68e64"
+  "hash": "cc7019b45037e155c4ce8f0bad9df0dcbe339fb59f93aec8bb6d34719ee042d3"
 }


### PR DESCRIPTION
I realized in https://github.com/rust-lang/bors/pull/226 that we can do this in a more idiomatic way.