### PR TITLE
 Add init_db.sh script for database initialization and migration

### DIFF
--- a/scripts/init_db.sh
+++ b/scripts/init_db.sh
@@ -1,0 +1,58 @@
+set -x
+
+set -eo pipefail
+
+if ! [ -x "$(command -v psql)" ]; then
+  echo >&2 "Error: psql is not installed."
+  exit 1
+fi
+
+if ! [ -x "$(command -v sqlx)" ]; then
+  echo >&2 "Error: sqlx is not installed."
+  echo >&2 "Use:"
+  echo >&2 "     cargo install sqlx-cli \
+--no-default-features --features rustls,postgres"
+  echo >&2 "to install it."
+  exit 1
+fi
+
+DB_USER="${POSTGRES_USER:=bors}"
+
+DB_PASSWORD="${POSTGRES_PASSWORD:=bors}"
+
+DB_PORT="${POSTGRES_PORT:=5432}"
+
+DB_NAME="${POSTGRES_DB:=bors}"
+
+DB_HOST="${POSTGRES_HOST:=localhost}"
+
+if [[ -z "${SKIP_DOCKER}" ]]; then
+
+  docker run \
+    -e POSTGRES_USER=${DB_USER} \
+    -e POSTGRES_PASSWORD=${DB_PASSWORD} \
+    -e POSTGRES_NAME=${DB_NAME} \
+    --name bors \
+    -p ${DB_PORT}:5432 \
+    -d postgres:15.5 \
+    postgres
+fi
+
+export PGPASSWORD="${DB_PASSWORD}"
+
+until psql -h "${DB_HOST}" -U "${DB_USER}" -p "${DB_PORT}" -d "postgres" -c '\q'; do
+  >&2 echo "Postgres is still unavailable - sleeping"
+  sleep 1
+done
+
+>&2 echo "Postgres is up and running on port ${DB_PORT}!"
+
+DATABASE_URL="postgres://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}"
+
+export DATABASE_URL
+
+sqlx database create
+
+sqlx migrate run
+
+>&2 echo "Postgres has been migrated, ready to go!"


### PR DESCRIPTION
How it works?
- Runs the existing init_db function
- Applies database migrations using sqlx-cli
- Uses environment variables for configuration [POSTGRES_USER, ..... ,SKIP_DOCKER=1]
- Ensures safe execution 
- Requires psql and sqlx-cli to be installed
- Make sure to run chmod +x scripts/init_db.sh before executing the script