### PR TITLE
Add database migrations population tests

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -118,6 +118,10 @@ Make sure to also run `cargo sqlx migrate run` to apply the migrations to the da
     ```console
     $ cargo sqlx migrate run
     ```
+4) Add a test data file to `tests/data/migrations/<timestamp>-<new-migration>.sql`.
+    - The file should contain SQL that inserts some reasonable data into a test database after the migration is applied.
+    The goal is to check that we have a test database with production-like data, so that we can test that applying migrations will not produce errors on a non-empty database.
+    - If it doesn't make sense to add any data to the migration (e.g. if the migration only adds an index), put `-- Empty to satisfy migration tests` into the file.
 
 ### Generate `.sqlx` directory
 ```console

--- a/tests/data/migrations/20240517094752_create_build.sql
+++ b/tests/data/migrations/20240517094752_create_build.sql
@@ -1,0 +1,24 @@
+INSERT INTO
+    build (repository, branch, commit_sha, status, parent)
+VALUES
+    (
+        'rust-lang/bors',
+        'automation/bors/try',
+        'a7ec24743ca724dd4b164b3a76d29d0da9573617',
+        'pending',
+        '8f5e9988e7aa74bffcbec51af17f541d8e7d8e3c'
+    ),
+    (
+        'rust-lang/cargo',
+        'automation/bors/try-merge',
+        'b3f987c12ee248ef21d37b59a40b17e93fac7c8a',
+        'success',
+        'c53f32bb8a51fa9fd49d7bd83eb4b15ccfd8a372'
+    ),
+    (
+        'rust-lang/rust',
+        'automation/bors/try',
+        '4ee5a1bfc10bc49f30a8f527557ac4a93a2b9d66',
+        'failure',
+        '9d4e0ac0fca0d0c268be3e9d24d98e3906f0e89b'
+    );

--- a/tests/data/migrations/20240518024921_create_pr.sql
+++ b/tests/data/migrations/20240518024921_create_pr.sql
@@ -1,0 +1,7 @@
+INSERT INTO
+    pull_request (repository, number, build_id)
+VALUES
+    ('rust-lang/bors', 269, 1),
+    ('rust-lang/cargo', 14718, 2),
+    ('rust-lang/rust', 136864, 3),
+    ('rust-lang/clippy', 10521, NULL);

--- a/tests/data/migrations/20240518024946_create_workflow.sql
+++ b/tests/data/migrations/20240518024946_create_workflow.sql
@@ -1,0 +1,59 @@
+INSERT INTO
+    workflow (build_id, name, run_id, url, status, type)
+VALUES
+    (
+        1,
+        'Test / Test',
+        4937812456,
+        'https://github.com/rust-lang/bors/actions/runs/4937812456',
+        'success',
+        'github'
+    ),
+    (
+        1,
+        'Test / Test Docker',
+        4937812457,
+        'https://github.com/rust-lang/bors/actions/runs/4937812457',
+        'success',
+        'github'
+    ),
+    (
+        2,
+        'CI / Calculate job matrix',
+        4938210157,
+        'https://github.com/rust-lang/cargo/actions/runs/4938210157',
+        'success',
+        'github'
+    ),
+    (
+        3,
+        'CI / PR - mingw-check',
+        4939843621,
+        'https://github.com/rust-lang/rust/actions/runs/4939843621',
+        'success',
+        'github'
+    ),
+    (
+        3,
+        'CI / PR - x86_64-gnu-llvm-19',
+        4939843622,
+        'https://github.com/rust-lang/rust/actions/runs/4939843622',
+        'pending',
+        'github'
+    ),
+    (
+        3,
+        'CI / PR - x86_64-gnu-tools',
+        4939843623,
+        'https://github.com/rust-lang/rust/actions/runs/4939843623',
+        'success',
+        'github'
+    ),
+    (
+        3,
+        'bors: buildbot',
+        2493574,
+        'https://buildbot.rust-lang.org/builders/try/builds/2493574',
+        'pending',
+        'external'
+    );

--- a/tests/data/migrations/20240626072340_add_approved_by_to_pr.sql
+++ b/tests/data/migrations/20240626072340_add_approved_by_to_pr.sql
@@ -1,0 +1,11 @@
+UPDATE pull_request
+SET
+    approved_by = 'kobzol'
+WHERE
+    id = 1;
+
+UPDATE pull_request
+SET
+    approved_by = 'sakib25800'
+WHERE
+    id = 2;

--- a/tests/data/migrations/20250227095730_add_priority_to_pr.sql
+++ b/tests/data/migrations/20250227095730_add_priority_to_pr.sql
@@ -1,0 +1,11 @@
+UPDATE pull_request
+SET
+    priority = 1
+WHERE
+    id = 1;
+
+UPDATE pull_request
+SET
+    priority = 2
+WHERE
+    id = 2;

--- a/tests/data/migrations/20250304150656_add_delegated_to_pr.sql
+++ b/tests/data/migrations/20250304150656_add_delegated_to_pr.sql
@@ -1,0 +1,11 @@
+UPDATE pull_request
+SET
+    delegated = TRUE
+WHERE
+    id = 1;
+
+UPDATE pull_request
+SET
+    delegated = FALSE
+WHERE
+    id = 2;

--- a/tests/data/migrations/20250304172534_add_repository_model.sql
+++ b/tests/data/migrations/20250304172534_add_repository_model.sql
@@ -1,0 +1,19 @@
+INSERT INTO
+    repository (name, tree_state, treeclosed_src)
+VALUES
+    (
+        'rust-lang/bors',
+        0,
+        'https://buildbot.rust-lang.org/homu/queue/rust'
+    ),
+    ('rust-lang/cargo', NULL, NULL),
+    (
+        'rust-lang/rust',
+        1,
+        'https://github.com/rust-lang/rust/pull/109831#issuecomment-2045783212'
+    ),
+    (
+        'rust-lang/clippy',
+        2,
+        'https://github.com/rust-lang/clippy/pull/10521#issuecomment-2045981453'
+    );

--- a/tests/data/migrations/20250307150834_add_rollup_to_pr.sql
+++ b/tests/data/migrations/20250307150834_add_rollup_to_pr.sql
@@ -1,0 +1,11 @@
+UPDATE pull_request
+SET
+    rollup = 'always'
+WHERE
+    id = 1;
+
+UPDATE pull_request
+SET
+    rollup = 'never'
+WHERE
+    id = 2;

--- a/tests/data/migrations/20250311143621_add_approved_sha_to_pr.sql
+++ b/tests/data/migrations/20250311143621_add_approved_sha_to_pr.sql
@@ -1,0 +1,11 @@
+UPDATE pull_request
+SET
+    approved_sha = 'abc123def456'
+WHERE
+    id = 1;
+
+UPDATE pull_request
+SET
+    approved_sha = 'fed987cba654'
+WHERE
+    id = 2;

--- a/tests/data/migrations/20250313013946_add_base_branch_to_pr.sql
+++ b/tests/data/migrations/20250313013946_add_base_branch_to_pr.sql
@@ -1,0 +1,11 @@
+UPDATE pull_request
+SET
+    base_branch = 'main'
+WHERE
+    id = 1;
+
+UPDATE pull_request
+SET
+    base_branch = 'beta'
+WHERE
+    id = 2;

--- a/tests/data/migrations/20250315140840_add_merge_state_to_pr.sql
+++ b/tests/data/migrations/20250315140840_add_merge_state_to_pr.sql
@@ -1,0 +1,11 @@
+UPDATE pull_request
+SET
+    mergeable_state = 'mergeable'
+WHERE
+    id = 1;
+
+UPDATE pull_request
+SET
+    mergeable_state = 'has_conflicts'
+WHERE
+    id = 2;

--- a/tests/data/migrations/20250318120405_add_pr_status.sql
+++ b/tests/data/migrations/20250318120405_add_pr_status.sql
@@ -1,0 +1,11 @@
+UPDATE pull_request
+SET
+    status = 'merged'
+WHERE
+    id = 1;
+
+UPDATE pull_request
+SET
+    status = 'closed'
+WHERE
+    id = 2;

--- a/tests/data/migrations/20250324151905_rename_delegated_to_delegated_permission.sql
+++ b/tests/data/migrations/20250324151905_rename_delegated_to_delegated_permission.sql
@@ -1,0 +1,11 @@
+UPDATE pull_request
+SET
+    delegated_permission = 'review'
+WHERE
+    id = 1;
+
+UPDATE pull_request
+SET
+    delegated_permission = NULL
+WHERE
+    id = 2;

--- a/tests/data/migrations/20250331142635_add_pr_status_index.sql
+++ b/tests/data/migrations/20250331142635_add_pr_status_index.sql
@@ -1,0 +1,1 @@
+-- Empty to satisfy migration tests


### PR DESCRIPTION
Fixes #257 

This PR adds tests that incrementally populate the database with test data for every migration. 