### PR TITLE
Add `IF NOT EXISTS` to repository creation migration

### DIFF
--- a/migrations/20250304172534_add_repository_model.up.sql
+++ b/migrations/20250304172534_add_repository_model.up.sql
@@ -1,5 +1,5 @@
 -- Add up migration script here
-CREATE TABLE repository
+CREATE TABLE IF NOT EXISTS repository
 (
     id             SERIAL PRIMARY KEY,
     name           TEXT        NOT NULL UNIQUE,


### PR DESCRIPTION
For consistency with the rest of the migrations.