### PR TITLE
Bootstrap website

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
+name = "askama"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f75363874b771be265f4ffe307ca705ef6f3baa19011c149da8674a87f1b75c4"
+dependencies = [
+ "askama_derive",
+ "itoa",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "askama_derive"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "129397200fe83088e8a68407a8e2b1f826cf0086b21ccdb866a722c8bcd3a94f"
+dependencies = [
+ "askama_parser",
+ "basic-toml",
+ "memchr",
+ "proc-macro2",
+ "quote",
+ "rustc-hash",
+ "serde",
+ "serde_derive",
+ "syn",
+]
+
+[[package]]
+name = "askama_parser"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6ab5630b3d5eaf232620167977f95eb51f3432fc76852328774afbd242d4358"
+dependencies = [
+ "memchr",
+ "serde",
+ "serde_derive",
+ "winnow 0.7.10",
+]
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,6 +274,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "basic-toml"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -255,6 +306,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "arc-swap",
+ "askama",
  "axum",
  "base64",
  "chrono",
@@ -282,6 +334,7 @@ dependencies = [
  "tokio",
  "toml",
  "tower",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
  "tracing-test",
@@ -2541,7 +2594,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow",
+ "winnow 0.6.20",
 ]
 
 [[package]]
@@ -2563,15 +2616,16 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.1"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8437150ab6bbc8c5f0f519e3d5ed4aa883a83dd4cdd3d1b21f9482936046cb97"
+checksum = "0fdb0c213ca27a9f57ab69ddb290fd80d970922355b83ae380b395d3986b8a2e"
 dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "iri-string",
  "pin-project-lite",
  "tower",
@@ -3098,6 +3152,15 @@ name = "winnow"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,10 +35,12 @@ arc-swap = "1"
 hyper = "1"
 axum = "0.8"
 tower = { version = "0.5", features = ["limit"] }
+tower-http = { version = "0.6.4", features = ["catch-panic"] }
 jsonwebtoken = "9"
 url = "2"
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
 http = "1"
+askama = "0.14.0"
 
 # Cryptography
 sha2 = "0.10"
@@ -52,6 +54,7 @@ sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls", "postgres",
 # Time
 chrono = "0.4"
 
+# Utilities
 itertools = "0.14"
 
 # Text processing

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ COPY Cargo.lock .
 COPY migrations migrations
 COPY .sqlx .sqlx
 COPY src src
+COPY templates templates
 
 RUN cargo build --release
 
@@ -37,6 +38,6 @@ COPY --from=build /app/target/release/bors .
 EXPOSE 80
 
 HEALTHCHECK --timeout=10s --start-period=10s \
-  CMD curl -f http://localhost/health || exit 1
+    CMD curl -f http://localhost/health || exit 1
 
 ENTRYPOINT ["./bors"]

--- a/src/bin/bors.rs
+++ b/src/bin/bors.rs
@@ -122,7 +122,12 @@ fn try_main(opts: Opts) -> anyhow::Result<()> {
         repos.insert(name, Arc::new(repo));
     }
 
-    let ctx = BorsContext::new(CommandParser::new(opts.cmd_prefix), Arc::new(db), repos);
+    let db = Arc::new(db);
+    let ctx = BorsContext::new(
+        CommandParser::new(opts.cmd_prefix),
+        db.clone(),
+        repos.clone(),
+    );
     let BorsProcess {
         repository_tx,
         global_tx,
@@ -170,6 +175,8 @@ fn try_main(opts: Opts) -> anyhow::Result<()> {
         repository_tx,
         global_tx,
         WebhookSecret::new(opts.webhook_secret),
+        repos,
+        db,
     );
     let server_process = webhook_server(state);
 

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -350,6 +350,12 @@ pub enum TreeState {
     },
 }
 
+impl TreeState {
+    pub fn is_closed(&self) -> bool {
+        matches!(self, TreeState::Closed { .. })
+    }
+}
+
 impl sqlx::Type<sqlx::Postgres> for TreeState {
     fn type_info() -> sqlx::postgres::PgTypeInfo {
         <(Option<i32>, Option<String>) as sqlx::Type<sqlx::Postgres>>::type_info()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod config;
 mod database;
 mod github;
 mod permissions;
+mod templates;
 mod utils;
 
 pub use bors::{BorsContext, CommandParser, event::BorsGlobalEvent, event::BorsRepositoryEvent};

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -1,0 +1,32 @@
+use askama::Template;
+use axum::response::{Html, IntoResponse, Response};
+use http::StatusCode;
+
+pub struct HtmlTemplate<T>(pub T);
+
+impl<T> IntoResponse for HtmlTemplate<T>
+where
+    T: Template,
+{
+    fn into_response(self) -> Response {
+        match self.0.render() {
+            Ok(html) => Html(html).into_response(),
+            Err(error) => {
+                let message = format!("Failed to render template: {error:?}");
+                tracing::error!("{message}");
+                (StatusCode::INTERNAL_SERVER_ERROR, message).into_response()
+            }
+        }
+    }
+}
+
+#[derive(Template)]
+#[template(path = "index.html")]
+pub struct IndexTemplate {
+    pub repos: Vec<RepositoryView>,
+}
+
+pub struct RepositoryView {
+    pub name: String,
+    pub treeclosed: bool,
+}

--- a/src/tests/mocks/bors.rs
+++ b/src/tests/mocks/bors.rs
@@ -123,7 +123,11 @@ impl BorsTester {
             repos.insert(name, Arc::new(repo));
         }
 
-        let ctx = BorsContext::new(CommandParser::new("@bors".to_string()), db.clone(), repos);
+        let ctx = BorsContext::new(
+            CommandParser::new("@bors".to_string()),
+            db.clone(),
+            repos.clone(),
+        );
 
         let BorsProcess {
             repository_tx,
@@ -136,6 +140,8 @@ impl BorsTester {
             repository_tx,
             global_tx.clone(),
             WebhookSecret::new(TEST_WEBHOOK_SECRET.to_string()),
+            repos.clone(),
+            db.clone(),
         );
         let app = create_app(state);
         let bors = tokio::spawn(bors_process);

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,135 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Bors</title>
+    <style>
+      * {
+        font-family: sans-serif;
+      }
+      code {
+        font-family: monospace;
+      }
+      h1 {
+        font-size: 22px;
+      }
+      h2 {
+        font-size: 18px;
+      }
+      h3 {
+        font-size: 16px;
+      }
+      h4 {
+        font-size: 14px;
+      }
+      p,
+      ul {
+        font-size: 15px;
+        line-height: 150%;
+      }
+      code {
+        background-color: #efefef;
+      }
+      div.wrapper {
+        max-width: 60em;
+        margin-left: auto;
+        margin-right: auto;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="wrapper">
+      <h1>Bors</h1>
+
+      <h2>Repositories</h2>
+
+      <ul class="repos">
+        {% for repo in repos %}
+        <li>
+          <a href="queue/{{repo.name}}">{{repo.name}}</a>
+          {% if repo.treeclosed %} [TREECLOSED] {% endif %}
+        </li>
+        {% endfor %}
+      </ul>
+
+      <hr />
+
+      <h2>Bors Cheatsheet</h2>
+
+      <h3>Commands</h3>
+
+      <p>
+        Here's a quick reference for the commands bors accepts. Commands must be
+        posted as comments on the PR they refer to. Comments may include
+        multiple commands. Bors will only listen to official reviewers that it
+        is configured to listen to. A comment must mention the GitHub account
+        bors is configured to use. (e.g. for the Rust project this is <code>@bors</code>)
+        Note that bors will only recognize comments in <i>open</i> PRs.
+      </p>
+
+      <ul>
+        <li><code>info</code>: Get information about the current PR.</li>
+        <li>
+          <code>ping</code>: Send a ping to bors to check that it responds.
+        </li>
+        <li><code>help</code>: Print help message with available commands.</li>
+        <li>
+          <code>rollup=&lt;never|iffy|maybe|always&gt;</code>: Mark the PR as
+          "always", "maybe", "iffy", or "never" rollup-able.
+        </li>
+        <li><code>rollup</code>: Short for <code>rollup=always</code>.</li>
+        <li><code>rollup-</code>: Short for <code>rollup=maybe</code>.</li>
+        <li>
+          <code>p=&lt;priority&gt;</code>: Set the priority of the approved PR
+          (defaults to 0).
+        </li>
+        <li>
+          <code>r=&lt;user&gt;</code>: Approve a PR on behalf of specified user.
+        </li>
+        <li><code>r+</code>: Approve a PR.</li>
+        <li><code>r-</code>: Unapprove a PR.</li>
+        <li>
+          <code>try</code>: Start a try build based on the most recent commit
+          from the main branch.
+        </li>
+        <li>
+          <code>try parent=&lt;sha&gt;</code>: Start a try build based on the
+          specified parent commit.
+        </li>
+        <li>
+          <code>try parent=last</code>: Start a try build based on the parent
+          commit of the last try build.
+        </li>
+        <li>
+          <code>try jobs=&lt;job1,job2,...&gt;</code>: Start a try build with
+          specific CI jobs (up to 10).
+        </li>
+        <li><code>try cancel</code>: Cancel a running try build.</li>
+        <li>
+          <code>delegate=&lt;try|review&gt;</code>: Delegate try or review
+          permissions to the PR author.
+        </li>
+        <li>
+          <code>delegate+</code>: Delegate review permissions to the PR author.
+        </li>
+        <li>
+          <code>delegate-</code>: Remove any previously granted delegation.
+        </li>
+      </ul>
+
+      <h4>Examples</h4>
+
+      <ul>
+        <li><code>@bors r+ p=1</code></li>
+        <li><code>@bors try parent=abcd123</code></li>
+        <li><code>@bors rollup=always</code></li>
+        <li><code>@bors delegate=review</code></li>
+        <li><code>@bors delegate=try</code></li>
+        <li>
+          <code>@bors try @rust-timer queue</code>: Short-hand for compile-perf
+          benchmarking of PRs.
+        </li>
+      </ul>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
This PR adds the website's home page, where it displays the repos. It also displays "[TREECLOSED]" is the tree is closed for the corresponding repo. 

The HTML is essentially the same as it was 11 years ago with slight differences:
- Homu -> Bors
- The section on "Customizing the Queue's Contents" has not been added as that will be added when the /queue is added and I don't know if all of the mentioned features are going to be supported
- The commands shown in the home page do not completely match as either some are not yet handled by bors just yet (e.g. `force` command) or some have been removed (e.g. `r=<name>`)