### PR TITLE
Fix flaky test `refresh_cancel_workflow_after_timeout`

### DIFF
--- a/src/bors/handlers/refresh.rs
+++ b/src/bors/handlers/refresh.rs
@@ -280,6 +280,28 @@ timeout = 3600
                     .await?;
                 WAIT_FOR_WORKFLOW_STARTED.sync().await;
 
+                // Wait for workflow to be created before timing out builds
+                tester
+                    .wait_for(|| async {
+                        let builds = tester
+                            .db()
+                            .get_running_builds(&default_repo_name())
+                            .await
+                            .unwrap();
+                        if builds.is_empty() {
+                            return Ok(false);
+                        }
+
+                        let workflows = tester
+                            .db()
+                            .get_workflows_for_build(&builds[0])
+                            .await
+                            .unwrap();
+                        Ok(!workflows.is_empty())
+                    })
+                    .await
+                    .unwrap();
+
                 with_mocked_time(Duration::from_secs(4000), async {
                     tester.cancel_timed_out_builds().await;
                 })


### PR DESCRIPTION
This PR fixes the flaky test `refresh_cancel_workflow_after_timeout`.

From my understanding, there's a race condition:
1. Try command completes (build is created in DB)
2. Workflow event sent and processing beings
3. Test immediately cancels timed out builds
4. Test tries to get workflows for the build but finds none (this is where it fails)
5. All the while workflow processing is still going

Essentially the test is checking for workflows before the workflow event has actually finished creating the workflow in the DB.

Logs:
```sh
2025-06-08T14:02:00.872420Z ... get_workflows_for_build (test checking)
2025-06-08T14:02:00.986623Z ... create_workflow (workflow event still processing)
```
