### PR TITLE
Reload PR state from DB after each executed command

### DIFF
--- a/src/bors/handlers/review.rs
+++ b/src/bors/handlers/review.rs
@@ -1017,4 +1017,27 @@ mod tests {
             })
             .await;
     }
+
+    #[sqlx::test]
+    async fn multiple_commands_in_one_comment(pool: sqlx::PgPool) {
+        run_test(pool, |mut tester| async {
+            tester
+                .post_comment(
+                    r#"
+@bors r+ rollup=never
+@bors p=10
+"#,
+                )
+                .await?;
+            tester.expect_comments(1).await;
+
+            tester
+                .wait_for_default_pr(|pr| {
+                    pr.rollup == Some(RollupMode::Never) && pr.priority == Some(10)
+                })
+                .await?;
+            Ok(tester)
+        })
+        .await;
+    }
 }


### PR DESCRIPTION
This ensures that the PR state is consistent between individual executed commands. We could go further and actually apply each executed SQL query to the PR model in memory, but that would be a much larger change, and it also has some trade-offs. I think that this should be enough for now.