### PR TITLE
Add remaining columns to queue page

### DIFF
--- a/templates/queue.html
+++ b/templates/queue.html
@@ -25,6 +25,7 @@
         <th>Status</th>
         <th>Mergeable</th>
         <th>Title</th>
+        <th>Author</th>
         <th>Approved by</th>
         <th>Priority</th>
         <th>Rollup</th>
@@ -55,6 +56,7 @@
                 {% endmatch %}
             </td>
             <td>{{ pr.title }}</td>
+            <td>{{ pr.author }}</td>
             <td>
                 {% if let Some(approver) = pr.approver() %}
                     {{ approver }}

--- a/templates/queue.html
+++ b/templates/queue.html
@@ -26,6 +26,7 @@
         <th>Mergeable</th>
         <th>Title</th>
         <th>Author</th>
+        <th>Assignees</th>
         <th>Approved by</th>
         <th>Priority</th>
         <th>Rollup</th>
@@ -57,6 +58,7 @@
             </td>
             <td>{{ pr.title }}</td>
             <td>{{ pr.author }}</td>
+            <td>{{ pr.assignees|join(", ") }}</td>
             <td>
                 {% if let Some(approver) = pr.approver() %}
                     {{ approver }}

--- a/templates/queue.html
+++ b/templates/queue.html
@@ -24,6 +24,7 @@
         <th>#</th>
         <th>Status</th>
         <th>Mergeable</th>
+        <th>Title</th>
         <th>Approved by</th>
         <th>Priority</th>
         <th>Rollup</th>
@@ -53,6 +54,7 @@
                     {% when Unknown %}
                 {% endmatch %}
             </td>
+            <td>{{ pr.title }}</td>
             <td>
                 {% if let Some(approver) = pr.approver() %}
                     {{ approver }}

--- a/templates/queue.html
+++ b/templates/queue.html
@@ -2,6 +2,14 @@
 
 {% block title %}Bors queue - {{ repo_name }} {% if tree_state.is_closed() %} [TREECLOSED] {% endif %}{% endblock %}
 
+{% block head %}
+<style>
+  table {
+    border-spacing: 30px 0;
+  }
+</style>
+{% endblock %}
+
 {% block body %}
 <h1>
     Bors queue - <a href="{{ repo_url }}" target="_blank">{{ repo_name }}</a>


### PR DESCRIPTION
Adds the remaining columns for the queue page, including:
- Title
- Author
- Assignees

and some table spacing to make it easier to parse.
