### PR TITLE
Drain previously seen notifications in `TestSyncMarker`

### DIFF
--- a/src/bors/handlers/mod.rs
+++ b/src/bors/handlers/mod.rs
@@ -35,9 +35,6 @@ use refresh::sync_pull_requests_state;
 use review::{command_delegate, command_set_priority, command_set_rollup, command_undelegate};
 use tracing::Instrument;
 
-#[cfg(test)]
-use crate::tests::util::TestSyncMarker;
-
 use super::mergeable_queue::MergeableQueueSender;
 
 mod help;
@@ -49,9 +46,6 @@ mod refresh;
 mod review;
 mod trybuild;
 mod workflow;
-
-#[cfg(test)]
-pub static WAIT_FOR_WORKFLOW_STARTED: TestSyncMarker = TestSyncMarker::new();
 
 /// This function executes a single BORS repository event
 pub async fn handle_bors_repository_event(
@@ -114,7 +108,7 @@ pub async fn handle_bors_repository_event(
                 .await?;
 
             #[cfg(test)]
-            WAIT_FOR_WORKFLOW_STARTED.mark();
+            super::WAIT_FOR_WORKFLOW_STARTED.mark();
         }
         BorsRepositoryEvent::WorkflowCompleted(payload) => {
             let span = tracing::info_span!(

--- a/src/bors/handlers/refresh.rs
+++ b/src/bors/handlers/refresh.rs
@@ -180,11 +180,10 @@ fn elapsed_time(date: DateTime<Utc>) -> Duration {
 #[cfg(test)]
 mod tests {
     use crate::bors::PullRequestStatus;
-    use crate::bors::handlers::WAIT_FOR_WORKFLOW_STARTED;
     use crate::bors::handlers::refresh::MOCK_TIME;
     use crate::database::{MergeableState, OctocrabMergeableState};
     use crate::tests::mocks::{
-        BorsBuilder, GitHubState, WorkflowEvent, default_pr_number, default_repo_name, run_test,
+        BorsBuilder, GitHubState, default_pr_number, default_repo_name, run_test,
     };
     use chrono::Utc;
     use std::future::Future;
@@ -275,10 +274,7 @@ timeout = 3600
             .run_test(|mut tester| async move {
                 tester.post_comment("@bors try").await?;
                 tester.expect_comments(1).await;
-                tester
-                    .workflow_event(WorkflowEvent::started(tester.try_branch()))
-                    .await?;
-                WAIT_FOR_WORKFLOW_STARTED.sync().await;
+                tester.start_workflow(tester.try_branch()).await?;
 
                 with_mocked_time(Duration::from_secs(4000), async {
                     tester.cancel_timed_out_builds().await;

--- a/src/bors/handlers/trybuild.rs
+++ b/src/bors/handlers/trybuild.rs
@@ -306,7 +306,6 @@ fn auto_merge_commit_message(
 
 #[cfg(test)]
 mod tests {
-    use crate::bors::handlers::WAIT_FOR_WORKFLOW_STARTED;
     use crate::bors::handlers::trybuild::{TRY_BRANCH_NAME, TRY_MERGE_BRANCH_NAME};
     use crate::database::operations::get_all_workflows;
     use crate::github::CommitSha;
@@ -597,11 +596,8 @@ mod tests {
             tester.post_comment("@bors try").await?;
             tester.expect_comments(1).await;
             tester
-                .workflow_event(WorkflowEvent::started(
-                    Workflow::from(tester.try_branch()).with_run_id(123),
-                ))
+                .start_workflow(Workflow::from(tester.try_branch()).with_run_id(123))
                 .await?;
-            WAIT_FOR_WORKFLOW_STARTED.sync().await;
 
             tester.post_comment("@bors try").await?;
             insta::assert_snapshot!(tester.get_comment().await?, @r"

--- a/src/bors/mod.rs
+++ b/src/bors/mod.rs
@@ -33,6 +33,9 @@ pub static WAIT_FOR_MERGEABILITY_STATUS_REFRESH: TestSyncMarker = TestSyncMarker
 #[cfg(test)]
 pub static WAIT_FOR_PR_STATUS_REFRESH: TestSyncMarker = TestSyncMarker::new();
 
+#[cfg(test)]
+pub static WAIT_FOR_WORKFLOW_STARTED: TestSyncMarker = TestSyncMarker::new();
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum CheckSuiteStatus {
     Pending,

--- a/src/tests/mocks/bors.rs
+++ b/src/tests/mocks/bors.rs
@@ -863,7 +863,9 @@ where
 {
     let res = func().await;
     if res.is_ok() {
-        marker.sync().await;
+        tokio::time::timeout(Duration::from_secs(5), marker.sync())
+            .await
+            .map_err(|_| anyhow::anyhow!("Timed out waiting for a test marker to be marked"))?;
     }
     res
 }

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -1,7 +1,10 @@
-use std::sync::atomic::{AtomicUsize, Ordering};
 use thread_local::ThreadLocal;
 use tokio::sync;
 
+/// This struct serves for waiting for certain async (and unsynchronized) events to happen in tests.
+/// The test should start an async operation and then call `sync().await` to wait until it's
+/// finished. The expectation is that the operation will eventually call `mark()` to unblock the
+/// test.
 pub struct TestSyncMarker {
     inner: ThreadLocal<TestSyncMarkerInner>,
 }
@@ -30,7 +33,6 @@ impl TestSyncMarker {
 struct TestSyncMarkerInner {
     rx: sync::Mutex<sync::mpsc::Receiver<()>>,
     tx: sync::mpsc::Sender<()>,
-    hits: AtomicUsize,
 }
 
 impl TestSyncMarkerInner {
@@ -39,7 +41,6 @@ impl TestSyncMarkerInner {
         Self {
             tx,
             rx: sync::Mutex::new(rx),
-            hits: AtomicUsize::new(0),
         }
     }
 
@@ -47,7 +48,6 @@ impl TestSyncMarkerInner {
     pub fn mark(&self) {
         // If we cannot send, don't block the program.
         let _ = self.tx.try_send(());
-        self.hits.fetch_add(1, Ordering::SeqCst);
     }
 
     /// Wait until code has encountered this location.


### PR DESCRIPTION
This should hopefully fix the spurious errors that we have been seeing with `refresh_cancel_workflow_after_timeout`.

CC @Sakib25800