### PR TITLE
Add http to link printed by bors

### DIFF
--- a/src/bin/bors.rs
+++ b/src/bin/bors.rs
@@ -65,7 +65,10 @@ async fn webhook_server(state: ServerState) -> anyhow::Result<()> {
         .await
         .context("Cannot create TCP/IP server socket")?;
 
-    tracing::info!("Listening on 0.0.0.0:{}", listener.local_addr()?.port());
+    tracing::info!(
+        "Listening on http://0.0.0.0:{}",
+        listener.local_addr()?.port()
+    );
 
     axum::serve(listener, app).await?;
     Ok(())


### PR DESCRIPTION
So that you can easily click on the link in terminal when bors starts up.