### PR TITLE
Use `.enqueue_now(...)` for mergeable queue refresh event

### DIFF
--- a/src/bors/handlers/refresh.rs
+++ b/src/bors/handlers/refresh.rs
@@ -86,7 +86,7 @@ pub async fn reload_unknown_mergeable_prs(
     );
 
     for pr in prs {
-        mergeable_queue.enqueue(repo.repository().clone(), pr.number);
+        mergeable_queue.enqueue_now(repo.repository().clone(), pr.number);
     }
 
     Ok(())

--- a/src/bors/mergeable_queue.rs
+++ b/src/bors/mergeable_queue.rs
@@ -121,8 +121,7 @@ impl MergeableQueueSender {
         );
     }
 
-    #[allow(dead_code)]
-    pub fn enqueue_now(&self, pr_number: PullRequestNumber, repo: GithubRepoName) {
+    pub fn enqueue_now(&self, repo: GithubRepoName, pr_number: PullRequestNumber) {
         self.insert_item(
             MergeableQueueItem {
                 pull_request: QueuedPullRequest { pr_number, repo },


### PR DESCRIPTION
I had forgotten to use `.enqueue_now(...)` rather than `.enqueue(...)`.

Since the purpose of the mergeable queue refresh event is to catch missed PRs, we know that time has already elapsed, so we can enqueue immediately.
