### PR TITLE
Delete auto build on PR and cancel running workflows

### DIFF
--- a/.sqlx/query-5d288166198bd4a3dbed0ef31933d029004241b0ad01f19b8bd0f5465b752f9b.json
+++ b/.sqlx/query-5d288166198bd4a3dbed0ef31933d029004241b0ad01f19b8bd0f5465b752f9b.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            -- Clear the PR's auto_build_id\n            WITH removed_auto_build AS (\n                UPDATE pull_request\n                SET auto_build_id = NULL\n                WHERE id = $1 AND auto_build_id IS NOT NULL\n                RETURNING auto_build_id\n            )\n            -- Delete the build record if one was removed\n            DELETE FROM build\n            WHERE id IN (SELECT auto_build_id FROM removed_auto_build)\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "5d288166198bd4a3dbed0ef31933d029004241b0ad01f19b8bd0f5465b752f9b"
+}

--- a/migrations/20250624212942_add_workflow_cascade_delete.down.sql
+++ b/migrations/20250624212942_add_workflow_cascade_delete.down.sql
@@ -1,0 +1,3 @@
+-- Add down migration script here
+ALTER TABLE workflow DROP CONSTRAINT fk_build_id;
+ALTER TABLE workflow ADD CONSTRAINT fk_build_id FOREIGN KEY (build_id) REFERENCES build(id);

--- a/migrations/20250624212942_add_workflow_cascade_delete.up.sql
+++ b/migrations/20250624212942_add_workflow_cascade_delete.up.sql
@@ -1,0 +1,3 @@
+-- Add up migration script here
+ALTER TABLE workflow DROP CONSTRAINT fk_build_id;
+ALTER TABLE workflow ADD CONSTRAINT fk_build_id FOREIGN KEY (build_id) REFERENCES build(id) ON DELETE CASCADE;

--- a/src/database/client.rs
+++ b/src/database/client.rs
@@ -10,14 +10,14 @@ use crate::github::{CommitSha, GithubRepoName};
 
 use super::operations::{
     approve_pull_request, create_build, create_pull_request, create_workflow,
-    delegate_pull_request, find_build, find_pr_by_build, get_nonclosed_pull_requests,
-    get_nonclosed_pull_requests_by_base_branch, get_prs_with_unknown_mergeable_state,
-    get_pull_request, get_repository, get_repository_by_name, get_running_builds,
-    get_workflow_urls_for_build, get_workflows_for_build, insert_repo_if_not_exists,
-    set_pr_assignees, set_pr_priority, set_pr_rollup, set_pr_status, unapprove_pull_request,
-    undelegate_pull_request, update_build_status, update_mergeable_states_by_base_branch,
-    update_pr_mergeable_state, update_pr_try_build_id, update_workflow_status, upsert_pull_request,
-    upsert_repository,
+    delegate_pull_request, delete_auto_build, find_build, find_pr_by_build,
+    get_nonclosed_pull_requests, get_nonclosed_pull_requests_by_base_branch,
+    get_prs_with_unknown_mergeable_state, get_pull_request, get_repository, get_repository_by_name,
+    get_running_builds, get_workflow_urls_for_build, get_workflows_for_build,
+    insert_repo_if_not_exists, set_pr_assignees, set_pr_priority, set_pr_rollup, set_pr_status,
+    unapprove_pull_request, undelegate_pull_request, update_build_status,
+    update_mergeable_states_by_base_branch, update_pr_mergeable_state, update_pr_try_build_id,
+    update_workflow_status, upsert_pull_request, upsert_repository,
 };
 use super::{ApprovalInfo, DelegatedPermission, MergeableState, RunId, UpsertPullRequestParams};
 
@@ -295,5 +295,9 @@ impl PgDbClient {
         tree_state: TreeState,
     ) -> anyhow::Result<()> {
         upsert_repository(&self.pool, repo, tree_state).await
+    }
+
+    pub async fn delete_auto_build(&self, pr: &PullRequestModel) -> anyhow::Result<()> {
+        delete_auto_build(&self.pool, pr.id).await
     }
 }

--- a/tests/data/migrations/20250624212942_add_workflow_cascade_delete.sql
+++ b/tests/data/migrations/20250624212942_add_workflow_cascade_delete.sql
@@ -1,0 +1,1 @@
+-- Empty to satisfy migration tests


### PR DESCRIPTION
- Deletes a PR's auto build on PR push (if it exists)
- Cancels a running auto builds workflows on PR push
- Adds new migration to delete associated workflows when a build is deleted

I can't really write tests for this yet since the merge queue is what creates auto builds, so I'll have to write tests for this in another PR after the merge queue is added.
