### PR TITLE
Merge queue

### DIFF
--- a/.sqlx/query-3ae0ba7ce98f0a68b47df52a9181134df3ac7818af0c085ac432eb52874a62a2.json
+++ b/.sqlx/query-3ae0ba7ce98f0a68b47df52a9181134df3ac7818af0c085ac432eb52874a62a2.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE pull_request SET auto_build_id = $1 WHERE id = $2",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int4",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "3ae0ba7ce98f0a68b47df52a9181134df3ac7818af0c085ac432eb52874a62a2"
+}

--- a/rust-bors.example.toml
+++ b/rust-bors.example.toml
@@ -19,6 +19,8 @@ approve = ["+approved"]
 try = ["+foo", "-bar"]
 try_succeed = ["+foobar", "+foo", "+baz"]
 try_failed = []
+auto_build_succeeded = ["+foo", "+bar"]
+auto_build_failed = ["+foo", "+bar"]
 
 # Labels that will block approval when present on a PR
 # (Optional)

--- a/src/bors/comment.rs
+++ b/src/bors/comment.rs
@@ -327,3 +327,9 @@ pub fn auto_build_succeeded_comment(
         ":sunny: Test successful - {urls}\nApproved by: `{approved_by}`\nPushing {merge_sha} to `{base_ref}`...",
     ))
 }
+
+pub fn auto_build_push_failed_comment(error: &str) -> Comment {
+    Comment::new(format!(
+        ":eyes: Test was successful, but fast-forwarding failed: {error}"
+    ))
+}

--- a/src/bors/comment.rs
+++ b/src/bors/comment.rs
@@ -303,3 +303,10 @@ fn list_workflows_status(workflows: &[WorkflowModel]) -> String {
         .collect::<Vec<_>>()
         .join("\n")
 }
+
+pub fn auto_build_started_comment(head_sha: &CommitSha, merge_sha: &CommitSha) -> Comment {
+    Comment::new(format!(
+        ":hourglass: Testing commit {} with merge {}...",
+        head_sha, merge_sha
+    ))
+}

--- a/src/bors/comment.rs
+++ b/src/bors/comment.rs
@@ -310,3 +310,20 @@ pub fn auto_build_started_comment(head_sha: &CommitSha, merge_sha: &CommitSha) -
         head_sha, merge_sha
     ))
 }
+
+pub fn auto_build_succeeded_comment(
+    workflows: &[WorkflowModel],
+    approved_by: &str,
+    merge_sha: &CommitSha,
+    base_ref: &str,
+) -> Comment {
+    let urls = workflows
+        .iter()
+        .map(|w| format!("[{}]({})", w.name, w.url))
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    Comment::new(format!(
+        ":sunny: Test successful - {urls}\nApproved by: `{approved_by}`\nPushing {merge_sha} to `{base_ref}`...",
+    ))
+}

--- a/src/bors/handlers/review.rs
+++ b/src/bors/handlers/review.rs
@@ -717,13 +717,9 @@ mod tests {
         gh.check_sha_history(
             default_repo_name(),
             TRY_MERGE_BRANCH_NAME,
-            &["main-sha1", "merge-main-sha1-pr-1-sha-0"],
+            &["main-sha1", "merge-0-pr-1"],
         );
-        gh.check_sha_history(
-            default_repo_name(),
-            TRY_BRANCH_NAME,
-            &["merge-main-sha1-pr-1-sha-0"],
-        );
+        gh.check_sha_history(default_repo_name(), TRY_BRANCH_NAME, &["merge-0-pr-1"]);
     }
 
     #[sqlx::test]
@@ -1130,7 +1126,7 @@ mod tests {
 
                 tester.post_comment("@bors try").await?;
                 insta::assert_snapshot!(tester.get_comment().await?, @r"
-                :hourglass: Trying commit pr-1-sha with merge merge-main-sha1-pr-1-sha-0…
+                :hourglass: Trying commit pr-1-sha with merge merge-0-pr-1…
 
                 To cancel the try build, run the command `@bors try cancel`.
                 ");

--- a/src/bors/handlers/trybuild.rs
+++ b/src/bors/handlers/trybuild.rs
@@ -422,9 +422,9 @@ mod tests {
                 tester.get_comment().await?,
                 @r#"
             :sunny: Try build successful ([Workflow1](https://github.com/workflows/Workflow1/1))
-            Build commit: merge-main-sha1-pr-1-sha-0 (`merge-main-sha1-pr-1-sha-0`, parent: `main-sha1`)
+            Build commit: merge-0-pr-1 (`merge-0-pr-1`, parent: `main-sha1`)
 
-            <!-- homu: {"type":"TryBuildCompleted","merge_sha":"merge-main-sha1-pr-1-sha-0"} -->
+            <!-- homu: {"type":"TryBuildCompleted","merge_sha":"merge-0-pr-1"} -->
             "#
             );
             Ok(())
@@ -507,7 +507,7 @@ mod tests {
             insta::assert_snapshot!(
                 tester.get_comment().await?,
                 @r"
-            :hourglass: Trying commit pr-1-sha with merge merge-main-sha1-pr-1-sha-0…
+            :hourglass: Trying commit pr-1-sha with merge merge-0-pr-1…
 
             To cancel the try build, run the command `@bors try cancel`.
             "
@@ -524,7 +524,7 @@ mod tests {
             insta::assert_snapshot!(
                 tester.get_comment().await?,
                 @r"
-            :hourglass: Trying commit pr-1-sha with merge merge-main-sha1-pr-1-sha-0…
+            :hourglass: Trying commit pr-1-sha with merge merge-0-pr-1…
 
             To cancel the try build, run the command `@bors try cancel`.
             "
@@ -631,13 +631,9 @@ try-job: Bar
         gh.check_sha_history(
             default_repo_name(),
             TRY_MERGE_BRANCH_NAME,
-            &["main-sha1", "merge-main-sha1-pr-1-sha-0"],
+            &["main-sha1", "merge-0-pr-1"],
         );
-        gh.check_sha_history(
-            default_repo_name(),
-            TRY_BRANCH_NAME,
-            &["merge-main-sha1-pr-1-sha-0"],
-        );
+        gh.check_sha_history(default_repo_name(), TRY_BRANCH_NAME, &["merge-0-pr-1"]);
     }
 
     #[sqlx::test]
@@ -653,10 +649,7 @@ try-job: Bar
         gh.check_sha_history(
             default_repo_name(),
             TRY_MERGE_BRANCH_NAME,
-            &[
-                "ea9c1b050cc8b420c2c211d2177811e564a4dc60",
-                "merge-ea9c1b050cc8b420c2c211d2177811e564a4dc60-pr-1-sha-0",
-            ],
+            &["ea9c1b050cc8b420c2c211d2177811e564a4dc60", "merge-0-pr-1"],
         );
     }
 
@@ -671,7 +664,7 @@ try-job: Bar
             tester.expect_comments(1).await;
             tester.post_comment("@bors try parent=last").await?;
             insta::assert_snapshot!(tester.get_comment().await?, @r"
-            :hourglass: Trying commit pr-1-sha with merge merge-ea9c1b050cc8b420c2c211d2177811e564a4dc60-pr-1-sha-1…
+            :hourglass: Trying commit pr-1-sha with merge merge-1-pr-1…
 
             To cancel the try build, run the command `@bors try cancel`.
             ");
@@ -683,9 +676,9 @@ try-job: Bar
             TRY_MERGE_BRANCH_NAME,
             &[
                 "ea9c1b050cc8b420c2c211d2177811e564a4dc60",
-                "merge-ea9c1b050cc8b420c2c211d2177811e564a4dc60-pr-1-sha-0",
+                "merge-0-pr-1",
                 "ea9c1b050cc8b420c2c211d2177811e564a4dc60",
-                "merge-ea9c1b050cc8b420c2c211d2177811e564a4dc60-pr-1-sha-1",
+                "merge-1-pr-1",
             ],
         );
     }
@@ -773,7 +766,7 @@ try-job: Bar
             tester.expect_comments(1).await;
             tester.post_comment("@bors try").await?;
             insta::assert_snapshot!(tester.get_comment().await?, @r"
-            :hourglass: Trying commit pr-1-sha with merge merge-main-sha1-pr-1-sha-1…
+            :hourglass: Trying commit pr-1-sha with merge merge-1-pr-1…
 
             To cancel the try build, run the command `@bors try cancel`.
             ");
@@ -795,7 +788,7 @@ try-job: Bar
                 )
                 .await?;
             insta::assert_snapshot!(tester.get_comment().await?, @r"
-            :hourglass: Trying commit pr-1-sha with merge merge-main-sha1-pr-1-sha-0…
+            :hourglass: Trying commit pr-1-sha with merge merge-0-pr-1…
 
             To cancel the try build, run the command `@bors try cancel`.
             ");
@@ -816,7 +809,7 @@ try-job: Bar
 
             tester.post_comment("@bors try").await?;
             insta::assert_snapshot!(tester.get_comment().await?, @r"
-            :hourglass: Trying commit pr-1-sha with merge merge-main-sha1-pr-1-sha-1…
+            :hourglass: Trying commit pr-1-sha with merge merge-1-pr-1…
 
             (The previously running try build was automatically cancelled.)
 
@@ -840,18 +833,22 @@ try-job: Bar
 
             tester.post_comment("@bors try").await?;
             insta::assert_snapshot!(tester.get_comment().await?, @r"
-            :hourglass: Trying commit pr-1-sha with merge merge-main-sha1-pr-1-sha-1…
+            :hourglass: Trying commit pr-1-sha with merge merge-1-pr-1…
 
             To cancel the try build, run the command `@bors try cancel`.
             ");
             tester
-                .workflow_full_success(WorkflowRunData::from(tester.try_branch()).with_run_id(2).with_check_suite_id(2))
+                .workflow_full_success(
+                    WorkflowRunData::from(tester.try_branch())
+                        .with_run_id(2)
+                        .with_check_suite_id(2),
+                )
                 .await?;
             insta::assert_snapshot!(tester.get_comment().await?, @r#"
             :sunny: Try build successful ([Workflow1](https://github.com/workflows/Workflow1/2))
-            Build commit: merge-main-sha1-pr-1-sha-1 (`merge-main-sha1-pr-1-sha-1`, parent: `main-sha1`)
+            Build commit: merge-1-pr-1 (`merge-1-pr-1`, parent: `main-sha1`)
 
-            <!-- homu: {"type":"TryBuildCompleted","merge_sha":"merge-main-sha1-pr-1-sha-1"} -->
+            <!-- homu: {"type":"TryBuildCompleted","merge_sha":"merge-1-pr-1"} -->
             "#);
             Ok(())
         })
@@ -988,7 +985,7 @@ try = ["+foo", "+bar", "-baz"]
             .run_test(async |tester| {
                 tester.post_comment("@bors try").await?;
                 insta::assert_snapshot!(tester.get_comment().await?, @r"
-                :hourglass: Trying commit pr-1-sha with merge merge-main-sha1-pr-1-sha-0…
+                :hourglass: Trying commit pr-1-sha with merge merge-0-pr-1…
 
                 To cancel the try build, run the command `@bors try cancel`.
                 ");
@@ -1013,7 +1010,7 @@ try_succeed = ["+foo", "+bar", "-baz"]
             .run_test(async |tester| {
                 tester.post_comment("@bors try").await?;
                 insta::assert_snapshot!(tester.get_comment().await?, @r"
-                :hourglass: Trying commit pr-1-sha with merge merge-main-sha1-pr-1-sha-0…
+                :hourglass: Trying commit pr-1-sha with merge merge-0-pr-1…
 
                 To cancel the try build, run the command `@bors try cancel`.
                 ");
@@ -1043,7 +1040,7 @@ try_failed = ["+foo", "+bar", "-baz"]
             .run_test(async |tester| {
                 tester.post_comment("@bors try").await?;
                 insta::assert_snapshot!(tester.get_comment().await?, @r"
-                :hourglass: Trying commit pr-1-sha with merge merge-main-sha1-pr-1-sha-0…
+                :hourglass: Trying commit pr-1-sha with merge merge-0-pr-1…
 
                 To cancel the try build, run the command `@bors try cancel`.
                 ");

--- a/src/bors/mod.rs
+++ b/src/bors/mod.rs
@@ -41,6 +41,9 @@ pub static WAIT_FOR_PR_STATUS_REFRESH: TestSyncMarker = TestSyncMarker::new();
 #[cfg(test)]
 pub static WAIT_FOR_WORKFLOW_STARTED: TestSyncMarker = TestSyncMarker::new();
 
+#[cfg(test)]
+pub static WAIT_FOR_MERGE_QUEUE: TestSyncMarker = TestSyncMarker::new();
+
 /// Corresponds to a single execution of a workflow.
 #[derive(Clone, Debug)]
 pub struct WorkflowRun {

--- a/src/config.rs
+++ b/src/config.rs
@@ -73,6 +73,8 @@ where
         Try,
         TrySucceed,
         TryFailed,
+        AutoBuildSucceeded,
+        AutoBuildFailed,
     }
 
     impl From<Trigger> for LabelTrigger {
@@ -83,6 +85,8 @@ where
                 Trigger::Try => LabelTrigger::TryBuildStarted,
                 Trigger::TrySucceed => LabelTrigger::TryBuildSucceeded,
                 Trigger::TryFailed => LabelTrigger::TryBuildFailed,
+                Trigger::AutoBuildSucceeded => LabelTrigger::AutoBuildSucceeded,
+                Trigger::AutoBuildFailed => LabelTrigger::AutoBuildFailed,
             }
         }
     }
@@ -210,9 +214,11 @@ approve = ["+approved"]
 try = ["+foo", "-bar"]
 try_succeed = ["+foobar", "+foo", "+baz"]
 try_failed = []
+auto_build_succeeded = ["+foobar", "-foo"]
+auto_build_failed = ["+bar", "+baz"]
 "#;
         let config = load_config(content);
-        insta::assert_debug_snapshot!(config.labels.into_iter().collect::<BTreeMap<_, _>>(), @r###"
+        insta::assert_debug_snapshot!(config.labels.into_iter().collect::<BTreeMap<_, _>>(), @r#"
         {
             Approved: [
                 Add(
@@ -244,8 +250,24 @@ try_failed = []
                 ),
             ],
             TryBuildFailed: [],
+            AutoBuildSucceeded: [
+                Add(
+                    "foobar",
+                ),
+                Remove(
+                    "foo",
+                ),
+            ],
+            AutoBuildFailed: [
+                Add(
+                    "bar",
+                ),
+                Add(
+                    "baz",
+                ),
+            ],
         }
-        "###);
+        "#);
     }
 
     #[test]

--- a/src/database/operations.rs
+++ b/src/database/operations.rs
@@ -515,6 +515,24 @@ pub(crate) async fn update_pr_try_build_id(
     .await
 }
 
+pub(crate) async fn update_pr_auto_build_id(
+    executor: impl PgExecutor<'_>,
+    pr_id: i32,
+    auto_build_id: i32,
+) -> anyhow::Result<()> {
+    measure_db_query("update_pr_auto_build_id", || async {
+        sqlx::query!(
+            "UPDATE pull_request SET auto_build_id = $1 WHERE id = $2",
+            auto_build_id,
+            pr_id
+        )
+        .execute(executor)
+        .await?;
+        Ok(())
+    })
+    .await
+}
+
 pub(crate) async fn create_build(
     executor: impl PgExecutor<'_>,
     repo: &GithubRepoName,

--- a/src/github/labels.rs
+++ b/src/github/labels.rs
@@ -6,6 +6,8 @@ pub enum LabelTrigger {
     TryBuildStarted,
     TryBuildSucceeded,
     TryBuildFailed,
+    AutoBuildSucceeded,
+    AutoBuildFailed,
 }
 
 #[derive(Debug, Eq, PartialEq)]

--- a/src/tests/mocks/bors.rs
+++ b/src/tests/mocks/bors.rs
@@ -19,7 +19,7 @@ use super::repository::PullRequest;
 use crate::bors::merge_queue::MergeQueueSender;
 use crate::bors::mergeable_queue::MergeableQueueSender;
 use crate::bors::{
-    CommandPrefix, RollupMode, WAIT_FOR_CANCEL_TIMED_OUT_BUILDS_REFRESH,
+    CommandPrefix, RollupMode, WAIT_FOR_CANCEL_TIMED_OUT_BUILDS_REFRESH, WAIT_FOR_MERGE_QUEUE,
     WAIT_FOR_MERGEABILITY_STATUS_REFRESH, WAIT_FOR_PR_STATUS_REFRESH, WAIT_FOR_WORKFLOW_STARTED,
 };
 use crate::database::{
@@ -41,7 +41,7 @@ use crate::tests::mocks::{
 use crate::tests::util::TestSyncMarker;
 use crate::tests::webhook::{TEST_WEBHOOK_SECRET, create_webhook_request};
 use crate::{
-    BorsContext, BorsGlobalEvent, CommandParser, PgDbClient, ServerState, WebhookSecret,
+    BorsContext, BorsGlobalEvent, CommandParser, PgDbClient, ServerState, TreeState, WebhookSecret,
     create_app, create_bors_process,
 };
 
@@ -147,7 +147,13 @@ impl BorsTester {
         let mut repos = HashMap::default();
         for (name, repo) in loaded_repos {
             let repo = repo.unwrap();
-            repos.insert(name, Arc::new(repo));
+            repos.insert(name.clone(), Arc::new(repo));
+        }
+
+        for (name, _) in &repos {
+            if let Err(error) = db.insert_repo_if_not_exists(name, TreeState::Open).await {
+                tracing::warn!("Failed to insert repository {name} in test: {error:?}");
+            }
         }
 
         let ctx = BorsContext::new(
@@ -298,6 +304,10 @@ impl BorsTester {
         self.get_branch("automation/bors/try")
     }
 
+    pub fn auto_branch(&self) -> Branch {
+        self.get_branch("automation/bors/auto")
+    }
+
     /// Wait until the next bot comment is received on the default repo and the default PR.
     pub async fn get_comment(&mut self) -> anyhow::Result<String> {
         Ok(self
@@ -356,6 +366,22 @@ impl BorsTester {
                 Ok(())
             },
             &WAIT_FOR_PR_STATUS_REFRESH,
+        )
+        .await
+        .unwrap();
+    }
+
+    pub async fn process_merge_queue(&self) {
+        // Wait until the merge queue processing is fully handled
+        wait_for_marker(
+            async || {
+                self.global_tx
+                    .send(BorsGlobalEvent::ProcessMergeQueue)
+                    .await
+                    .unwrap();
+                Ok(())
+            },
+            &WAIT_FOR_MERGE_QUEUE,
         )
         .await
         .unwrap();

--- a/src/tests/mocks/comment.rs
+++ b/src/tests/mocks/comment.rs
@@ -8,7 +8,7 @@ use url::Url;
 use crate::github::GithubRepoName;
 use crate::tests::mocks::repository::GitHubRepository;
 use crate::tests::mocks::user::{GitHubUser, User};
-use crate::tests::mocks::{Repo, default_pr_number};
+use crate::tests::mocks::{Repo, default_pr_number, default_repo_name};
 
 #[derive(Clone, Debug)]
 pub struct Comment {
@@ -28,6 +28,10 @@ impl Comment {
             content: content.to_string(),
             comment_id: 1, // comment_id will be updated by the mock server
         }
+    }
+
+    pub fn pr(pr: u64, content: &str) -> Self {
+        Self::new(default_repo_name(), pr, content)
     }
 
     pub fn with_author(self, author: User) -> Self {

--- a/src/tests/mocks/mod.rs
+++ b/src/tests/mocks/mod.rs
@@ -29,7 +29,7 @@ pub use workflow::WorkflowJob;
 pub use workflow::WorkflowRunData;
 
 mod app;
-mod bors;
+pub mod bors;
 mod comment;
 mod github;
 mod permissions;

--- a/src/tests/mocks/repository.rs
+++ b/src/tests/mocks/repository.rs
@@ -547,7 +547,7 @@ async fn mock_merge_branch(repo: Arc<Mutex<Repo>>, mock_server: &MockServer) {
             let head_sha = match head {
                 None => {
                     // head is a SHA
-                    data.head
+                    data.head.clone()
                 }
                 Some(branch) => {
                     // head is a branch
@@ -562,10 +562,14 @@ async fn mock_merge_branch(repo: Arc<Mutex<Repo>>, mock_server: &MockServer) {
                 return ResponseTemplate::new(409);
             }
 
-            let merge_sha = format!(
-                "merge-{}-{head_sha}-{}",
-                base_branch.sha, base_branch.merge_counter
-            );
+            let source_info = if head_sha.starts_with("pr-") && head_sha.ends_with("-sha") {
+                head_sha.strip_suffix("-sha").unwrap()
+            } else {
+                // Use the original head reference (branch name or SHA)
+                &data.head
+            };
+
+            let merge_sha = format!("merge-{}-{source_info}", base_branch.merge_counter);
             base_branch.merge_counter += 1;
             base_branch.set_to_sha(&merge_sha);
             repo.set_commit_message(&merge_sha, &data.commit_message);

--- a/src/tests/mocks/repository.rs
+++ b/src/tests/mocks/repository.rs
@@ -168,6 +168,8 @@ pub struct Repo {
     pub check_runs: Vec<CheckRunData>,
     /// Cause pull request fetch to fail.
     pub pull_request_error: bool,
+    // Cause branch push to fail.
+    pub push_error: bool,
     pub pr_push_counter: u64,
 }
 
@@ -184,6 +186,7 @@ impl Repo {
             workflow_cancel_error: false,
             workflow_runs: vec![],
             pull_request_error: false,
+            push_error: false,
             pr_push_counter: 0,
             check_runs: vec![],
         }
@@ -508,6 +511,10 @@ async fn mock_update_branch(repo: Arc<Mutex<Repo>>, mock_server: &MockServer) {
             }
 
             let data: SetRefRequest = req.body_json().unwrap();
+
+            if repo.push_error {
+                return ResponseTemplate::new(500).set_body_string("Push error");
+            }
 
             let sha = data.sha;
             match repo.get_branch_by_name(branch_name) {

--- a/src/utils/sort_queue.rs
+++ b/src/utils/sort_queue.rs
@@ -46,8 +46,8 @@ fn get_queue_blocking_priority(pr: &PullRequestModel) -> u32 {
 fn get_status_priority(pr: &PullRequestModel) -> u32 {
     match &pr.auto_build {
         Some(build) => match build.status {
-            BuildStatus::Success => 1,
-            BuildStatus::Pending => 1, // Same as success since queue blocking is handled separately
+            BuildStatus::Success => 0,
+            BuildStatus::Pending => 1,
             BuildStatus::Failure => 3,
             BuildStatus::Cancelled | BuildStatus::Timeouted => 2,
         },


### PR DESCRIPTION
This PR adds the complete merge queue process from auto build -> merge to master. 

The merge queue works like so: 
- Every 30s `handle_merge_queue(...)` is called
- It selects a PR that can be merged (based on a set of merge queue priority rules)
- As part of the sorts, successful auto builds come first and pending ones second and a bunch of other rules. But those are 
the two most important. 
- If `handle_merge_queue(...)` sees:
  - Successful auto build, it will merge it 
  - Pending auto build, it will halt the queue until the auto build is done (to prevent simultaneous auto builds)
- From the check suite completed webhook, we attempt to `try_complete_build(...)` where we attempt to determine the build status and post relevant comments

Homu works in exactly the same way, with the only difference being that we use the GitHub checks API rather than the the commit status API. 