### PR TITLE
Add try build check run

### DIFF
--- a/.sqlx/query-02da9f6b50aedf8ccca20aa166c04e7406180ec882d79a0c5d5961779894a6f0.json
+++ b/.sqlx/query-02da9f6b50aedf8ccca20aa166c04e7406180ec882d79a0c5d5961779894a6f0.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\nSELECT\n    id,\n    repository as \"repository: GithubRepoName\",\n    branch,\n    commit_sha,\n    parent,\n    status as \"status: BuildStatus\",\n    created_at as \"created_at: DateTime<Utc>\"\nFROM build\nWHERE repository = $1\n    AND branch = $2\n    AND commit_sha = $3\n",
+  "query": "\nSELECT\n    id,\n    repository as \"repository: GithubRepoName\",\n    branch,\n    commit_sha,\n    status as \"status: BuildStatus\",\n    parent,\n    created_at as \"created_at: DateTime<Utc>\",\n    check_run_id\nFROM build\nWHERE repository = $1\n    AND status = $2\n",
   "describe": {
     "columns": [
       {
@@ -25,23 +25,27 @@
       },
       {
         "ordinal": 4,
-        "name": "parent",
+        "name": "status: BuildStatus",
         "type_info": "Text"
       },
       {
         "ordinal": 5,
-        "name": "status: BuildStatus",
+        "name": "parent",
         "type_info": "Text"
       },
       {
         "ordinal": 6,
         "name": "created_at: DateTime<Utc>",
         "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
+        "name": "check_run_id",
+        "type_info": "Int8"
       }
     ],
     "parameters": {
       "Left": [
-        "Text",
         "Text",
         "Text"
       ]
@@ -53,8 +57,9 @@
       false,
       false,
       false,
-      false
+      false,
+      true
     ]
   },
-  "hash": "1a744cce3bc5cf50c0eb8d78100281153c6755c7a667690c2dc80e5f3d5cb0ce"
+  "hash": "02da9f6b50aedf8ccca20aa166c04e7406180ec882d79a0c5d5961779894a6f0"
 }

--- a/.sqlx/query-1b2604805b896aead48b3f56ddefbe045ade285f5886ee3b0291c403293ad236.json
+++ b/.sqlx/query-1b2604805b896aead48b3f56ddefbe045ade285f5886ee3b0291c403293ad236.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\nSELECT\n    workflow.id,\n    workflow.name,\n    workflow.url,\n    workflow.run_id,\n    workflow.type as \"workflow_type: WorkflowType\",\n    workflow.status as \"status: WorkflowStatus\",\n    workflow.created_at as \"created_at: DateTime<Utc>\",\n    (\n        build.id,\n        build.repository,\n        build.branch,\n        build.commit_sha,\n        build.status,\n        build.parent,\n        build.created_at\n    ) AS \"build!: BuildModel\"\nFROM workflow\n    LEFT JOIN build ON workflow.build_id = build.id\nWHERE build.id = $1\n",
+  "query": "\nSELECT\n    workflow.id,\n    workflow.name,\n    workflow.url,\n    workflow.run_id,\n    workflow.type as \"workflow_type: WorkflowType\",\n    workflow.status as \"status: WorkflowStatus\",\n    workflow.created_at as \"created_at: DateTime<Utc>\",\n    (\n        build.id,\n        build.repository,\n        build.branch,\n        build.commit_sha,\n        build.status,\n        build.parent,\n        build.created_at,\n        build.check_run_id\n    ) AS \"build!: BuildModel\"\nFROM workflow\n    LEFT JOIN build ON workflow.build_id = build.id\nWHERE build.id = $1\n",
   "describe": {
     "columns": [
       {
@@ -60,5 +60,5 @@
       null
     ]
   },
-  "hash": "9f5c42d04e14181378569c3c0bc05ad524575cb38c10cee918e443b097c8d04f"
+  "hash": "1b2604805b896aead48b3f56ddefbe045ade285f5886ee3b0291c403293ad236"
 }

--- a/.sqlx/query-3107d965f4602e40a60f856dda74ed7cc57f40071bad913011db294e90d6859b.json
+++ b/.sqlx/query-3107d965f4602e40a60f856dda74ed7cc57f40071bad913011db294e90d6859b.json
@@ -108,6 +108,10 @@
                 [
                   "created_at",
                   "Timestamptz"
+                ],
+                [
+                  "check_run_id",
+                  "Int8"
                 ]
               ]
             }
@@ -149,6 +153,10 @@
                 [
                   "created_at",
                   "Timestamptz"
+                ],
+                [
+                  "check_run_id",
+                  "Int8"
                 ]
               ]
             }

--- a/.sqlx/query-33cf1b803a0b658f197ab26d87e2c6c4fe42128cb481a234372626f35392e809.json
+++ b/.sqlx/query-33cf1b803a0b658f197ab26d87e2c6c4fe42128cb481a234372626f35392e809.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE build SET check_run_id = $1 WHERE id = $2",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "33cf1b803a0b658f197ab26d87e2c6c4fe42128cb481a234372626f35392e809"
+}

--- a/.sqlx/query-35e097f1dd2bcfe944c09c789426aa5716b90dc1b91de17629b158dd36eee7d9.json
+++ b/.sqlx/query-35e097f1dd2bcfe944c09c789426aa5716b90dc1b91de17629b158dd36eee7d9.json
@@ -108,6 +108,10 @@
                 [
                   "created_at",
                   "Timestamptz"
+                ],
+                [
+                  "check_run_id",
+                  "Int8"
                 ]
               ]
             }
@@ -149,6 +153,10 @@
                 [
                   "created_at",
                   "Timestamptz"
+                ],
+                [
+                  "check_run_id",
+                  "Int8"
                 ]
               ]
             }

--- a/.sqlx/query-367bf2de86a8a92b56b2be296cef119a7835ab5fd09326265a4a1403d0d6ad19.json
+++ b/.sqlx/query-367bf2de86a8a92b56b2be296cef119a7835ab5fd09326265a4a1403d0d6ad19.json
@@ -108,6 +108,10 @@
                 [
                   "created_at",
                   "Timestamptz"
+                ],
+                [
+                  "check_run_id",
+                  "Int8"
                 ]
               ]
             }
@@ -149,6 +153,10 @@
                 [
                   "created_at",
                   "Timestamptz"
+                ],
+                [
+                  "check_run_id",
+                  "Int8"
                 ]
               ]
             }

--- a/.sqlx/query-483efa3070e78c109d493533ca114433d1228427b35742760521487a9bc0be51.json
+++ b/.sqlx/query-483efa3070e78c109d493533ca114433d1228427b35742760521487a9bc0be51.json
@@ -108,6 +108,10 @@
                 [
                   "created_at",
                   "Timestamptz"
+                ],
+                [
+                  "check_run_id",
+                  "Int8"
                 ]
               ]
             }
@@ -149,6 +153,10 @@
                 [
                   "created_at",
                   "Timestamptz"
+                ],
+                [
+                  "check_run_id",
+                  "Int8"
                 ]
               ]
             }

--- a/.sqlx/query-62763d313a8278147d0f6fea3dd3d945e77bbdcf50e3fcfba029f24ce7481618.json
+++ b/.sqlx/query-62763d313a8278147d0f6fea3dd3d945e77bbdcf50e3fcfba029f24ce7481618.json
@@ -108,6 +108,10 @@
                 [
                   "created_at",
                   "Timestamptz"
+                ],
+                [
+                  "check_run_id",
+                  "Int8"
                 ]
               ]
             }
@@ -149,6 +153,10 @@
                 [
                   "created_at",
                   "Timestamptz"
+                ],
+                [
+                  "check_run_id",
+                  "Int8"
                 ]
               ]
             }

--- a/.sqlx/query-7c02e94615e2ac8d8ea1d45b7b21a3dc29b884f514131df60aeb63569568e82f.json
+++ b/.sqlx/query-7c02e94615e2ac8d8ea1d45b7b21a3dc29b884f514131df60aeb63569568e82f.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\nSELECT\n    workflow.id,\n    workflow.name,\n    workflow.url,\n    workflow.run_id,\n    workflow.type as \"workflow_type: WorkflowType\",\n    workflow.status as \"status: WorkflowStatus\",\n    workflow.created_at as \"created_at: DateTime<Utc>\",\n    (\n        build.id,\n        build.repository,\n        build.branch,\n        build.commit_sha,\n        build.status,\n        build.parent,\n        build.created_at\n    ) AS \"build!: BuildModel\"\nFROM workflow\n    LEFT JOIN build ON workflow.build_id = build.id\n",
+  "query": "\nSELECT\n    workflow.id,\n    workflow.name,\n    workflow.url,\n    workflow.run_id,\n    workflow.type as \"workflow_type: WorkflowType\",\n    workflow.status as \"status: WorkflowStatus\",\n    workflow.created_at as \"created_at: DateTime<Utc>\",\n    (\n        build.id,\n        build.repository,\n        build.branch,\n        build.commit_sha,\n        build.status,\n        build.parent,\n        build.created_at,\n        build.check_run_id\n    ) AS \"build!: BuildModel\"\nFROM workflow\n    LEFT JOIN build ON workflow.build_id = build.id\n",
   "describe": {
     "columns": [
       {
@@ -58,5 +58,5 @@
       null
     ]
   },
-  "hash": "4ba899ceb5200a74b944f26b4df293d6eaeb7c10e4a9d594b003f04a7f493dc1"
+  "hash": "7c02e94615e2ac8d8ea1d45b7b21a3dc29b884f514131df60aeb63569568e82f"
 }

--- a/.sqlx/query-92a82f32ea1f0ae952e7f0a116b473893358292541fd507ebd381138901ae48a.json
+++ b/.sqlx/query-92a82f32ea1f0ae952e7f0a116b473893358292541fd507ebd381138901ae48a.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\nSELECT\n    id,\n    repository as \"repository: GithubRepoName\",\n    branch,\n    commit_sha,\n    parent,\n    status as \"status: BuildStatus\",\n    created_at as \"created_at: DateTime<Utc>\"\nFROM build\nWHERE repository = $1\n    AND status = $2\n",
+  "query": "\nSELECT\n    id,\n    repository as \"repository: GithubRepoName\",\n    branch,\n    commit_sha,\n    status as \"status: BuildStatus\",\n    parent,\n    created_at as \"created_at: DateTime<Utc>\",\n    check_run_id\nFROM build\nWHERE repository = $1\n    AND branch = $2\n    AND commit_sha = $3\n",
   "describe": {
     "columns": [
       {
@@ -25,22 +25,28 @@
       },
       {
         "ordinal": 4,
-        "name": "parent",
+        "name": "status: BuildStatus",
         "type_info": "Text"
       },
       {
         "ordinal": 5,
-        "name": "status: BuildStatus",
+        "name": "parent",
         "type_info": "Text"
       },
       {
         "ordinal": 6,
         "name": "created_at: DateTime<Utc>",
         "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
+        "name": "check_run_id",
+        "type_info": "Int8"
       }
     ],
     "parameters": {
       "Left": [
+        "Text",
         "Text",
         "Text"
       ]
@@ -52,8 +58,9 @@
       false,
       false,
       false,
-      false
+      false,
+      true
     ]
   },
-  "hash": "34ecdfb5ba37fecb10fdf805f2a372e22382c4aa4ec78ba631373416108387ee"
+  "hash": "92a82f32ea1f0ae952e7f0a116b473893358292541fd507ebd381138901ae48a"
 }

--- a/.sqlx/query-a146064228559bca97e795319590ddeb83e3a97562c6330fe72375bfc3cadfd3.json
+++ b/.sqlx/query-a146064228559bca97e795319590ddeb83e3a97562c6330fe72375bfc3cadfd3.json
@@ -108,6 +108,10 @@
                 [
                   "created_at",
                   "Timestamptz"
+                ],
+                [
+                  "check_run_id",
+                  "Int8"
                 ]
               ]
             }
@@ -149,6 +153,10 @@
                 [
                   "created_at",
                   "Timestamptz"
+                ],
+                [
+                  "check_run_id",
+                  "Int8"
                 ]
               ]
             }

--- a/migrations/20250702100259_add_check_run_id_to_build.down.sql
+++ b/migrations/20250702100259_add_check_run_id_to_build.down.sql
@@ -1,0 +1,2 @@
+-- Add down migration script here
+ALTER TABLE build DROP COLUMN check_run_id;

--- a/migrations/20250702100259_add_check_run_id_to_build.up.sql
+++ b/migrations/20250702100259_add_check_run_id_to_build.up.sql
@@ -1,0 +1,2 @@
+-- Add up migration script here
+ALTER TABLE build ADD COLUMN check_run_id BIGINT;

--- a/src/bors/handlers/refresh.rs
+++ b/src/bors/handlers/refresh.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 
 use anyhow::Context;
 use chrono::{DateTime, Utc};
+use octocrab::params::checks::{CheckRunConclusion, CheckRunStatus};
 use std::collections::BTreeMap;
 
 use crate::bors::Comment;
@@ -28,6 +29,22 @@ pub async fn cancel_timed_out_builds(
 
             db.update_build_status(&build, BuildStatus::Cancelled)
                 .await?;
+
+            if let Some(check_run_id) = build.check_run_id {
+                if let Err(error) = repo
+                    .client
+                    .update_check_run(
+                        check_run_id as u64,
+                        CheckRunStatus::Completed,
+                        Some(CheckRunConclusion::TimedOut),
+                        None,
+                    )
+                    .await
+                {
+                    tracing::error!("Could not update check run {check_run_id}: {error:?}");
+                }
+            }
+
             if let Some(pr) = db.find_pr_by_build(&build).await? {
                 if let Err(error) = cancel_build_workflows(&repo.client, db, &build).await {
                     tracing::error!(
@@ -181,11 +198,13 @@ fn elapsed_time(date: DateTime<Utc>) -> Duration {
 mod tests {
     use crate::bors::PullRequestStatus;
     use crate::bors::handlers::refresh::MOCK_TIME;
+    use crate::bors::handlers::trybuild::TRY_BUILD_CHECK_RUN_NAME;
     use crate::database::{MergeableState, OctocrabMergeableState};
     use crate::tests::mocks::{
         BorsBuilder, GitHubState, default_pr_number, default_repo_name, run_test,
     };
     use chrono::Utc;
+    use octocrab::params::checks::{CheckRunConclusion, CheckRunStatus};
     use std::future::Future;
     use std::time::Duration;
     use tokio::runtime::RuntimeFlavor;
@@ -262,6 +281,33 @@ timeout = 3600
                         .len(),
                     0
                 );
+                Ok(tester)
+            })
+            .await;
+    }
+
+    #[sqlx::test]
+    async fn refresh_cancel_build_updates_check_run(pool: sqlx::PgPool) {
+        BorsBuilder::new(pool)
+            .github(gh_state_with_long_timeout())
+            .run_test(|mut tester| async move {
+                tester.post_comment("@bors try").await?;
+                tester.expect_comments(1).await;
+
+                with_mocked_time(Duration::from_secs(4000), async {
+                    tester.cancel_timed_out_builds().await;
+                })
+                .await;
+                tester.expect_comments(1).await;
+
+                tester.expect_check_run(
+                    &tester.default_pr().await.get_gh_pr().head_sha,
+                    TRY_BUILD_CHECK_RUN_NAME,
+                    "Bors try build",
+                    CheckRunStatus::Completed,
+                    Some(CheckRunConclusion::TimedOut),
+                );
+
                 Ok(tester)
             })
             .await;

--- a/src/bors/handlers/trybuild.rs
+++ b/src/bors/handlers/trybuild.rs
@@ -36,7 +36,7 @@ pub(super) const TRY_MERGE_BRANCH_NAME: &str = "automation/bors/try-merge";
 pub(super) const TRY_BRANCH_NAME: &str = "automation/bors/try";
 
 // The name of the check run seen in the GitHub UI.
-const TRY_BUILD_CHECK_RUN_NAME: &str = "Bors try build";
+pub(super) const TRY_BUILD_CHECK_RUN_NAME: &str = "Bors try build";
 
 /// Performs a so-called try build - merges the PR branch into a special branch designed
 /// for running CI checks.
@@ -909,10 +909,6 @@ try_failed = ["+foo", "+bar", "-baz"]
                 CheckRunStatus::InProgress,
                 None,
             );
-
-            let check_run = tester.get_check_run().await?;
-            insta::assert_snapshot!(check_run.summary, @"");
-            insta::assert_snapshot!(check_run.text, @"");
 
             Ok(tester)
         })

--- a/src/database/client.rs
+++ b/src/database/client.rs
@@ -15,9 +15,9 @@ use super::operations::{
     get_prs_with_unknown_mergeable_state, get_pull_request, get_repository, get_repository_by_name,
     get_running_builds, get_workflow_urls_for_build, get_workflows_for_build,
     insert_repo_if_not_exists, set_pr_assignees, set_pr_priority, set_pr_rollup, set_pr_status,
-    unapprove_pull_request, undelegate_pull_request, update_build_status,
-    update_mergeable_states_by_base_branch, update_pr_mergeable_state, update_pr_try_build_id,
-    update_workflow_status, upsert_pull_request, upsert_repository,
+    unapprove_pull_request, undelegate_pull_request, update_build_check_run_id,
+    update_build_status, update_mergeable_states_by_base_branch, update_pr_mergeable_state,
+    update_pr_try_build_id, update_workflow_status, upsert_pull_request, upsert_repository,
 };
 use super::{ApprovalInfo, DelegatedPermission, MergeableState, RunId, UpsertPullRequestParams};
 
@@ -181,13 +181,13 @@ impl PgDbClient {
         branch: String,
         commit_sha: CommitSha,
         parent: CommitSha,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<i32> {
         let mut tx = self.pool.begin().await?;
         let build_id =
             create_build(&mut *tx, &pr.repository, &branch, &commit_sha, &parent).await?;
         update_pr_try_build_id(&mut *tx, pr.id, build_id).await?;
         tx.commit().await?;
-        Ok(())
+        Ok(build_id)
     }
 
     pub async fn find_build(
@@ -212,6 +212,14 @@ impl PgDbClient {
         status: BuildStatus,
     ) -> anyhow::Result<()> {
         update_build_status(&self.pool, build.id, status).await
+    }
+
+    pub async fn update_build_check_run_id(
+        &self,
+        build_id: i32,
+        check_run_id: i64,
+    ) -> anyhow::Result<()> {
+        update_build_check_run_id(&self.pool, build_id, check_run_id).await
     }
 
     pub async fn create_workflow(

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -315,6 +315,7 @@ pub struct BuildModel {
     /// The base commit SHA that this build is merged with (e.g., main branch HEAD).
     pub parent: String,
     pub created_at: DateTime<Utc>,
+    /// The ID of the check run associated with the build.
     pub check_run_id: Option<i64>,
 }
 

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -315,6 +315,7 @@ pub struct BuildModel {
     /// The base commit SHA that this build is merged with (e.g., main branch HEAD).
     pub parent: String,
     pub created_at: DateTime<Utc>,
+    pub check_run_id: Option<i64>,
 }
 
 /// Represents a pull request.

--- a/src/database/operations.rs
+++ b/src/database/operations.rs
@@ -946,6 +946,24 @@ pub(crate) async fn upsert_repository(
     .await
 }
 
+pub(crate) async fn update_build_check_run_id(
+    executor: impl PgExecutor<'_>,
+    build_id: i32,
+    check_run_id: i64,
+) -> anyhow::Result<()> {
+    measure_db_query("update_build_check_run_id", || async {
+        sqlx::query!(
+            "UPDATE build SET check_run_id = $1 WHERE id = $2",
+            check_run_id,
+            build_id
+        )
+        .execute(executor)
+        .await?;
+        Ok(())
+    })
+    .await
+}
+
 /// Removes the auto build associated with a PR and deletes the build record (if one exists).
 pub(crate) async fn delete_auto_build(
     executor: impl PgExecutor<'_>,

--- a/src/database/operations.rs
+++ b/src/database/operations.rs
@@ -557,9 +557,10 @@ SELECT
     repository as "repository: GithubRepoName",
     branch,
     commit_sha,
-    parent,
     status as "status: BuildStatus",
-    created_at as "created_at: DateTime<Utc>"
+    parent,
+    created_at as "created_at: DateTime<Utc>",
+    check_run_id
 FROM build
 WHERE repository = $1
     AND branch = $2
@@ -589,9 +590,10 @@ SELECT
     repository as "repository: GithubRepoName",
     branch,
     commit_sha,
-    parent,
     status as "status: BuildStatus",
-    created_at as "created_at: DateTime<Utc>"
+    parent,
+    created_at as "created_at: DateTime<Utc>",
+    check_run_id
 FROM build
 WHERE repository = $1
     AND status = $2
@@ -750,7 +752,8 @@ SELECT
         build.commit_sha,
         build.status,
         build.parent,
-        build.created_at
+        build.created_at,
+        build.check_run_id
     ) AS "build!: BuildModel"
 FROM workflow
     LEFT JOIN build ON workflow.build_id = build.id
@@ -809,7 +812,8 @@ SELECT
         build.commit_sha,
         build.status,
         build.parent,
-        build.created_at
+        build.created_at,
+        build.check_run_id
     ) AS "build!: BuildModel"
 FROM workflow
     LEFT JOIN build ON workflow.build_id = build.id

--- a/src/tests/mocks/bors.rs
+++ b/src/tests/mocks/bors.rs
@@ -26,7 +26,6 @@ use crate::github::api::load_repositories;
 use crate::github::server::BorsProcess;
 use crate::github::{GithubRepoName, PullRequestNumber};
 use crate::tests::mocks::comment::{Comment, GitHubIssueCommentEventPayload};
-use crate::tests::mocks::repository;
 use crate::tests::mocks::workflow::{
     CheckSuite, GitHubCheckRunEventPayload, GitHubCheckSuiteEventPayload,
     GitHubWorkflowEventPayload, TestWorkflowStatus, Workflow, WorkflowEvent, WorkflowEventKind,
@@ -272,17 +271,6 @@ impl BorsTester {
 
     pub fn try_branch(&self) -> Branch {
         self.get_branch("automation/bors/try")
-    }
-
-    /// Get the latest check run.
-    pub async fn get_check_run(&mut self) -> anyhow::Result<repository::CheckRunData> {
-        Ok(self
-            .default_repo()
-            .lock()
-            .check_runs
-            .last()
-            .unwrap()
-            .clone())
     }
 
     /// Wait until the next bot comment is received on the default repo and the default PR.

--- a/src/tests/mocks/bors.rs
+++ b/src/tests/mocks/bors.rs
@@ -26,10 +26,12 @@ use crate::github::api::load_repositories;
 use crate::github::server::BorsProcess;
 use crate::github::{GithubRepoName, PullRequestNumber};
 use crate::tests::mocks::comment::{Comment, GitHubIssueCommentEventPayload};
+use crate::tests::mocks::repository;
 use crate::tests::mocks::workflow::{
     CheckSuite, GitHubCheckRunEventPayload, GitHubCheckSuiteEventPayload,
     GitHubWorkflowEventPayload, TestWorkflowStatus, Workflow, WorkflowEvent, WorkflowEventKind,
 };
+use octocrab::params::checks::{CheckRunConclusion, CheckRunStatus};
 
 pub fn default_cmd_prefix() -> String {
     "@bors".to_string()
@@ -270,6 +272,17 @@ impl BorsTester {
 
     pub fn try_branch(&self) -> Branch {
         self.get_branch("automation/bors/try")
+    }
+
+    /// Get the latest check run.
+    pub async fn get_check_run(&mut self) -> anyhow::Result<repository::CheckRunData> {
+        Ok(self
+            .default_repo()
+            .lock()
+            .check_runs
+            .last()
+            .unwrap()
+            .clone())
     }
 
     /// Wait until the next bot comment is received on the default repo and the default PR.
@@ -655,6 +668,64 @@ impl BorsTester {
                 .await
                 .unwrap_or_else(|_| panic!("Failed to get comment #{i}"));
         }
+    }
+
+    #[track_caller]
+    pub fn expect_check_run(
+        &self,
+        head_sha: &str,
+        name: &str,
+        title: &str,
+        status: CheckRunStatus,
+        conclusion: Option<CheckRunConclusion>,
+    ) -> &Self {
+        let repo = self.default_repo();
+        let repo = repo.lock();
+        let check_runs: Vec<_> = repo
+            .check_runs
+            .iter()
+            .filter(|check_run| check_run.head_sha == head_sha)
+            .collect();
+
+        assert_eq!(check_runs.len(), 1);
+
+        let check_run = check_runs[0];
+        let expected_status = match status {
+            CheckRunStatus::Queued => "queued",
+            CheckRunStatus::InProgress => "in_progress",
+            CheckRunStatus::Completed => "completed",
+        };
+        let expected_conclusion = conclusion.map(|c| match c {
+            CheckRunConclusion::Success => "success",
+            CheckRunConclusion::Failure => "failure",
+            CheckRunConclusion::Neutral => "neutral",
+            CheckRunConclusion::Cancelled => "cancelled",
+            CheckRunConclusion::TimedOut => "timed_out",
+            CheckRunConclusion::ActionRequired => "action_required",
+            CheckRunConclusion::Stale => "stale",
+            CheckRunConclusion::Skipped => "skipped",
+        });
+
+        assert_eq!(
+            (
+                check_run.name.as_str(),
+                check_run.head_sha.as_str(),
+                check_run.status.as_str(),
+                check_run.title.as_str(),
+                check_run.conclusion.as_deref(),
+                check_run.external_id.parse::<u64>().is_ok()
+            ),
+            (
+                name,
+                head_sha,
+                expected_status,
+                title,
+                expected_conclusion,
+                true
+            )
+        );
+
+        self
     }
 
     /// Wait until the given condition is true.

--- a/tests/data/migrations/20250702100259_add_check_run_id_to_build.sql
+++ b/tests/data/migrations/20250702100259_add_check_run_id_to_build.sql
@@ -1,0 +1,17 @@
+UPDATE build
+SET
+    check_run_id = 1234567890
+WHERE
+    id = 1;
+
+UPDATE build
+SET
+    check_run_id = 2345678901
+WHERE
+    id = 2;
+
+UPDATE build
+SET
+    check_run_id = 3456789012
+WHERE
+    id = 3;


### PR DESCRIPTION
Fixes half of #322 

This PR adds the dots and a title: "Bors try build". No detail or text is added to the check run UI. 

The check run is added to the PR head and starts off in pending -> error / success. 

Success: https://github.com/Sakib25800/rust/pull/424
Fail: https://github.com/Sakib25800/rust/pull/425

Before merging the try build we could also set `CheckRunStatus` to `CheckRunStatus::Queued` but I think the window is so small it's not worth adding and no one is going to notice. 