### PR TITLE
ci: trigger production deployment manually

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,45 @@
+name: Deploy production
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy-to-production:
+    name: Deploy to production
+    runs-on: ubuntu-latest
+    environment: production
+    concurrency: production
+    if: github.repository_owner == 'rust-lang'
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::351621253146:role/gha-access
+          aws-region: us-east-2
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - uses: docker/setup-buildx-action@v3
+      - name: Build and tag the Docker image
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REPOSITORY: bors
+          IMAGE_TAG: latest
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          tags: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.IMAGE_TAG }}
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Kick ECS to deploy new version
+        run: aws ecs update-service --service bors --cluster bors --force-new-deployment

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,11 +1,9 @@
-name: Deploy
+name: Deploy staging
 
 on:
   push:
     branches:
       - main
-
-concurrency: deploy
 
 jobs:
   deploy-to-staging:
@@ -25,45 +23,6 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::392478027976:role/gha-access
-          aws-region: us-east-2
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-
-      - uses: docker/setup-buildx-action@v3
-      - name: Build and tag the Docker image
-        env:
-          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          REPOSITORY: bors
-          IMAGE_TAG: latest
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          tags: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.IMAGE_TAG }}
-          push: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Kick ECS to deploy new version
-        run: aws ecs update-service --service bors --cluster bors --force-new-deployment
-  deploy-to-production:
-    name: Deploy to production
-    runs-on: ubuntu-latest
-    environment: production
-    concurrency: production
-    if: github.repository_owner == 'rust-lang'
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::351621253146:role/gha-access
           aws-region: us-east-2
 
       - name: Login to Amazon ECR


### PR DESCRIPTION
Change prod deployments to not being triggered automatically anymore.
Deployments can be manually requested on demand.
We have Deployments reviews setup, so another member of the bors team or an infra-admin can approve the deployment.

This also prevents people from self-approving deployments because the workflow_dispatch is triggered from the user, not from the github actions bot. See [#t-infra > Migrating bors try to new bors @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/Migrating.20bors.20try.20to.20new.20bors/near/528520590)