### PR TITLE
Refactor test suite to handle timeouts in a more robust way

### DIFF
--- a/src/bors/handlers/help.rs
+++ b/src/bors/handlers/help.rs
@@ -83,7 +83,7 @@ mod tests {
 
     #[sqlx::test]
     async fn help_command(pool: sqlx::PgPool) {
-        run_test(pool, |mut tester| async {
+        run_test(pool, async |tester| {
             tester.post_comment("@bors help").await?;
             insta::assert_snapshot!(tester.get_comment().await?, @r"
             You can use the following commands:
@@ -119,7 +119,7 @@ mod tests {
             - `ping`: Check if the bot is alive
             - `help`: Print this help message
             ");
-            Ok(tester)
+            Ok(())
         })
         .await;
     }

--- a/src/bors/handlers/info.rs
+++ b/src/bors/handlers/info.rs
@@ -64,7 +64,7 @@ mod tests {
 
     #[sqlx::test]
     async fn info_for_unapproved_pr(pool: sqlx::PgPool) {
-        run_test(pool, |mut tester| async {
+        run_test(pool, async |tester| {
             tester.post_comment("@bors info").await?;
             insta::assert_snapshot!(
                 tester.get_comment().await?,
@@ -75,14 +75,14 @@ mod tests {
             - Mergeable: yes
             "
             );
-            Ok(tester)
+            Ok(())
         })
         .await;
     }
 
     #[sqlx::test]
     async fn info_for_approved_pr(pool: sqlx::PgPool) {
-        run_test(pool, |mut tester| async {
+        run_test(pool, async |tester| {
             tester.post_comment("@bors r+").await?;
             tester.expect_comments(1).await;
 
@@ -96,14 +96,14 @@ mod tests {
             - Mergeable: yes
             "
             );
-            Ok(tester)
+            Ok(())
         })
         .await;
     }
 
     #[sqlx::test]
     async fn info_for_pr_with_priority(pool: sqlx::PgPool) {
-        run_test(pool, |mut tester| async {
+        run_test(pool, async |tester| {
             tester.post_comment("@bors p=5").await?;
             tester
                 .wait_for_default_pr(|pr| pr.priority == Some(5))
@@ -119,14 +119,14 @@ mod tests {
             - Mergeable: yes
             "
             );
-            Ok(tester)
+            Ok(())
         })
         .await;
     }
 
     #[sqlx::test]
     async fn info_for_pr_with_try_build(pool: sqlx::PgPool) {
-        run_test(pool, |mut tester| async {
+        run_test(pool, async |tester| {
             tester.post_comment("@bors try").await?;
             tester.expect_comments(1).await;
 
@@ -141,14 +141,14 @@ mod tests {
             - Try build is in progress
             "
             );
-            Ok(tester)
+            Ok(())
         })
         .await;
     }
 
     #[sqlx::test]
     async fn info_for_pr_with_everything(pool: sqlx::PgPool) {
-        run_test(pool, |mut tester| async {
+        run_test(pool, async |tester| {
             tester.post_comment("@bors r+ p=10").await?;
             tester.expect_comments(1).await;
 
@@ -171,7 +171,7 @@ mod tests {
             	- Workflow URL: https://github.com/workflows/Workflow1/1
             "
             );
-            Ok(tester)
+            Ok(())
         })
         .await;
     }

--- a/src/bors/handlers/mod.rs
+++ b/src/bors/handlers/mod.rs
@@ -636,32 +636,32 @@ mod tests {
 
     #[sqlx::test]
     async fn ignore_bot_comment(pool: sqlx::PgPool) {
-        run_test(pool, |mut tester| async {
+        run_test(pool, async |tester| {
             tester
                 .post_comment(Comment::from("@bors ping").with_author(User::bors_bot()))
                 .await?;
             // Returning here will make sure that no comments were received
-            Ok(tester)
+            Ok(())
         })
         .await;
     }
 
     #[sqlx::test]
     async fn do_not_load_pr_on_unrelated_comment(pool: sqlx::PgPool) {
-        run_test(pool, |mut tester| async {
+        run_test(pool, async |tester| {
             tester.default_repo().lock().pull_request_error = true;
             tester.post_comment("no command").await?;
-            Ok(tester)
+            Ok(())
         })
         .await;
     }
 
     #[sqlx::test]
     async fn unknown_command(pool: sqlx::PgPool) {
-        run_test(pool, |mut tester| async {
+        run_test(pool, async |tester| {
             tester.post_comment(Comment::from("@bors foo")).await?;
             insta::assert_snapshot!(tester.get_comment().await?, @r#"Unknown command "foo". Run `@bors help` to see available commands."#);
-            Ok(tester)
+            Ok(())
         })
         .await;
     }

--- a/src/bors/handlers/ping.rs
+++ b/src/bors/handlers/ping.rs
@@ -20,10 +20,10 @@ mod tests {
 
     #[sqlx::test]
     async fn ping_command(pool: sqlx::PgPool) {
-        run_test(pool, |mut tester| async {
+        run_test(pool, async |tester| {
             tester.post_comment("@bors ping").await?;
             assert_eq!(tester.get_comment().await?, "Pong 🏓!");
-            Ok(tester)
+            Ok(())
         })
         .await;
     }

--- a/src/bors/handlers/pr_events.rs
+++ b/src/bors/handlers/pr_events.rs
@@ -343,7 +343,7 @@ mod tests {
 
     #[sqlx::test]
     async fn unapprove_on_base_edited(pool: sqlx::PgPool) {
-        run_test(pool, |mut tester| async {
+        run_test(pool, async |tester| {
             tester.post_comment("@bors r+").await?;
             tester.expect_comments(1).await;
             let branch = tester.create_branch("beta").clone();
@@ -361,14 +361,14 @@ mod tests {
             "
             );
             tester.default_pr().await.expect_unapproved();
-            Ok(tester)
+            Ok(())
         })
         .await;
     }
 
     #[sqlx::test]
     async fn edit_pr_do_nothing_when_base_not_edited(pool: sqlx::PgPool) {
-        run_test(pool, |mut tester| async {
+        run_test(pool, async |tester| {
             tester.post_comment("@bors r+").await?;
             tester.expect_comments(1).await;
             tester
@@ -379,14 +379,14 @@ mod tests {
                 .default_pr()
                 .await
                 .expect_approved_by(&User::default_pr_author().name);
-            Ok(tester)
+            Ok(())
         })
         .await;
     }
 
     #[sqlx::test]
     async fn edit_pr_do_nothing_when_not_approved(pool: sqlx::PgPool) {
-        run_test(pool, |mut tester| async {
+        run_test(pool, async |tester| {
             let branch = tester.create_branch("beta").clone();
             tester
                 .edit_pr(default_repo_name(), default_pr_number(), |pr| {
@@ -395,14 +395,14 @@ mod tests {
                 .await?;
 
             // No comment should be posted
-            Ok(tester)
+            Ok(())
         })
         .await;
     }
 
     #[sqlx::test]
     async fn unapprove_on_push(pool: sqlx::PgPool) {
-        run_test(pool, |mut tester| async {
+        run_test(pool, async |tester| {
             tester.post_comment("@bors r+").await?;
             tester.expect_comments(1).await;
             tester
@@ -417,27 +417,27 @@ mod tests {
             "
             );
             tester.default_pr().await.expect_unapproved();
-            Ok(tester)
+            Ok(())
         })
         .await;
     }
 
     #[sqlx::test]
     async fn push_to_pr_do_nothing_when_not_approved(pool: sqlx::PgPool) {
-        run_test(pool, |mut tester| async {
+        run_test(pool, async |tester| {
             tester
                 .push_to_pr(default_repo_name(), default_pr_number())
                 .await?;
 
             // No comment should be posted
-            Ok(tester)
+            Ok(())
         })
         .await;
     }
 
     #[sqlx::test]
     async fn store_base_branch_on_pr_opened(pool: sqlx::PgPool) {
-        run_test(pool, |mut tester| async {
+        run_test(pool, async |tester| {
             let pr = tester.open_pr(default_repo_name(), false).await?;
             tester
                 .wait_for_pr(default_repo_name(), pr.number.0, |pr| {
@@ -445,14 +445,14 @@ mod tests {
                         && pr.pr_status == PullRequestStatus::Open
                 })
                 .await?;
-            Ok(tester)
+            Ok(())
         })
         .await;
     }
 
     #[sqlx::test]
     async fn update_base_branch_on_pr_edited(pool: sqlx::PgPool) {
-        run_test(pool.clone(), |mut tester| async {
+        run_test(pool, async |tester| {
             let branch = tester.create_branch("foo").clone();
             tester
                 .edit_pr(default_repo_name(), default_pr_number(), |pr| {
@@ -464,14 +464,14 @@ mod tests {
                     pr.base_branch == "foo"
                 })
                 .await?;
-            Ok(tester)
+            Ok(())
         })
         .await;
     }
 
     #[sqlx::test]
     async fn update_mergeable_state_on_pr_edited(pool: sqlx::PgPool) {
-        run_test(pool.clone(), |mut tester| async {
+        run_test(pool, async |tester| {
             tester
                 .edit_pr(default_repo_name(), default_pr_number(), |pr| {
                     pr.mergeable_state = OctocrabMergeableState::Dirty;
@@ -480,14 +480,14 @@ mod tests {
             tester
                 .wait_for_default_pr(|pr| pr.mergeable_state == MergeableState::HasConflicts)
                 .await?;
-            Ok(tester)
+            Ok(())
         })
         .await;
     }
 
     #[sqlx::test]
     async fn open_close_and_reopen_pr(pool: sqlx::PgPool) {
-        run_test(pool, |mut tester| async {
+        run_test(pool, async |tester| {
             let pr = tester.open_pr(default_repo_name(), false).await?;
             tester
                 .wait_for_pr(default_repo_name(), pr.number.0, |pr| {
@@ -508,14 +508,14 @@ mod tests {
                     pr.pr_status == PullRequestStatus::Open
                 })
                 .await?;
-            Ok(tester)
+            Ok(())
         })
         .await;
     }
 
     #[sqlx::test]
     async fn open_draft_pr_and_convert_to_ready_for_review(pool: sqlx::PgPool) {
-        run_test(pool, |mut tester| async {
+        run_test(pool, async |tester| {
             let pr = tester.open_pr(default_repo_name(), true).await?;
             tester
                 .wait_for_pr(default_repo_name(), pr.number.0, |pr| {
@@ -530,14 +530,14 @@ mod tests {
                     pr.pr_status == PullRequestStatus::Open
                 })
                 .await?;
-            Ok(tester)
+            Ok(())
         })
         .await;
     }
 
     #[sqlx::test]
     async fn open_pr_and_convert_to_draft(pool: sqlx::PgPool) {
-        run_test(pool, |mut tester| async {
+        run_test(pool, async |tester| {
             let pr = tester.open_pr(default_repo_name(), false).await?;
             tester
                 .wait_for_pr(default_repo_name(), pr.number.0, |pr| {
@@ -552,14 +552,14 @@ mod tests {
                     pr.pr_status == PullRequestStatus::Draft
                 })
                 .await?;
-            Ok(tester)
+            Ok(())
         })
         .await;
     }
 
     #[sqlx::test]
     async fn assign_pr_updates_assignees(pool: sqlx::PgPool) {
-        run_test(pool, |mut tester| async {
+        run_test(pool, async |tester| {
             let pr = tester.open_pr(default_repo_name(), false).await?;
             tester
                 .wait_for_pr(default_repo_name(), pr.number.0, |pr| {
@@ -574,14 +574,14 @@ mod tests {
                     pr.assignees == vec![User::reviewer().name]
                 })
                 .await?;
-            Ok(tester)
+            Ok(())
         })
         .await;
     }
 
     #[sqlx::test]
     async fn unassign_pr_updates_assignees(pool: sqlx::PgPool) {
-        run_test(pool, |mut tester| async {
+        run_test(pool, async |tester| {
             let pr = tester.open_pr(default_repo_name(), false).await?;
             tester
                 .assign_pr(default_repo_name(), pr.number.0, User::reviewer())
@@ -599,14 +599,14 @@ mod tests {
                     pr.assignees.is_empty()
                 })
                 .await?;
-            Ok(tester)
+            Ok(())
         })
         .await;
     }
 
     #[sqlx::test]
     async fn open_and_merge_pr(pool: sqlx::PgPool) {
-        run_test(pool, |mut tester| async {
+        run_test(pool, async |tester| {
             let pr = tester.open_pr(default_repo_name(), false).await?;
             tester
                 .wait_for_pr(default_repo_name(), pr.number.0, |pr| {
@@ -621,14 +621,14 @@ mod tests {
                     pr.pr_status == PullRequestStatus::Merged
                 })
                 .await?;
-            Ok(tester)
+            Ok(())
         })
         .await;
     }
 
     #[sqlx::test]
     async fn mergeable_queue_processes_pr_base_change(pool: sqlx::PgPool) {
-        run_test(pool, |mut tester| async {
+        run_test(pool, async |tester| {
             let branch = tester.create_branch("beta").clone();
             tester
                 .edit_pr(default_repo_name(), default_pr_number(), |pr| {
@@ -647,14 +647,14 @@ mod tests {
             tester
                 .wait_for_default_pr(|pr| pr.mergeable_state == MergeableState::HasConflicts)
                 .await?;
-            Ok(tester)
+            Ok(())
         })
         .await;
     }
 
     #[sqlx::test]
     async fn enqueue_prs_on_push_to_branch(pool: sqlx::PgPool) {
-        run_test(pool, |mut tester| async {
+        run_test(pool, async |tester| {
             tester.open_pr(default_repo_name(), false).await?;
             tester.push_to_branch(default_branch_name()).await?;
             tester
@@ -668,14 +668,14 @@ mod tests {
             tester
                 .wait_for_default_pr(|pr| pr.mergeable_state == MergeableState::HasConflicts)
                 .await?;
-            Ok(tester)
+            Ok(())
         })
         .await;
     }
 
     #[sqlx::test]
     async fn enqueue_prs_on_pr_opened(pool: sqlx::PgPool) {
-        run_test(pool, |mut tester| async {
+        run_test(pool, async |tester| {
             tester.open_pr(default_repo_name(), false).await?;
             tester
                 .wait_for_default_pr(|pr| pr.mergeable_state == MergeableState::Unknown)
@@ -688,14 +688,14 @@ mod tests {
             tester
                 .wait_for_default_pr(|pr| pr.mergeable_state == MergeableState::HasConflicts)
                 .await?;
-            Ok(tester)
+            Ok(())
         })
         .await;
     }
 
     #[sqlx::test]
     async fn enqueue_prs_on_pr_reopened(pool: sqlx::PgPool) {
-        run_test(pool, |mut tester| async {
+        run_test(pool, async |tester| {
             tester
                 .default_repo()
                 .lock()
@@ -715,14 +715,14 @@ mod tests {
             tester
                 .wait_for_default_pr(|pr| pr.mergeable_state == MergeableState::HasConflicts)
                 .await?;
-            Ok(tester)
+            Ok(())
         })
         .await;
     }
 
     #[sqlx::test]
     async fn enqueue_prs_on_push_to_pr(pool: sqlx::PgPool) {
-        run_test(pool, |mut tester| async {
+        run_test(pool, async |tester| {
             tester
                 .push_to_pr(default_repo_name(), default_pr_number())
                 .await?;
@@ -737,7 +737,7 @@ mod tests {
             tester
                 .wait_for_default_pr(|pr| pr.mergeable_state == MergeableState::HasConflicts)
                 .await?;
-            Ok(tester)
+            Ok(())
         })
         .await;
     }

--- a/src/bors/handlers/workflow.rs
+++ b/src/bors/handlers/workflow.rs
@@ -244,14 +244,14 @@ mod tests {
 
     #[sqlx::test]
     async fn workflow_started_unknown_build(pool: sqlx::PgPool) {
-        run_test(pool.clone(), |mut tester| async {
+        run_test(pool.clone(), async |tester| {
             tester
                 .workflow_event(WorkflowEvent::started(Branch::new(
                     "unknown",
                     "unknown-sha",
                 )))
                 .await?;
-            Ok(tester)
+            Ok(())
         })
         .await;
         assert_eq!(get_all_workflows(&pool).await.unwrap().len(), 0);
@@ -259,14 +259,14 @@ mod tests {
 
     #[sqlx::test]
     async fn workflow_completed_unknown_build(pool: sqlx::PgPool) {
-        run_test(pool.clone(), |mut tester| async {
+        run_test(pool.clone(), async |tester| {
             tester
                 .workflow_event(WorkflowEvent::success(Branch::new(
                     "unknown",
                     "unknown-sha",
                 )))
                 .await?;
-            Ok(tester)
+            Ok(())
         })
         .await;
         assert_eq!(get_all_workflows(&pool).await.unwrap().len(), 0);
@@ -274,13 +274,13 @@ mod tests {
 
     #[sqlx::test]
     async fn try_workflow_started(pool: sqlx::PgPool) {
-        run_test(pool.clone(), |mut tester| async {
+        run_test(pool.clone(), async |tester| {
             tester.post_comment("@bors try").await?;
             tester.expect_comments(1).await;
             tester
                 .workflow_event(WorkflowEvent::started(tester.try_branch()))
                 .await?;
-            Ok(tester)
+            Ok(())
         })
         .await;
         let suite = get_all_workflows(&pool).await.unwrap().pop().unwrap();
@@ -289,7 +289,7 @@ mod tests {
 
     #[sqlx::test]
     async fn try_workflow_start_twice(pool: sqlx::PgPool) {
-        run_test(pool.clone(), |mut tester| async {
+        run_test(pool.clone(), async |tester| {
             tester.post_comment("@bors try").await?;
             tester.expect_comments(1).await;
 
@@ -300,7 +300,7 @@ mod tests {
             tester
                 .workflow_event(WorkflowEvent::started(workflow.with_run_id(2)))
                 .await?;
-            Ok(tester)
+            Ok(())
         })
         .await;
         assert_eq!(get_all_workflows(&pool).await.unwrap().len(), 2);
@@ -308,21 +308,21 @@ mod tests {
 
     #[sqlx::test]
     async fn try_check_suite_finished_missing_build(pool: sqlx::PgPool) {
-        run_test(pool.clone(), |mut tester| async {
+        run_test(pool, async |tester| {
             tester
                 .check_suite(CheckSuite::completed(Branch::new(
                     "<branch>",
                     "<unknown-sha>",
                 )))
                 .await?;
-            Ok(tester)
+            Ok(())
         })
         .await;
     }
 
     #[sqlx::test]
     async fn try_success_multiple_suites(pool: sqlx::PgPool) {
-        run_test(pool.clone(), |mut tester| async {
+        run_test(pool, async |tester| {
             tester.create_branch(TRY_BRANCH_NAME).expect_suites(2);
             tester.post_comment("@bors try").await?;
             tester.expect_comments(1).await;
@@ -343,14 +343,14 @@ mod tests {
             <!-- homu: {"type":"TryBuildCompleted","merge_sha":"merge-main-sha1-pr-1-sha-0"} -->
             "#
             );
-            Ok(tester)
+            Ok(())
         })
         .await;
     }
 
     #[sqlx::test]
     async fn try_failure_multiple_suites(pool: sqlx::PgPool) {
-        run_test(pool.clone(), |mut tester| async {
+        run_test(pool, async |tester| {
             tester.create_branch(TRY_BRANCH_NAME).expect_suites(2);
             tester.post_comment("@bors try").await?;
             tester.expect_comments(1).await;
@@ -368,14 +368,14 @@ mod tests {
             - [Workflow1](https://github.com/workflows/Workflow1/2) :x:
             "###
             );
-            Ok(tester)
+            Ok(())
         })
         .await;
     }
 
     #[sqlx::test]
     async fn try_suite_completed_received_before_workflow_completed(pool: sqlx::PgPool) {
-        run_test(pool.clone(), |mut tester| async {
+        run_test(pool, async |tester| {
             tester.create_branch(TRY_BRANCH_NAME).expect_suites(1);
             tester.post_comment("@bors try").await?;
             tester.expect_comments(1).await;
@@ -401,14 +401,14 @@ mod tests {
             <!-- homu: {"type":"TryBuildCompleted","merge_sha":"merge-main-sha1-pr-1-sha-0"} -->
             "#
             );
-            Ok(tester)
+            Ok(())
         })
         .await;
     }
 
     #[sqlx::test]
     async fn try_check_suite_finished_twice(pool: sqlx::PgPool) {
-        run_test(pool.clone(), |mut tester| async {
+        run_test(pool, async |tester| {
             tester.create_branch(TRY_BRANCH_NAME).expect_suites(1);
             tester.post_comment("@bors try").await?;
             tester.expect_comments(1).await;
@@ -417,7 +417,7 @@ mod tests {
                 .check_suite(CheckSuite::completed(tester.try_branch()))
                 .await?;
             tester.expect_comments(1).await;
-            Ok(tester)
+            Ok(())
         })
         .await;
     }


### PR DESCRIPTION
If we use async closures to avoid passing `BorsTester` to tests, we don't have to return it from them. Thanks to that, we can always wait for bors to finish (and thus see any of its potential errors), regardless of the actual test finishing successfully or not.