### PR TITLE
Show a sample of failed jobs when a build fails

### DIFF
--- a/src/bors/comment.rs
+++ b/src/bors/comment.rs
@@ -115,8 +115,7 @@ pub fn build_failed_comment(
 
         let mut failed_jobs: Vec<Job> = failed_workflows
             .into_iter()
-            .map(|w| w.failed_jobs)
-            .flatten()
+            .flat_map(|w| w.failed_jobs)
             .collect();
         failed_jobs.sort_by(|l, r| l.name.cmp(&r.name));
 

--- a/src/bors/handlers/trybuild.rs
+++ b/src/bors/handlers/trybuild.rs
@@ -10,7 +10,6 @@ use crate::bors::comment::{
     cant_find_last_parent_comment, merge_conflict_comment, try_build_started_comment,
 };
 use crate::bors::handlers::labels::handle_label_trigger;
-use crate::database::RunId;
 use crate::database::{BuildModel, BuildStatus, PullRequestModel};
 use crate::github::GithubRepoName;
 use crate::github::api::client::GithubRepositoryClient;
@@ -20,6 +19,7 @@ use crate::permissions::PermissionType;
 use crate::utils::text::suppress_github_mentions;
 use anyhow::{Context, anyhow};
 use itertools::Itertools;
+use octocrab::models::CheckRunId;
 use octocrab::params::checks::CheckRunConclusion;
 use octocrab::params::checks::CheckRunOutput;
 use octocrab::params::checks::CheckRunStatus;
@@ -312,8 +312,12 @@ pub async fn cancel_build_workflows(
     db: &PgDbClient,
     build: &BuildModel,
     check_run_conclusion: CheckRunConclusion,
-) -> anyhow::Result<Vec<RunId>> {
+) -> anyhow::Result<Vec<octocrab::models::RunId>> {
     let pending_workflows = db.get_pending_workflows_for_build(build).await?;
+    let pending_workflows: Vec<octocrab::models::RunId> = pending_workflows
+        .into_iter()
+        .map(|id| octocrab::models::RunId(id.0))
+        .collect();
 
     tracing::info!("Cancelling workflows {:?}", pending_workflows);
     client.cancel_workflows(&pending_workflows).await?;
@@ -324,7 +328,7 @@ pub async fn cancel_build_workflows(
     if let Some(check_run_id) = build.check_run_id {
         if let Err(error) = client
             .update_check_run(
-                check_run_id as u64,
+                CheckRunId(check_run_id as u64),
                 CheckRunStatus::Completed,
                 Some(check_run_conclusion),
                 None,
@@ -446,10 +450,7 @@ mod tests {
             tester.workflow_full_failure(tester.try_branch()).await?;
             insta::assert_snapshot!(
                 tester.get_comment().await?,
-                @r###"
-            :broken_heart: Test failed
-            - [Workflow1](https://github.com/workflows/Workflow1/1) :x:
-            "###
+                @":broken_heart: Test failed ([Workflow1](https://github.com/workflows/Workflow1/1))"
             );
             Ok(())
         })

--- a/src/bors/handlers/workflow.rs
+++ b/src/bors/handlers/workflow.rs
@@ -219,7 +219,7 @@ async fn maybe_complete_build(
         // Download failed jobs
         let mut workflow_runs: Vec<FailedWorkflowRun> = vec![];
         for workflow_run in db_workflow_runs {
-            let failed_jobs = match get_failed_jobs(&repo, &workflow_run).await {
+            let failed_jobs = match get_failed_jobs(repo, &workflow_run).await {
                 Ok(jobs) => jobs,
                 Err(error) => {
                     tracing::error!(

--- a/src/bors/handlers/workflow.rs
+++ b/src/bors/handlers/workflow.rs
@@ -1,19 +1,19 @@
-use std::sync::Arc;
-use std::time::Duration;
-
-use octocrab::params::checks::CheckRunConclusion;
-use octocrab::params::checks::CheckRunStatus;
-
 use crate::PgDbClient;
-use crate::bors::comment::{try_build_succeeded_comment, workflow_failed_comment};
+use crate::bors::comment::{build_failed_comment, try_build_succeeded_comment};
 use crate::bors::event::{WorkflowRunCompleted, WorkflowRunStarted};
 use crate::bors::handlers::is_bors_observed_branch;
 use crate::bors::handlers::labels::handle_label_trigger;
 use crate::bors::merge_queue::AUTO_BRANCH_NAME;
 use crate::bors::merge_queue::MergeQueueSender;
-use crate::bors::{RepositoryState, WorkflowRun};
-use crate::database::{BuildStatus, WorkflowStatus};
+use crate::bors::{FailedWorkflowRun, RepositoryState, WorkflowRun};
+use crate::database::{BuildStatus, WorkflowModel, WorkflowStatus};
 use crate::github::LabelTrigger;
+use octocrab::models::CheckRunId;
+use octocrab::models::workflows::{Conclusion, Job, Status};
+use octocrab::params::checks::CheckRunConclusion;
+use octocrab::params::checks::CheckRunStatus;
+use std::sync::Arc;
+use std::time::Duration;
 
 pub(super) async fn handle_workflow_started(
     db: Arc<PgDbClient>,
@@ -203,7 +203,7 @@ async fn maybe_complete_build(
 
         if let Err(error) = repo
             .client
-            .update_check_run(check_run_id as u64, status, conclusion, None)
+            .update_check_run(CheckRunId(check_run_id as u64), status, conclusion, None)
             .await
         {
             tracing::error!("Could not update check run {check_run_id}: {error:?}");
@@ -211,12 +211,32 @@ async fn maybe_complete_build(
     }
 
     db_workflow_runs.sort_by(|a, b| a.name.cmp(&b.name));
+
     let message = if !has_failure {
-        tracing::info!("Workflow succeeded");
+        tracing::info!("Build succeeded");
         try_build_succeeded_comment(&db_workflow_runs, payload.commit_sha, &build)
     } else {
-        tracing::info!("Workflow failed");
-        workflow_failed_comment(&db_workflow_runs)
+        // Download failed jobs
+        let mut workflow_runs: Vec<FailedWorkflowRun> = vec![];
+        for workflow_run in db_workflow_runs {
+            let failed_jobs = match get_failed_jobs(&repo, &workflow_run).await {
+                Ok(jobs) => jobs,
+                Err(error) => {
+                    tracing::error!(
+                        "Cannot download jobs for workflow run {}: {error:?}",
+                        workflow_run.run_id
+                    );
+                    vec![]
+                }
+            };
+            workflow_runs.push(FailedWorkflowRun {
+                workflow_run,
+                failed_jobs,
+            })
+        }
+
+        tracing::info!("Build failed");
+        build_failed_comment(repo.repository(), workflow_runs)
     };
     repo.client.post_comment(pr.number, message).await?;
 
@@ -226,6 +246,29 @@ async fn maybe_complete_build(
     }
 
     Ok(())
+}
+
+/// Return failed jobs from the given workflow run.
+async fn get_failed_jobs(
+    repo: &RepositoryState,
+    workflow_run: &WorkflowModel,
+) -> anyhow::Result<Vec<Job>> {
+    let jobs = repo
+        .client
+        .get_jobs_for_workflow_run(workflow_run.run_id.into())
+        .await?;
+    Ok(jobs
+        .into_iter()
+        .filter(|j| {
+            j.status == Status::Failed || {
+                j.status == Status::Completed
+                    && matches!(
+                        j.conclusion,
+                        Some(Conclusion::Failure | Conclusion::Cancelled | Conclusion::TimedOut)
+                    )
+            }
+        })
+        .collect())
 }
 
 #[cfg(test)]
@@ -376,11 +419,7 @@ mod tests {
             tester.workflow_event(WorkflowEvent::failure(w2)).await?;
             insta::assert_snapshot!(
                 tester.get_comment().await?,
-                @r"
-            :broken_heart: Test failed
-            - [Workflow1](https://github.com/workflows/Workflow1/1) :question:
-            - [Workflow1](https://github.com/workflows/Workflow1/2) :x:
-            "
+                @":broken_heart: Test failed ([Workflow1](https://github.com/workflows/Workflow1/1), [Workflow1](https://github.com/workflows/Workflow1/2))"
             );
             Ok(())
         })

--- a/src/bors/mod.rs
+++ b/src/bors/mod.rs
@@ -8,6 +8,7 @@ pub use comment::Comment;
 pub use context::BorsContext;
 pub use handlers::{handle_bors_global_event, handle_bors_repository_event};
 use octocrab::models::RunId;
+use octocrab::models::workflows::Job;
 use serde::Serialize;
 
 use crate::config::RepositoryConfig;
@@ -25,7 +26,7 @@ mod handlers;
 pub mod merge_queue;
 pub mod mergeable_queue;
 
-use crate::database::WorkflowStatus;
+use crate::database::{WorkflowModel, WorkflowStatus};
 pub use command::CommandPrefix;
 
 #[cfg(test)]
@@ -45,6 +46,11 @@ pub static WAIT_FOR_WORKFLOW_STARTED: TestSyncMarker = TestSyncMarker::new();
 pub struct WorkflowRun {
     pub id: RunId,
     pub status: WorkflowStatus,
+}
+
+pub struct FailedWorkflowRun {
+    pub workflow_run: WorkflowModel,
+    pub failed_jobs: Vec<Job>,
 }
 
 /// An access point to a single repository.

--- a/src/github/api/client.rs
+++ b/src/github/api/client.rs
@@ -286,11 +286,7 @@ impl GithubRepositoryClient {
 
             // Cancel all workflows in parallel
             futures::future::join_all(run_ids.iter().map(|run_id| {
-                actions.cancel_workflow_run(
-                    self.repo_name.owner(),
-                    self.repo_name.name(),
-                    (*run_id).into(),
-                )
+                actions.cancel_workflow_run(self.repo_name.owner(), self.repo_name.name(), *run_id)
             }))
             .await
             .into_iter()

--- a/src/github/api/operations.rs
+++ b/src/github/api/operations.rs
@@ -201,7 +201,7 @@ pub async fn create_check_run(
 
 pub async fn update_check_run(
     repo: &GithubRepositoryClient,
-    check_run_id: u64,
+    check_run_id: CheckRunId,
     status: CheckRunStatus,
     conclusion: Option<CheckRunConclusion>,
     output: Option<CheckRunOutput>,
@@ -210,9 +210,7 @@ pub async fn update_check_run(
         .client()
         .checks(repo.repository().owner(), repo.repository().name());
 
-    let mut request = checks
-        .update_check_run(CheckRunId(check_run_id))
-        .status(status);
+    let mut request = checks.update_check_run(check_run_id).status(status);
 
     if let Some(conclusion) = conclusion {
         request = request.conclusion(conclusion);

--- a/src/tests/mocks/mod.rs
+++ b/src/tests/mocks/mod.rs
@@ -25,6 +25,7 @@ pub use repository::default_branch_name;
 pub use repository::default_repo_name;
 pub use user::User;
 pub use workflow::WorkflowEvent;
+pub use workflow::WorkflowJob;
 pub use workflow::WorkflowRunData;
 
 mod app;

--- a/src/tests/mocks/workflow.rs
+++ b/src/tests/mocks/workflow.rs
@@ -1,11 +1,11 @@
-use chrono::{DateTime, Utc};
-use octocrab::models::{CheckSuiteId, RunId, WorkflowId};
-use serde::Serialize;
-use url::Url;
-
+use crate::database::WorkflowStatus;
 use crate::github::GithubRepoName;
 use crate::tests::mocks::default_repo_name;
 use crate::tests::mocks::repository::{Branch, GitHubRepository};
+use chrono::{DateTime, Utc};
+use octocrab::models::{CheckSuiteId, JobId, RunId, WorkflowId};
+use serde::Serialize;
+use url::Url;
 
 #[derive(Clone)]
 pub struct WorkflowEvent {
@@ -45,12 +45,19 @@ pub enum WorkflowEventKind {
 }
 
 #[derive(Clone)]
+pub struct WorkflowJob {
+    pub id: JobId,
+    pub status: WorkflowStatus,
+}
+
+#[derive(Clone)]
 pub struct WorkflowRunData {
     pub repository: GithubRepoName,
     name: String,
     pub run_id: RunId,
     pub check_suite_id: CheckSuiteId,
     pub head_branch: String,
+    pub jobs: Vec<WorkflowJob>,
     head_sha: String,
 }
 
@@ -62,6 +69,7 @@ impl WorkflowRunData {
             run_id: RunId(1),
             check_suite_id: CheckSuiteId(1),
             head_branch: branch.get_name().to_string(),
+            jobs: vec![],
             head_sha: branch.get_sha().to_string(),
         }
     }

--- a/src/utils/text.rs
+++ b/src/utils/text.rs
@@ -1,4 +1,5 @@
 use regex::{Captures, Regex};
+use std::borrow::Cow;
 
 /// Replaces github @mentions with backticks to prevent accidental pings
 pub fn suppress_github_mentions(text: &str) -> String {
@@ -13,6 +14,15 @@ pub fn suppress_github_mentions(text: &str) -> String {
         .to_string()
 }
 
+/// Pluralizes a piece of text.
+pub fn pluralize(base: &str, count: usize) -> Cow<str> {
+    if count == 1 {
+        base.into()
+    } else {
+        format!("{base}s").into()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -25,5 +35,20 @@ mod tests {
             suppress_github_mentions("mail@example.com"),
             "mail@example.com"
         )
+    }
+
+    #[test]
+    fn pluralize_zero() {
+        assert_eq!(pluralize("foo", 0), "foos");
+    }
+
+    #[test]
+    fn pluralize_one() {
+        assert_eq!(pluralize("foo", 1), "foo");
+    }
+
+    #[test]
+    fn pluralize_two() {
+        assert_eq!(pluralize("foo", 2), "foos");
     }
 }

--- a/src/utils/timing.rs
+++ b/src/utils/timing.rs
@@ -110,7 +110,6 @@ mod tests {
     use std::time::Duration;
     use tokio::time::sleep;
 
-    #[tracing_test::traced_test]
     #[tokio::test]
     async fn test_measure_operation() {
         // Test basic timing functionality
@@ -123,7 +122,6 @@ mod tests {
         assert_eq!(result.unwrap_or_default(), 42);
     }
 
-    #[tracing_test::traced_test]
     #[tokio::test]
     async fn test_error_handling() {
         // Test that errors are properly propagated


### PR DESCRIPTION
As noted [here](https://github.com/rust-lang/bors/issues/356#issuecomment-3090121768), it takes a while to load the jobs on rust-lang/rust. I'll be observing how it works on production and if it's problematic, I'll remove this functionality.

Fixes: https://github.com/rust-lang/bors/issues/356