### PR TITLE
Remove repository name from merge commit message

### DIFF
--- a/src/bors/handlers/trybuild.rs
+++ b/src/bors/handlers/trybuild.rs
@@ -88,11 +88,7 @@ pub(super) async fn command_try_build(
         &repo.client,
         &pr.github.head.sha,
         &base_sha,
-        &create_merge_commit_message(
-            pr,
-            repo.client.repository(),
-            MergeType::Try { try_jobs: jobs },
-        ),
+        &create_merge_commit_message(pr, MergeType::Try { try_jobs: jobs }),
     )
     .await?
     {
@@ -355,11 +351,7 @@ enum MergeType {
     Try { try_jobs: Vec<String> },
 }
 
-fn create_merge_commit_message(
-    pr: &PullRequestData,
-    name: &GithubRepoName,
-    merge_type: MergeType,
-) -> String {
+fn create_merge_commit_message(pr: &PullRequestData, merge_type: MergeType) -> String {
     let pr_number = pr.number();
 
     let reviewer = match &merge_type {
@@ -387,14 +379,12 @@ fn create_merge_commit_message(
     };
 
     let mut message = format!(
-        r#"Auto merge of {repo_owner}/{repo_name}#{pr_number} - {pr_label}, r={reviewer}
+        r#"Auto merge of #{pr_number} - {pr_label}, r={reviewer}
 {pr_title}
 
 {pr_description}"#,
         pr_label = pr.github.head_label,
         pr_title = pr.github.title,
-        repo_owner = name.owner(),
-        repo_name = name.name()
     );
 
     match merge_type {
@@ -560,10 +550,10 @@ It fixes so many issues, sir."
             tester.post_comment("@bors try").await?;
             tester.expect_comments(1).await;
 
-            insta::assert_snapshot!(tester.get_branch_commit_message(&tester.try_branch()), @r"
-            Auto merge of rust-lang/borstest#1 - pr-1, r=<try>
+            insta::assert_snapshot!(tester.get_branch_commit_message(&tester.try_branch()), @r###"
+            Auto merge of #1 - pr-1, r=<try>
             Title of PR 1
-            ");
+            "###);
             Ok(())
         })
         .await;
@@ -589,13 +579,13 @@ try-job: Bar
             tester.post_comment("@bors try").await?;
             tester.expect_comments(1).await;
 
-            insta::assert_snapshot!(tester.get_branch_commit_message(&tester.try_branch()), @r"
-            Auto merge of rust-lang/borstest#1 - pr-1, r=<try>
+            insta::assert_snapshot!(tester.get_branch_commit_message(&tester.try_branch()), @r###"
+            Auto merge of #1 - pr-1, r=<try>
             Title of PR 1
 
             try-job: Foo
             try-job: Bar
-            ");
+            "###);
             Ok(())
         })
         .await;
@@ -618,14 +608,14 @@ try-job: Bar
             tester.post_comment("@bors try jobs=Baz,Baz2").await?;
             tester.expect_comments(1).await;
 
-            insta::assert_snapshot!(tester.get_branch_commit_message(&tester.try_branch()), @r"
-            Auto merge of rust-lang/borstest#1 - pr-1, r=<try>
+            insta::assert_snapshot!(tester.get_branch_commit_message(&tester.try_branch()), @r###"
+            Auto merge of #1 - pr-1, r=<try>
             Title of PR 1
 
 
             try-job: Baz
             try-job: Baz2
-            ");
+            "###);
             Ok(())
         })
         .await;


### PR DESCRIPTION
Things have changed somewhat since I created https://github.com/rust-lang/bors/issues/99. We now plan to use bors only for rust-lang/rust, where the repository name is not needed, and where we have a bunch of automation tools that parse the old format without the repository name. So including the name in the merge commit message now seems like a loss-loss, so I removed it.

Closes: https://github.com/rust-lang/bors/issues/99