### PR TITLE
Configure web URL for bors and show it in approved commit message

### DIFF
--- a/src/bin/bors.rs
+++ b/src/bin/bors.rs
@@ -56,6 +56,10 @@ struct Opts {
     /// Prefix used for bot commands in PR comments.
     #[arg(long, env = "CMD_PREFIX", default_value = "@bors")]
     cmd_prefix: String,
+
+    /// Web URL where the bot's website is deployed.
+    #[arg(long, env = "WEB_URL", default_value = "http://localhost:8080")]
+    web_url: String,
 }
 
 /// Starts a server that receives GitHub webhooks and generates events into a queue
@@ -140,6 +144,7 @@ fn try_main(opts: Opts) -> anyhow::Result<()> {
         CommandParser::new(opts.cmd_prefix.clone().into()),
         db.clone(),
         repos.clone(),
+        &opts.web_url,
     );
     let BorsProcess {
         repository_tx,

--- a/src/bors/comment.rs
+++ b/src/bors/comment.rs
@@ -215,6 +215,21 @@ handled during merge and rebase. This is normal, and you should still perform st
     Comment::new(message)
 }
 
+pub fn approved_comment(
+    web_url: &str,
+    repo: &GithubRepoName,
+    commit_sha: &CommitSha,
+    reviewer: &str,
+) -> Comment {
+    Comment::new(format!(
+        r":pushpin: Commit {commit_sha} has been approved by `{reviewer}`
+
+It is now in the [queue]({web_url}/queue/{}) for this repository.
+",
+        repo.name()
+    ))
+}
+
 pub fn approve_non_open_pr_comment() -> Comment {
     Comment::new(":clipboard: Only open, non-draft PRs can be approved.".to_string())
 }

--- a/src/bors/context.rs
+++ b/src/bors/context.rs
@@ -11,6 +11,7 @@ pub struct BorsContext {
     pub parser: CommandParser,
     pub db: Arc<PgDbClient>,
     pub repositories: RwLock<HashMap<GithubRepoName, Arc<RepositoryState>>>,
+    web_url: String,
 }
 
 impl BorsContext {
@@ -18,12 +19,19 @@ impl BorsContext {
         parser: CommandParser,
         db: Arc<PgDbClient>,
         repositories: HashMap<GithubRepoName, Arc<RepositoryState>>,
+        web_url: &str,
     ) -> Self {
         let repositories = RwLock::new(repositories);
         Self {
             parser,
             db,
             repositories,
+            web_url: web_url.trim_end_matches('/').to_string(),
         }
+    }
+
+    /// Returns a URL where the bot's website is publicly accessible.
+    pub fn get_web_url(&self) -> &str {
+        &self.web_url
     }
 }

--- a/src/bors/handlers/mod.rs
+++ b/src/bors/handlers/mod.rs
@@ -389,6 +389,7 @@ async fn handle_comment(
                     } => {
                         let span = tracing::info_span!("Approve");
                         command_approve(
+                            ctx.clone(),
                             repo,
                             database,
                             &pr,

--- a/src/tests/mocks/bors.rs
+++ b/src/tests/mocks/bors.rs
@@ -150,6 +150,7 @@ impl BorsTester {
             CommandParser::new("@bors".to_string().into()),
             db.clone(),
             repos.clone(),
+            "https://test.com/bors",
         );
 
         let BorsProcess {


### PR DESCRIPTION
This will need configuration in simpleinfra (https://github.com/rust-lang/simpleinfra/pull/752).