### PR TITLE
Make error message nicer when bors service panics in tests

### DIFF
--- a/src/tests/mocks/bors.rs
+++ b/src/tests/mocks/bors.rs
@@ -86,7 +86,11 @@ impl BorsBuilder {
 
         match result {
             Ok(res) => match res {
-                Ok(_) => gh_state.expect("Bors service has failed"),
+                Ok(_) => gh_state
+                    .context("Bors service has failed")
+                    // This makes the error nicer
+                    .map_err(|e| e.to_string())
+                    .unwrap(),
                 Err(error) => {
                     panic!(
                         "Test has failed: {error:?}\n\nBors service error: {:?}",


### PR DESCRIPTION
When I changed the error reporting here last week, I was telling to myself: "the errors are not super nice here, maybe I could improve them.. no, it will be fine, this doesn't crash often". Well :)

Should help with https://github.com/rust-lang/bors/pull/330.

CC @Sakib25800