### PR TITLE
Add auto build cancel tests

### DIFF
--- a/src/bors/comment.rs
+++ b/src/bors/comment.rs
@@ -324,7 +324,9 @@ pub fn auto_build_succeeded_comment(
         .join(", ");
 
     Comment::new(format!(
-        ":sunny: Test successful - {urls}\nApproved by: `{approved_by}`\nPushing {merge_sha} to `{base_ref}`...",
+        r#":sunny: Test successful - {urls}
+Approved by: `{approved_by}`
+Pushing {merge_sha} to `{base_ref}`..."#
     ))
 }
 

--- a/src/bors/handlers/pr_events.rs
+++ b/src/bors/handlers/pr_events.rs
@@ -68,14 +68,6 @@ pub(super) async fn handle_push_to_pull_request(
             )
             .await
             {
-                Err(error) => {
-                    tracing::error!(
-                        "Could not cancel workflows for SHA {}: {error:?}",
-                        auto_build.commit_sha
-                    );
-
-                    notify_of_unclean_auto_build_cancelled_comment(&repo_state, pr_number).await?
-                }
                 Ok(workflow_ids) => {
                     tracing::info!("Auto build cancelled");
 
@@ -83,6 +75,14 @@ pub(super) async fn handle_push_to_pull_request(
                         .client
                         .get_workflow_urls(workflow_ids.into_iter());
                     notify_of_cancelled_workflows(&repo_state, pr_number, workflow_urls).await?
+                }
+                Err(error) => {
+                    tracing::error!(
+                        "Could not cancel workflows for SHA {}: {error:?}",
+                        auto_build.commit_sha
+                    );
+
+                    notify_of_unclean_auto_build_cancelled_comment(&repo_state, pr_number).await?
                 }
             };
         }


### PR DESCRIPTION
- Adds PR #326 tests. 
- Closes #369 

Also slips in a change from cooked to raw string literal for the auto build success comment. 