### PR TITLE
Improve logging around build cancellation

### DIFF
--- a/src/bors/event.rs
+++ b/src/bors/event.rs
@@ -65,8 +65,9 @@ pub enum BorsGlobalEvent {
     RefreshConfig,
     /// Refresh the team permissions.
     RefreshPermissions,
-    /// Cancel builds that have been running for a long time.
-    CancelTimedOutBuilds,
+    /// Examine pending builds and handle any issues (e.g. cancel builds that have been running for
+    /// a long time).
+    RefreshPendingBuilds,
     /// Refresh mergeability status of PRs that have unknown mergeability status.
     RefreshPullRequestMergeability,
     /// Periodic event that serves for synchronizing PR state.

--- a/src/bors/handlers/mod.rs
+++ b/src/bors/handlers/mod.rs
@@ -9,7 +9,7 @@ use crate::bors::handlers::pr_events::{
     handle_pull_request_assigned, handle_pull_request_unassigned,
 };
 use crate::bors::handlers::refresh::{
-    cancel_timed_out_builds, reload_repository_config, reload_repository_permissions,
+    refresh_pending_builds, reload_repository_config, reload_repository_permissions,
     reload_unknown_mergeable_prs,
 };
 use crate::bors::handlers::review::{
@@ -258,17 +258,17 @@ pub async fn handle_bors_global_event(
             .instrument(span)
             .await?;
         }
-        BorsGlobalEvent::CancelTimedOutBuilds => {
-            let span = tracing::info_span!("Cancel timed out builds");
+        BorsGlobalEvent::RefreshPendingBuilds => {
+            let span = tracing::info_span!("Refresh pending builds");
             for_each_repo(&ctx, |repo| {
                 let span = tracing::info_span!("Repo", repo = repo.repository().to_string());
-                cancel_timed_out_builds(repo, &db).instrument(span)
+                refresh_pending_builds(repo, &db).instrument(span)
             })
             .instrument(span)
             .await?;
 
             #[cfg(test)]
-            crate::bors::WAIT_FOR_CANCEL_TIMED_OUT_BUILDS_REFRESH.mark();
+            crate::bors::WAIT_FOR_REFRESH_PENDING_BUILDS.mark();
         }
         BorsGlobalEvent::RefreshPullRequestMergeability => {
             let span = tracing::info_span!("Refresh PR mergeability status");

--- a/src/bors/handlers/refresh.rs
+++ b/src/bors/handlers/refresh.rs
@@ -13,12 +13,12 @@ use crate::bors::handlers::trybuild::cancel_build_workflows;
 use crate::bors::mergeable_queue::MergeableQueueSender;
 use crate::{PgDbClient, TeamApiClient};
 
-/// Cancel CI builds that have been running for too long
-pub async fn cancel_timed_out_builds(
+/// Cancel CI builds that have been running for too long.
+pub async fn refresh_pending_builds(
     repo: Arc<RepositoryState>,
     db: &PgDbClient,
 ) -> anyhow::Result<()> {
-    let running_builds = db.get_running_builds(repo.repository()).await?;
+    let running_builds = db.get_pending_builds(repo.repository()).await?;
     tracing::info!("Found {} running build(s)", running_builds.len());
 
     let timeout = repo.config.load().timeout;
@@ -248,7 +248,7 @@ timeout = 3600
                     assert_eq!(
                         tester
                             .db()
-                            .get_running_builds(&default_repo_name())
+                            .get_pending_builds(&default_repo_name())
                             .await
                             .unwrap()
                             .len(),
@@ -261,7 +261,7 @@ timeout = 3600
                 assert_eq!(
                     tester
                         .db()
-                        .get_running_builds(&default_repo_name())
+                        .get_pending_builds(&default_repo_name())
                         .await
                         .unwrap()
                         .len(),

--- a/src/bors/mod.rs
+++ b/src/bors/mod.rs
@@ -30,7 +30,7 @@ use crate::database::{WorkflowModel, WorkflowStatus};
 pub use command::CommandPrefix;
 
 #[cfg(test)]
-pub static WAIT_FOR_CANCEL_TIMED_OUT_BUILDS_REFRESH: TestSyncMarker = TestSyncMarker::new();
+pub static WAIT_FOR_REFRESH_PENDING_BUILDS: TestSyncMarker = TestSyncMarker::new();
 
 #[cfg(test)]
 pub static WAIT_FOR_MERGEABILITY_STATUS_REFRESH: TestSyncMarker = TestSyncMarker::new();

--- a/src/database/client.rs
+++ b/src/database/client.rs
@@ -12,13 +12,13 @@ use crate::github::{CommitSha, GithubRepoName};
 use super::operations::{
     approve_pull_request, create_build, create_pull_request, create_workflow,
     delegate_pull_request, delete_auto_build, find_build, find_pr_by_build,
-    get_nonclosed_pull_requests, get_nonclosed_pull_requests_by_base_branch,
+    get_nonclosed_pull_requests, get_nonclosed_pull_requests_by_base_branch, get_pending_builds,
     get_prs_with_unknown_mergeable_state, get_pull_request, get_repository, get_repository_by_name,
-    get_running_builds, get_workflow_urls_for_build, get_workflows_for_build,
-    insert_repo_if_not_exists, set_pr_assignees, set_pr_priority, set_pr_rollup, set_pr_status,
-    unapprove_pull_request, undelegate_pull_request, update_build_check_run_id,
-    update_build_status, update_mergeable_states_by_base_branch, update_pr_mergeable_state,
-    update_pr_try_build_id, update_workflow_status, upsert_pull_request, upsert_repository,
+    get_workflow_urls_for_build, get_workflows_for_build, insert_repo_if_not_exists,
+    set_pr_assignees, set_pr_priority, set_pr_rollup, set_pr_status, unapprove_pull_request,
+    undelegate_pull_request, update_build_check_run_id, update_build_status,
+    update_mergeable_states_by_base_branch, update_pr_mergeable_state, update_pr_try_build_id,
+    update_workflow_status, upsert_pull_request, upsert_repository,
 };
 use super::{ApprovalInfo, DelegatedPermission, MergeableState, RunId, UpsertPullRequestParams};
 
@@ -215,11 +215,11 @@ impl PgDbClient {
         find_build(&self.pool, repo, &branch, &commit_sha).await
     }
 
-    pub async fn get_running_builds(
+    pub async fn get_pending_builds(
         &self,
         repo: &GithubRepoName,
     ) -> anyhow::Result<Vec<BuildModel>> {
-        get_running_builds(&self.pool, repo).await
+        get_pending_builds(&self.pool, repo).await
     }
 
     pub async fn update_build_status(

--- a/src/database/operations.rs
+++ b/src/database/operations.rs
@@ -595,7 +595,7 @@ WHERE repository = $1
     .await
 }
 
-pub(crate) async fn get_running_builds(
+pub(crate) async fn get_pending_builds(
     executor: impl PgExecutor<'_>,
     repo: &GithubRepoName,
 ) -> anyhow::Result<Vec<BuildModel>> {

--- a/src/tests/mocks/bors.rs
+++ b/src/tests/mocks/bors.rs
@@ -19,8 +19,8 @@ use super::repository::PullRequest;
 use crate::bors::merge_queue::MergeQueueSender;
 use crate::bors::mergeable_queue::MergeableQueueSender;
 use crate::bors::{
-    CommandPrefix, RollupMode, WAIT_FOR_CANCEL_TIMED_OUT_BUILDS_REFRESH, WAIT_FOR_MERGE_QUEUE,
-    WAIT_FOR_MERGEABILITY_STATUS_REFRESH, WAIT_FOR_PR_STATUS_REFRESH, WAIT_FOR_WORKFLOW_STARTED,
+    CommandPrefix, RollupMode, WAIT_FOR_MERGE_QUEUE, WAIT_FOR_MERGEABILITY_STATUS_REFRESH,
+    WAIT_FOR_PR_STATUS_REFRESH, WAIT_FOR_REFRESH_PENDING_BUILDS, WAIT_FOR_WORKFLOW_STARTED,
 };
 use crate::database::{
     BuildStatus, DelegatedPermission, OctocrabMergeableState, PullRequestModel, WorkflowStatus,
@@ -342,12 +342,12 @@ impl BorsTester {
         wait_for_marker(
             async || {
                 self.global_tx
-                    .send(BorsGlobalEvent::CancelTimedOutBuilds)
+                    .send(BorsGlobalEvent::RefreshPendingBuilds)
                     .await
                     .unwrap();
                 Ok(())
             },
-            &WAIT_FOR_CANCEL_TIMED_OUT_BUILDS_REFRESH,
+            &WAIT_FOR_REFRESH_PENDING_BUILDS,
         )
         .await
         .unwrap();


### PR DESCRIPTION
No functional changes, just renamed the global build cancellation event in anticipation of https://github.com/rust-lang/bors/issues/388, and improved logging to help debugging https://github.com/rust-lang/bors/issues/389.