### PR TITLE
Handle build cancellation errors properly

### DIFF
--- a/src/bors/comment.rs
+++ b/src/bors/comment.rs
@@ -335,16 +335,3 @@ pub fn auto_build_push_failed_comment(error: &str) -> Comment {
         ":eyes: Test was successful, but fast-forwarding failed: {error}"
     ))
 }
-
-pub fn auto_build_cancelled_msg(workflow_urls: impl Iterator<Item = String>) -> String {
-    let mut comment = r#"Auto build cancelled. Cancelled workflows:"#.to_string();
-    for url in workflow_urls {
-        comment += format!("\n- {}", url).as_str();
-    }
-
-    comment
-}
-
-pub fn auto_build_cancelled_with_failed_workflow_cancel_msg() -> String {
-    "Auto build was cancelled. It was not possible to cancel some workflows.".to_string()
-}

--- a/src/bors/comment.rs
+++ b/src/bors/comment.rs
@@ -86,7 +86,7 @@ pub fn no_try_build_in_progress_comment() -> Comment {
     Comment::new(":exclamation: There is currently no try build in progress.".to_string())
 }
 
-pub fn unclean_try_build_cancelled_comment() -> Comment {
+pub fn try_build_cancelled_with_failed_workflow_cancel_comment() -> Comment {
     Comment::new(
         "Try build was cancelled. It was not possible to cancel some workflows.".to_string(),
     )
@@ -334,4 +334,17 @@ pub fn auto_build_push_failed_comment(error: &str) -> Comment {
     Comment::new(format!(
         ":eyes: Test was successful, but fast-forwarding failed: {error}"
     ))
+}
+
+pub fn auto_build_cancelled_msg(workflow_urls: impl Iterator<Item = String>) -> String {
+    let mut comment = r#"Auto build cancelled. Cancelled workflows:"#.to_string();
+    for url in workflow_urls {
+        comment += format!("\n- {}", url).as_str();
+    }
+
+    comment
+}
+
+pub fn auto_build_cancelled_with_failed_workflow_cancel_msg() -> String {
+    "Auto build was cancelled. It was not possible to cancel some workflows.".to_string()
 }

--- a/src/bors/handlers/info.rs
+++ b/src/bors/handlers/info.rs
@@ -182,7 +182,7 @@ mod tests {
             - Priority: 10
             - Mergeable: yes
             - Try build is in progress
-            	- Workflow URL: https://github.com/workflows/Workflow1/1
+            	- Workflow URL: https://github.com/rust-lang/borstest/actions/runs/1
             "
             );
             Ok(())

--- a/src/bors/handlers/pr_events.rs
+++ b/src/bors/handlers/pr_events.rs
@@ -733,7 +733,7 @@ mod tests {
 
                 Auto build cancelled due to push. Cancelled workflows:
 
-                - https://github.com/workflows/Workflow1/1
+                - https://github.com/rust-lang/borstest/actions/runs/1
                 ");
                 Ok(())
             })

--- a/src/bors/handlers/pr_events.rs
+++ b/src/bors/handlers/pr_events.rs
@@ -4,8 +4,8 @@ use crate::bors::event::{
     PullRequestMerged, PullRequestOpened, PullRequestPushed, PullRequestReadyForReview,
     PullRequestReopened, PullRequestUnassigned, PushToBranch,
 };
-use crate::bors::handlers::trybuild::cancel_build_workflows;
 use crate::bors::handlers::unapprove_pr;
+use crate::bors::handlers::workflow::cancel_build_workflows;
 use crate::bors::mergeable_queue::MergeableQueueSender;
 use crate::bors::{Comment, PullRequestStatus, RepositoryState};
 use crate::database::{BuildStatus, MergeableState};

--- a/src/bors/handlers/refresh.rs
+++ b/src/bors/handlers/refresh.rs
@@ -9,7 +9,7 @@ use std::collections::BTreeMap;
 use crate::bors::PullRequestStatus;
 use crate::bors::RepositoryState;
 use crate::bors::comment::build_timed_out_comment;
-use crate::bors::handlers::trybuild::cancel_build_workflows;
+use crate::bors::handlers::workflow::cancel_build_workflows;
 use crate::bors::mergeable_queue::MergeableQueueSender;
 use crate::database::{BuildModel, BuildStatus};
 use crate::{PgDbClient, TeamApiClient};
@@ -42,7 +42,7 @@ async fn refresh_build(
         if let Some(pr) = db.find_pr_by_build(&build).await? {
             tracing::info!("Cancelling build {build:?}");
             if let Err(error) =
-                cancel_build(&repo.client, db, &build, CheckRunConclusion::TimedOut).await
+                cancel_build_workflows(&repo.client, db, &build, CheckRunConclusion::TimedOut).await
             {
                 tracing::error!(
                     "Could not cancel workflows for SHA {}: {error:?}",

--- a/src/bors/handlers/refresh.rs
+++ b/src/bors/handlers/refresh.rs
@@ -9,7 +9,7 @@ use std::collections::BTreeMap;
 use crate::bors::PullRequestStatus;
 use crate::bors::RepositoryState;
 use crate::bors::comment::build_timed_out_comment;
-use crate::bors::handlers::workflow::cancel_build_workflows;
+use crate::bors::handlers::workflow::{CancelBuildError, cancel_build};
 use crate::bors::mergeable_queue::MergeableQueueSender;
 use crate::database::{BuildModel, BuildStatus};
 use crate::{PgDbClient, TeamApiClient};
@@ -41,13 +41,17 @@ async fn refresh_build(
     if elapsed_time(build.created_at) >= timeout {
         if let Some(pr) = db.find_pr_by_build(&build).await? {
             tracing::info!("Cancelling build {build:?}");
-            if let Err(error) =
-                cancel_build_workflows(&repo.client, db, &build, CheckRunConclusion::TimedOut).await
-            {
-                tracing::error!(
-                    "Could not cancel workflows for SHA {}: {error:?}",
-                    build.commit_sha
-                );
+            match cancel_build(&repo.client, db, &build, CheckRunConclusion::TimedOut).await {
+                Ok(_) => {}
+                Err(
+                    CancelBuildError::FailedToMarkBuildAsCancelled(error)
+                    | CancelBuildError::FailedToCancelWorkflows(error),
+                ) => {
+                    tracing::error!(
+                        "Could not cancel workflows for SHA {}: {error:?}",
+                        build.commit_sha
+                    );
+                }
             }
 
             if let Err(error) = repo

--- a/src/bors/handlers/refresh.rs
+++ b/src/bors/handlers/refresh.rs
@@ -74,7 +74,7 @@ async fn refresh_build(
             tracing::warn!(
                 "Detected orphaned pending without a PR, marking it as time outed: {build:?}"
             );
-            db.update_build_status(build, BuildStatus::Cancelled)
+            db.update_build_status(build, BuildStatus::Timeouted)
                 .await?;
         }
     }

--- a/src/bors/handlers/refresh.rs
+++ b/src/bors/handlers/refresh.rs
@@ -11,6 +11,7 @@ use crate::bors::RepositoryState;
 use crate::bors::comment::build_timed_out_comment;
 use crate::bors::handlers::trybuild::cancel_build_workflows;
 use crate::bors::mergeable_queue::MergeableQueueSender;
+use crate::database::{BuildModel, BuildStatus};
 use crate::{PgDbClient, TeamApiClient};
 
 /// Go through pending builds and figure out if we need to do something about them:
@@ -20,33 +21,57 @@ pub async fn refresh_pending_builds(
     db: &PgDbClient,
 ) -> anyhow::Result<()> {
     let running_builds = db.get_pending_builds(repo.repository()).await?;
-    tracing::info!("Found {} running build(s)", running_builds.len());
+    tracing::info!("Found {} pending build(s)", running_builds.len());
 
     let timeout = repo.config.load().timeout;
     for build in running_builds {
-        if elapsed_time(build.created_at) >= timeout {
-            if let Some(pr) = db.find_pr_by_build(&build).await? {
-                tracing::info!("Cancelling build {build:?}");
-                if let Err(error) =
-                    cancel_build_workflows(&repo.client, db, &build, CheckRunConclusion::TimedOut)
-                        .await
-                {
-                    tracing::error!(
-                        "Could not cancel workflows for SHA {}: {error:?}",
-                        build.commit_sha
-                    );
-                }
+        if let Err(error) = refresh_build(&repo, db, &build, timeout).await {
+            tracing::error!("Could not refresh pending build {build:?}: {error:?}");
+        }
+    }
+    Ok(())
+}
 
-                if let Err(error) = repo
-                    .client
-                    .post_comment(pr.number, build_timed_out_comment(timeout))
-                    .await
-                {
-                    tracing::error!("Could not send comment to PR {}: {error:?}", pr.number);
-                }
-            } else {
-                tracing::warn!("No PR found for build {build:?}");
+async fn refresh_build(
+    repo: &RepositoryState,
+    db: &PgDbClient,
+    build: &BuildModel,
+    timeout: Duration,
+) -> anyhow::Result<()> {
+    if elapsed_time(build.created_at) >= timeout {
+        if let Some(pr) = db.find_pr_by_build(&build).await? {
+            tracing::info!("Cancelling build {build:?}");
+            if let Err(error) =
+                cancel_build(&repo.client, db, &build, CheckRunConclusion::TimedOut).await
+            {
+                tracing::error!(
+                    "Could not cancel workflows for SHA {}: {error:?}",
+                    build.commit_sha
+                );
             }
+
+            if let Err(error) = repo
+                .client
+                .post_comment(pr.number, build_timed_out_comment(timeout))
+                .await
+            {
+                tracing::error!("Could not send comment to PR {}: {error:?}", pr.number);
+            }
+        } else {
+            // This is an orphaned build. It should never be created, unless we have some bug or
+            // unexpected race condition in bors.
+            // When we do encounter such a build, we can mark it as timeouted, as it is no longer
+            // relevant.
+            // Note that we could write an explicit query for finding these orphaned builds,
+            // but that could be quite expensive. Instead we piggyback on the existing logic
+            // for timed out builds; if a build is still pending and has no PR attached, then
+            // there likely won't be any additional event that could mark it as finished.
+            // So eventually all such builds will arrive here
+            tracing::warn!(
+                "Detected orphaned pending without a PR, marking it as time outed: {build:?}"
+            );
+            db.update_build_status(build, BuildStatus::Cancelled)
+                .await?;
         }
     }
     Ok(())

--- a/src/bors/handlers/refresh.rs
+++ b/src/bors/handlers/refresh.rs
@@ -39,9 +39,9 @@ async fn refresh_build(
     timeout: Duration,
 ) -> anyhow::Result<()> {
     if elapsed_time(build.created_at) >= timeout {
-        if let Some(pr) = db.find_pr_by_build(&build).await? {
+        if let Some(pr) = db.find_pr_by_build(build).await? {
             tracing::info!("Cancelling build {build:?}");
-            match cancel_build(&repo.client, db, &build, CheckRunConclusion::TimedOut).await {
+            match cancel_build(&repo.client, db, build, CheckRunConclusion::TimedOut).await {
                 Ok(_) => {}
                 Err(
                     CancelBuildError::FailedToMarkBuildAsCancelled(error)

--- a/src/bors/handlers/review.rs
+++ b/src/bors/handlers/review.rs
@@ -10,7 +10,7 @@ use crate::bors::comment::{
     approved_comment, delegate_comment, delegate_try_builds_comment, unapprove_non_open_pr_comment,
 };
 use crate::bors::handlers::labels::handle_label_trigger;
-use crate::bors::handlers::trybuild::cancel_build_workflows;
+use crate::bors::handlers::workflow::cancel_build_workflows;
 use crate::bors::handlers::{PullRequestData, deny_request};
 use crate::bors::handlers::{has_permission, unapprove_pr};
 use crate::bors::merge_queue::MergeQueueSender;

--- a/src/bors/handlers/review.rs
+++ b/src/bors/handlers/review.rs
@@ -1,7 +1,5 @@
 use std::sync::Arc;
 
-use octocrab::params::checks::CheckRunConclusion;
-
 use crate::bors::RepositoryState;
 use crate::bors::command::RollupMode;
 use crate::bors::command::{Approver, CommandPrefix};
@@ -10,14 +8,14 @@ use crate::bors::comment::{
     approved_comment, delegate_comment, delegate_try_builds_comment, unapprove_non_open_pr_comment,
 };
 use crate::bors::handlers::labels::handle_label_trigger;
-use crate::bors::handlers::workflow::cancel_build_workflows;
+use crate::bors::handlers::workflow::maybe_cancel_auto_build;
 use crate::bors::handlers::{PullRequestData, deny_request};
 use crate::bors::handlers::{has_permission, unapprove_pr};
 use crate::bors::merge_queue::MergeQueueSender;
 use crate::bors::{Comment, PullRequestStatus};
+use crate::database::ApprovalInfo;
 use crate::database::DelegatedPermission;
 use crate::database::TreeState;
-use crate::database::{ApprovalInfo, BuildStatus};
 use crate::github::LabelTrigger;
 use crate::github::{GithubUser, PullRequestNumber};
 use crate::permissions::PermissionType;
@@ -137,41 +135,8 @@ pub(super) async fn command_unapprove(
         return Ok(());
     }
 
-    let mut auto_build_cancel_message: Option<String> = None;
-    if let Some(auto_build) = &pr.db.auto_build {
-        if auto_build.status != BuildStatus::Pending {
-            return Ok(());
-        }
-
-        tracing::info!("Cancelling auto build for PR {pr_num} due to push");
-
-        match cancel_build_workflows(
-            &repo_state.client,
-            db.as_ref(),
-            auto_build,
-            CheckRunConclusion::Cancelled,
-        )
-        .await
-        {
-            Ok(workflow_ids) => {
-                tracing::info!("Auto build cancelled");
-
-                let workflow_urls = repo_state
-                    .client
-                    .get_workflow_urls(workflow_ids.into_iter());
-                auto_build_cancel_message = Some(auto_build_cancelled_message(workflow_urls).await);
-            }
-            Err(error) => {
-                tracing::error!(
-                    "Could not cancel workflows for SHA {}: {error:?}",
-                    auto_build.commit_sha
-                );
-
-                auto_build_cancel_message = Some(unclean_auto_build_cancelled_message().await);
-            }
-        };
-    }
-
+    let auto_build_cancel_message =
+        maybe_cancel_auto_build(&repo_state.client, &db, &pr.db).await?;
     unapprove_pr(&repo_state, &db, &pr.db).await?;
     notify_of_unapproval(&repo_state, pr, auto_build_cancel_message).await?;
 
@@ -390,20 +355,6 @@ async fn notify_of_delegation(
     };
 
     repo.client.post_comment(pr_number, comment).await
-}
-
-async fn auto_build_cancelled_message(workflow_urls: impl Iterator<Item = String>) -> String {
-    let mut comment = r#"Auto build cancelled due to unapproval. Cancelled workflows:"#.to_string();
-    for url in workflow_urls {
-        comment += format!("\n- {}", url).as_str();
-    }
-
-    comment
-}
-
-async fn unclean_auto_build_cancelled_message() -> String {
-    "Auto build was cancelled due to unapproval. It was not possible to cancel some workflows."
-        .to_string()
 }
 
 #[cfg(test)]
@@ -1385,8 +1336,8 @@ merge_queue_enabled = true
                 insta::assert_snapshot!(tester.get_comment().await?, @r"
                 Commit pr-1-sha has been unapproved.
 
-                Auto build cancelled due to unapproval. Cancelled workflows:
-                - https://github.com/rust-lang/borstest/actions/runs/1
+                Auto build cancelled. Cancelled workflows:
+                - https://github.com/workflows/Workflow1/1
                 ");
                 Ok(())
             })
@@ -1415,7 +1366,7 @@ merge_queue_enabled = true
                 insta::assert_snapshot!(tester.get_comment().await?, @r"
                 Commit pr-1-sha has been unapproved.
 
-                Auto build was cancelled due to unapproval. It was not possible to cancel some workflows.
+                Auto build was cancelled. It was not possible to cancel some workflows.
                 ");
                 Ok(())
             })

--- a/src/bors/handlers/review.rs
+++ b/src/bors/handlers/review.rs
@@ -1343,7 +1343,7 @@ merge_queue_enabled = true
 
                 Auto build cancelled due to unapproval. Cancelled workflows:
 
-                - https://github.com/workflows/Workflow1/1
+                - https://github.com/rust-lang/borstest/actions/runs/1
                 ");
                 Ok(())
             })

--- a/src/bors/handlers/trybuild.rs
+++ b/src/bors/handlers/trybuild.rs
@@ -1,15 +1,18 @@
 use std::sync::Arc;
 
+use super::has_permission;
+use super::{PullRequestData, deny_request};
 use crate::PgDbClient;
 use crate::bors::RepositoryState;
 use crate::bors::command::{CommandPrefix, Parent};
 use crate::bors::comment::no_try_build_in_progress_comment;
 use crate::bors::comment::try_build_cancelled_comment;
-use crate::bors::comment::unclean_try_build_cancelled_comment;
+use crate::bors::comment::try_build_cancelled_with_failed_workflow_cancel_comment;
 use crate::bors::comment::{
     cant_find_last_parent_comment, merge_conflict_comment, try_build_started_comment,
 };
 use crate::bors::handlers::labels::handle_label_trigger;
+use crate::bors::handlers::workflow::{CancelBuildError, cancel_build};
 use crate::database::{BuildModel, BuildStatus, PullRequestModel};
 use crate::github::api::client::GithubRepositoryClient;
 use crate::github::api::operations::ForcePush;
@@ -22,9 +25,6 @@ use octocrab::params::checks::CheckRunConclusion;
 use octocrab::params::checks::CheckRunOutput;
 use octocrab::params::checks::CheckRunStatus;
 use tracing::log;
-
-use super::{PullRequestData, deny_request};
-use super::{has_permission, workflow};
 
 // This branch serves for preparing the final commit.
 // It will be reset to master and merged with the branch that should be tested.
@@ -155,17 +155,13 @@ async fn cancel_previous_try_build(
 ) -> anyhow::Result<Vec<String>> {
     assert_eq!(build.status, BuildStatus::Pending);
 
-    match workflow::cancel_build_workflows(&repo.client, db, build, CheckRunConclusion::Cancelled)
-        .await
-    {
-        Ok(workflow_ids) => {
+    match cancel_build(&repo.client, db, build, CheckRunConclusion::Cancelled).await {
+        Ok(workflows) => {
             tracing::info!("Try build cancelled");
-            Ok(repo
-                .client
-                .get_workflow_urls(workflow_ids.into_iter())
-                .collect())
+            Ok(workflows.into_iter().map(|w| w.url).collect())
         }
-        Err(error) => {
+        Err(CancelBuildError::FailedToMarkBuildAsCancelled(error)) => Err(error),
+        Err(CancelBuildError::FailedToCancelWorkflows(error)) => {
             tracing::error!(
                 "Could not cancel workflows for SHA {}: {error:?}",
                 build.commit_sha
@@ -262,14 +258,14 @@ pub(super) async fn command_try_cancel(
 
     let pr_number: PullRequestNumber = pr.number();
     let Some(build) = get_pending_build(&pr.db) else {
-        tracing::warn!("No build found");
+        tracing::info!("No try build found when trying to cancel a try build");
         repo.client
             .post_comment(pr_number, no_try_build_in_progress_comment())
             .await?;
         return Ok(());
     };
 
-    match workflow::cancel_build_workflows(
+    match cancel_build(
         &repo.client,
         db.as_ref(),
         build,
@@ -277,24 +273,28 @@ pub(super) async fn command_try_cancel(
     )
     .await
     {
-        Err(error) => {
-            tracing::error!(
-                "Could not cancel workflows for SHA {}: {error:?}",
-                build.commit_sha
-            );
-            repo.client
-                .post_comment(pr_number, unclean_try_build_cancelled_comment())
-                .await?
-        }
-        Ok(workflow_ids) => {
+        Ok(workflows) => {
             tracing::info!("Try build cancelled");
 
             repo.client
                 .post_comment(
                     pr_number,
-                    try_build_cancelled_comment(
-                        repo.client.get_workflow_urls(workflow_ids.into_iter()),
-                    ),
+                    try_build_cancelled_comment(workflows.into_iter().map(|w| w.url)),
+                )
+                .await?
+        }
+        Err(CancelBuildError::FailedToMarkBuildAsCancelled(error)) => {
+            return Err(error);
+        }
+        Err(CancelBuildError::FailedToCancelWorkflows(error)) => {
+            tracing::error!(
+                "Could not cancel workflows for try build with SHA {}: {error:?}",
+                build.commit_sha
+            );
+            repo.client
+                .post_comment(
+                    pr_number,
+                    try_build_cancelled_with_failed_workflow_cancel_comment(),
                 )
                 .await?
         }
@@ -367,8 +367,8 @@ mod tests {
     use crate::bors::handlers::trybuild::{
         TRY_BRANCH_NAME, TRY_BUILD_CHECK_RUN_NAME, TRY_MERGE_BRANCH_NAME,
     };
-    use crate::database::WorkflowStatus;
     use crate::database::operations::get_all_workflows;
+    use crate::database::{BuildStatus, WorkflowStatus};
     use crate::github::CommitSha;
     use crate::tests::BorsTester;
     use crate::tests::mocks::{
@@ -849,11 +849,11 @@ try-job: Bar
                 ))
                 .await?;
             tester.post_comment("@bors try cancel").await?;
-            insta::assert_snapshot!(tester.get_comment().await?, @r###"
+            insta::assert_snapshot!(tester.get_comment().await?, @r"
             Try build cancelled. Cancelled workflows:
-            - https://github.com/rust-lang/borstest/actions/runs/123
-            - https://github.com/rust-lang/borstest/actions/runs/124
-            "###);
+            - https://github.com/workflows/Workflow1/123
+            - https://github.com/workflows/Workflow1/124
+            ");
             Ok(())
         })
         .await;
@@ -862,7 +862,7 @@ try-job: Bar
 
     #[sqlx::test]
     async fn try_cancel_error(pool: sqlx::PgPool) {
-        run_test(pool, async |tester| {
+        run_test(pool, async |tester: &mut BorsTester| {
             tester.default_repo().lock().workflow_cancel_error = true;
             tester.post_comment("@bors try").await?;
             tester.expect_comments(1).await;
@@ -871,6 +871,13 @@ try-job: Bar
                 .await?;
             tester.post_comment("@bors try cancel").await?;
             insta::assert_snapshot!(tester.get_comment().await?, @"Try build was cancelled. It was not possible to cancel some workflows.");
+            let build = tester.db().find_build(
+                &default_repo_name(),
+                tester.try_branch().get_name().to_string(),
+                tester.try_branch().get_sha().to_string().into()
+            ).await?.expect("build not found");
+            assert_eq!(build.status, BuildStatus::Cancelled);
+
             Ok(())
         })
         .await;
@@ -914,7 +921,7 @@ try-job: Bar
             tester.post_comment("@bors try cancel").await?;
             insta::assert_snapshot!(tester.get_comment().await?, @r"
             Try build cancelled. Cancelled workflows:
-            - https://github.com/rust-lang/borstest/actions/runs/3
+            - https://github.com/workflows/Workflow1/3
             ");
             Ok(())
         })

--- a/src/bors/handlers/trybuild.rs
+++ b/src/bors/handlers/trybuild.rs
@@ -387,7 +387,7 @@ mod tests {
             insta::assert_snapshot!(
                 tester.get_comment().await?,
                 @r#"
-            :sunny: Try build successful ([Workflow1](https://github.com/workflows/Workflow1/1))
+            :sunny: Try build successful ([Workflow1](https://github.com/rust-lang/borstest/actions/runs/1))
             Build commit: merge-0-pr-1 (`merge-0-pr-1`, parent: `main-sha1`)
 
             <!-- homu: {"type":"TryBuildCompleted","merge_sha":"merge-0-pr-1"} -->
@@ -406,7 +406,7 @@ mod tests {
             tester.workflow_full_failure(tester.try_branch()).await?;
             insta::assert_snapshot!(
                 tester.get_comment().await?,
-                @":broken_heart: Test failed ([Workflow1](https://github.com/workflows/Workflow1/1))"
+                @":broken_heart: Test failed ([Workflow1](https://github.com/rust-lang/borstest/actions/runs/1))"
             );
             Ok(())
         })
@@ -438,7 +438,7 @@ mod tests {
             insta::assert_snapshot!(
                 tester.get_comment().await?,
                 @r"
-            :broken_heart: Test failed ([Workflow1](https://github.com/workflows/Workflow1/1)). Failed jobs:
+            :broken_heart: Test failed ([Workflow1](https://github.com/rust-lang/borstest/actions/runs/1)). Failed jobs:
 
             - `Job 42` ([web logs](https://github.com/job-logs/42), [extended logs](https://triage.rust-lang.org/gha-logs/rust-lang/borstest/42))
             - `Job 50` ([web logs](https://github.com/job-logs/50), [extended logs](https://triage.rust-lang.org/gha-logs/rust-lang/borstest/50))
@@ -811,7 +811,7 @@ try-job: Bar
                 )
                 .await?;
             insta::assert_snapshot!(tester.get_comment().await?, @r#"
-            :sunny: Try build successful ([Workflow1](https://github.com/workflows/Workflow1/2))
+            :sunny: Try build successful ([Workflow1](https://github.com/rust-lang/borstest/actions/runs/2))
             Build commit: merge-1-pr-1 (`merge-1-pr-1`, parent: `main-sha1`)
 
             <!-- homu: {"type":"TryBuildCompleted","merge_sha":"merge-1-pr-1"} -->
@@ -851,8 +851,8 @@ try-job: Bar
             tester.post_comment("@bors try cancel").await?;
             insta::assert_snapshot!(tester.get_comment().await?, @r"
             Try build cancelled. Cancelled workflows:
-            - https://github.com/workflows/Workflow1/123
-            - https://github.com/workflows/Workflow1/124
+            - https://github.com/rust-lang/borstest/actions/runs/123
+            - https://github.com/rust-lang/borstest/actions/runs/124
             ");
             Ok(())
         })
@@ -921,7 +921,7 @@ try-job: Bar
             tester.post_comment("@bors try cancel").await?;
             insta::assert_snapshot!(tester.get_comment().await?, @r"
             Try build cancelled. Cancelled workflows:
-            - https://github.com/workflows/Workflow1/3
+            - https://github.com/rust-lang/borstest/actions/runs/3
             ");
             Ok(())
         })

--- a/src/bors/handlers/workflow.rs
+++ b/src/bors/handlers/workflow.rs
@@ -553,8 +553,8 @@ mod tests {
                 tester.get_comment().await?,
                 @r#"
             :sunny: Try build successful
-            - [Workflow1](https://github.com/workflows/Workflow1/1) :white_check_mark:
-            - [Workflow1](https://github.com/workflows/Workflow1/2) :white_check_mark:
+            - [Workflow1](https://github.com/rust-lang/borstest/actions/runs/1) :white_check_mark:
+            - [Workflow1](https://github.com/rust-lang/borstest/actions/runs/2) :white_check_mark:
             Build commit: merge-0-pr-1 (`merge-0-pr-1`, parent: `main-sha1`)
 
             <!-- homu: {"type":"TryBuildCompleted","merge_sha":"merge-0-pr-1"} -->
@@ -583,8 +583,8 @@ mod tests {
                 tester.get_comment().await?,
                 @r#"
             :sunny: Try build successful
-            - [Workflow1](https://github.com/workflows/Workflow1/1) :white_check_mark:
-            - [Workflow1](https://github.com/workflows/Workflow1/2) :white_check_mark:
+            - [Workflow1](https://github.com/rust-lang/borstest/actions/runs/1) :white_check_mark:
+            - [Workflow1](https://github.com/rust-lang/borstest/actions/runs/2) :white_check_mark:
             Build commit: merge-0-pr-1 (`merge-0-pr-1`, parent: `main-sha1`)
 
             <!-- homu: {"type":"TryBuildCompleted","merge_sha":"merge-0-pr-1"} -->
@@ -610,7 +610,7 @@ mod tests {
             tester.workflow_event(WorkflowEvent::failure(w2)).await?;
             insta::assert_snapshot!(
                 tester.get_comment().await?,
-                @":broken_heart: Test failed ([Workflow1](https://github.com/workflows/Workflow1/1), [Workflow1](https://github.com/workflows/Workflow1/2))"
+                @":broken_heart: Test failed ([Workflow1](https://github.com/rust-lang/borstest/actions/runs/1), [Workflow1](https://github.com/rust-lang/borstest/actions/runs/2))"
             );
             Ok(())
         })
@@ -750,7 +750,7 @@ auto_build_failed = ["+foo", "+bar", "-baz"]
                 }).await?;
                 insta::assert_snapshot!(
                     tester.get_comment().await?,
-                    @":broken_heart: Test failed ([Workflow1](https://github.com/workflows/Workflow1/1))"
+                    @":broken_heart: Test failed ([Workflow1](https://github.com/rust-lang/borstest/actions/runs/1))"
                 );
 
                 Ok(())

--- a/src/bors/handlers/workflow.rs
+++ b/src/bors/handlers/workflow.rs
@@ -1,5 +1,8 @@
 use crate::PgDbClient;
-use crate::bors::comment::{build_failed_comment, try_build_succeeded_comment};
+use crate::bors::comment::{
+    auto_build_cancelled_msg, auto_build_cancelled_with_failed_workflow_cancel_msg,
+    build_failed_comment, try_build_succeeded_comment,
+};
 use crate::bors::event::{WorkflowRunCompleted, WorkflowRunStarted};
 use crate::bors::handlers::TRY_BRANCH_NAME;
 use crate::bors::handlers::is_bors_observed_branch;
@@ -7,7 +10,7 @@ use crate::bors::handlers::labels::handle_label_trigger;
 use crate::bors::merge_queue::AUTO_BRANCH_NAME;
 use crate::bors::merge_queue::MergeQueueSender;
 use crate::bors::{FailedWorkflowRun, RepositoryState, WorkflowRun};
-use crate::database::{BuildModel, BuildStatus, WorkflowModel, WorkflowStatus};
+use crate::database::{BuildModel, BuildStatus, PullRequestModel, WorkflowModel, WorkflowStatus};
 use crate::github::LabelTrigger;
 use crate::github::api::client::GithubRepositoryClient;
 use octocrab::models::CheckRunId;
@@ -305,6 +308,110 @@ async fn get_failed_jobs(
             }
         })
         .collect())
+}
+
+/// We want to distinguish between a critical failure (a build was not marked as cancelled, in which
+/// case bors should not continue with its normal logic), and a less important failure (could not
+/// cancel some workflow or finish check run).
+#[must_use]
+pub enum CancelBuildError {
+    /// It was not possible to mark the build as cancelled.
+    FailedToMarkBuildAsCancelled(anyhow::Error),
+    /// The build was marked as cancelled, but it was not possible to cancel external workflows
+    /// and/or mark the check run status as cancelled.
+    FailedToCancelWorkflows(anyhow::Error),
+}
+
+/// Attempt to cancel a pending build.
+/// It also tries to cancel its pending workflows and check run status, but that has a lesser
+/// priority.
+pub async fn cancel_build(
+    client: &GithubRepositoryClient,
+    db: &PgDbClient,
+    build: &BuildModel,
+    check_run_conclusion: CheckRunConclusion,
+) -> Result<Vec<WorkflowModel>, CancelBuildError> {
+    assert_eq!(
+        build.status,
+        BuildStatus::Pending,
+        "Passed a non-pending build to `cancel_build`"
+    );
+
+    // This is the most important part: we need to ensure that the status of the build is switched
+    // to cancelled.
+    db.update_build_status(build, BuildStatus::Cancelled)
+        .await
+        .map_err(CancelBuildError::FailedToMarkBuildAsCancelled)?;
+
+    let pending_workflows = db
+        .get_pending_workflows_for_build(build)
+        .await
+        .map_err(CancelBuildError::FailedToCancelWorkflows)?;
+    let pending_workflow_ids: Vec<octocrab::models::RunId> = pending_workflows
+        .iter()
+        .map(|workflow| octocrab::models::RunId(workflow.run_id.0))
+        .collect();
+
+    tracing::info!("Cancelling workflows {:?}", pending_workflow_ids);
+    client
+        .cancel_workflows(&pending_workflow_ids)
+        .await
+        .map_err(CancelBuildError::FailedToCancelWorkflows)?;
+
+    if let Some(check_run_id) = build.check_run_id {
+        if let Err(error) = client
+            .update_check_run(
+                CheckRunId(check_run_id as u64),
+                CheckRunStatus::Completed,
+                Some(check_run_conclusion),
+                None,
+            )
+            .await
+        {
+            tracing::error!(
+                "Could not update check run {check_run_id} for build {build:?}: {error:?}"
+            );
+        }
+    }
+
+    Ok(pending_workflows)
+}
+
+/// Cancel an auto build attached to the PR, if there is any.
+/// Returns an optional string that can be attached to a PR comment, which describes the result of
+/// the workflow cancellation.
+pub async fn maybe_cancel_auto_build(
+    client: &GithubRepositoryClient,
+    db: &PgDbClient,
+    pr: &PullRequestModel,
+) -> anyhow::Result<Option<String>> {
+    let mut auto_build_cancel_message: Option<String> = None;
+    if let Some(auto_build) = &pr.auto_build {
+        if auto_build.status != BuildStatus::Pending {
+            return Ok(None);
+        }
+
+        tracing::info!("Cancelling auto build {auto_build:?}");
+
+        match cancel_build(client, db, auto_build, CheckRunConclusion::Cancelled).await {
+            Ok(workflows) => {
+                tracing::info!("Auto build cancelled");
+                let workflow_urls = workflows.into_iter().map(|w| w.url);
+                auto_build_cancel_message = Some(auto_build_cancelled_msg(workflow_urls));
+            }
+            Err(CancelBuildError::FailedToMarkBuildAsCancelled(error)) => return Err(error),
+            Err(CancelBuildError::FailedToCancelWorkflows(error)) => {
+                tracing::error!(
+                    "Could not cancel workflows for auto build with SHA {}: {error:?}",
+                    auto_build.commit_sha
+                );
+
+                auto_build_cancel_message =
+                    Some(auto_build_cancelled_with_failed_workflow_cancel_msg());
+            }
+        };
+    }
+    Ok(auto_build_cancel_message)
 }
 
 #[cfg(test)]
@@ -643,39 +750,4 @@ auto_build_failed = ["+foo", "+bar", "-baz"]
             })
             .await;
     }
-}
-
-pub async fn cancel_build_workflows(
-    client: &GithubRepositoryClient,
-    db: &PgDbClient,
-    build: &BuildModel,
-    check_run_conclusion: CheckRunConclusion,
-) -> anyhow::Result<Vec<octocrab::models::RunId>> {
-    let pending_workflows = db.get_pending_workflows_for_build(build).await?;
-    let pending_workflows: Vec<octocrab::models::RunId> = pending_workflows
-        .into_iter()
-        .map(|id| octocrab::models::RunId(id.0))
-        .collect();
-
-    tracing::info!("Cancelling workflows {:?}", pending_workflows);
-    client.cancel_workflows(&pending_workflows).await?;
-
-    db.update_build_status(build, BuildStatus::Cancelled)
-        .await?;
-
-    if let Some(check_run_id) = build.check_run_id {
-        if let Err(error) = client
-            .update_check_run(
-                CheckRunId(check_run_id as u64),
-                CheckRunStatus::Completed,
-                Some(check_run_conclusion),
-                None,
-            )
-            .await
-        {
-            tracing::error!("Could not update check run {check_run_id}: {error:?}");
-        }
-    }
-
-    Ok(pending_workflows)
 }

--- a/src/bors/merge_queue.rs
+++ b/src/bors/merge_queue.rs
@@ -465,7 +465,7 @@ mod tests {
             insta::assert_snapshot!(
                 tester.get_comment().await?,
                 @r"
-            :sunny: Test successful - [Workflow1](https://github.com/workflows/Workflow1/1)
+            :sunny: Test successful - [Workflow1](https://github.com/rust-lang/borstest/actions/runs/1)
             Approved by: `default-user`
             Pushing merge-0-pr-1 to `main`...
             "

--- a/src/database/client.rs
+++ b/src/database/client.rs
@@ -11,8 +11,8 @@ use crate::github::{CommitSha, GithubRepoName};
 
 use super::operations::{
     approve_pull_request, create_build, create_pull_request, create_workflow,
-    delegate_pull_request, delete_auto_build, find_build, find_pr_by_build,
-    get_nonclosed_pull_requests, get_nonclosed_pull_requests_by_base_branch, get_pending_builds,
+    delegate_pull_request, find_build, find_pr_by_build, get_nonclosed_pull_requests,
+    get_nonclosed_pull_requests_by_base_branch, get_pending_builds,
     get_prs_with_unknown_mergeable_state, get_pull_request, get_repository, get_repository_by_name,
     get_workflow_urls_for_build, get_workflows_for_build, insert_repo_if_not_exists,
     set_pr_assignees, set_pr_priority, set_pr_rollup, set_pr_status, unapprove_pull_request,
@@ -318,10 +318,6 @@ impl PgDbClient {
         tree_state: TreeState,
     ) -> anyhow::Result<()> {
         upsert_repository(&self.pool, repo, tree_state).await
-    }
-
-    pub async fn delete_auto_build(&self, pr: &PullRequestModel) -> anyhow::Result<()> {
-        delete_auto_build(&self.pool, pr.id).await
     }
 
     pub async fn get_merge_queue_prs(

--- a/src/database/client.rs
+++ b/src/database/client.rs
@@ -284,7 +284,7 @@ impl PgDbClient {
     pub async fn get_pending_workflows_for_build(
         &self,
         build: &BuildModel,
-    ) -> anyhow::Result<Vec<RunId>> {
+    ) -> anyhow::Result<Vec<WorkflowModel>> {
         let workflows = self
             .get_workflows_for_build(build)
             .await?
@@ -292,8 +292,7 @@ impl PgDbClient {
             .filter(|w| {
                 w.status == WorkflowStatus::Pending && w.workflow_type == WorkflowType::Github
             })
-            .map(|w| w.run_id)
-            .collect::<Vec<_>>();
+            .collect::<Vec<WorkflowModel>>();
         Ok(workflows)
     }
 

--- a/src/database/operations.rs
+++ b/src/database/operations.rs
@@ -982,34 +982,6 @@ pub(crate) async fn update_build_check_run_id(
     .await
 }
 
-/// Removes the auto build associated with a PR and deletes the build record (if one exists).
-pub(crate) async fn delete_auto_build(
-    executor: impl PgExecutor<'_>,
-    pr_id: i32,
-) -> anyhow::Result<()> {
-    measure_db_query("delete_auto_build", || async {
-        sqlx::query!(
-            r#"
-            -- Clear the PR's auto_build_id
-            WITH removed_auto_build AS (
-                UPDATE pull_request
-                SET auto_build_id = NULL
-                WHERE id = $1 AND auto_build_id IS NOT NULL
-                RETURNING auto_build_id
-            )
-            -- Delete the build record if one was removed
-            DELETE FROM build
-            WHERE id IN (SELECT auto_build_id FROM removed_auto_build)
-            "#,
-            pr_id
-        )
-        .execute(executor)
-        .await?;
-        Ok(())
-    })
-    .await
-}
-
 /// Fetches pull requests eligible for merge:
 /// - Only approved PRs that are open and mergeable
 /// - Includes only PRs with pending or successful auto builds

--- a/src/github/api/mod.rs
+++ b/src/github/api/mod.rs
@@ -22,10 +22,6 @@ pub const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 
 pub const DEFAULT_RETRY_COUNT: u32 = 5;
 
-fn base_github_html_url() -> &'static str {
-    "https://github.com"
-}
-
 pub fn create_github_client(
     app_id: AppId,
     github_url: String,
@@ -101,7 +97,6 @@ pub async fn load_repositories(
                 app.clone(),
                 installation_client.clone(),
                 team_api_client,
-                repo.clone(),
                 name.clone(),
             )
             .await
@@ -152,12 +147,11 @@ async fn create_repo_state(
     app: App,
     repo_client: Octocrab,
     team_api_client: &TeamApiClient,
-    repo: Repository,
     name: GithubRepoName,
 ) -> anyhow::Result<RepositoryState> {
     tracing::info!("Found repository {name}");
 
-    let client = GithubRepositoryClient::new(app, repo_client, name.clone(), repo);
+    let client = GithubRepositoryClient::new(app, repo_client, name.clone());
 
     let permissions = team_api_client
         .load_permissions(&name)

--- a/src/tests/mocks/workflow.rs
+++ b/src/tests/mocks/workflow.rs
@@ -113,8 +113,8 @@ impl From<WorkflowEvent> for GitHubWorkflowEventPayload {
         let WorkflowEvent { event, workflow } = value;
 
         let url: Url = format!(
-            "https://github.com/workflows/{}/{}",
-            workflow.name, workflow.run_id
+            "https://github.com/{}/actions/runs/{}",
+            workflow.repository, workflow.run_id
         )
         .parse()
         .unwrap();


### PR DESCRIPTION
There are a few places in bors where we try to cancel a pending build. Before, we used to mostly ignore cancellation errors, because we assumed that cancelling the workflows is best effort. While that is true, marking the build itself as cancelled is actually load-bearing! Because if that happens, we shouldn't continue with normal bors logic, otherwise invariants might get broken, and can get e.g. "orphaned" builds (https://github.com/rust-lang/bors/issues/389).

So we need to ideally mark the build status as cancelled first, and also distinguish an error that happens during this from the less important error that happens when external CI workflows cannot be cancelled.

While I was changing this, I also unified code for cancelling auto builds, and realized that we should not delete cancelled auto builds from PRs. Bors has to be able to robustly handle auto builds *attached to PRs*, even if they are failed, cancelled or timed out. So there's no need to actually delete these builds from the DB, as we don't do that anywhere else, e.g. when we cancel try builds, so it was not consistent.

Closes: https://github.com/rust-lang/bors/issues/389

r? @Sakib25800