### PR TITLE
Unify logic for unapproving a DB

### DIFF
--- a/src/bors/handlers/review.rs
+++ b/src/bors/handlers/review.rs
@@ -9,10 +9,10 @@ use crate::bors::comment::{
     approve_blocking_labels_present, approve_non_open_pr_comment, approve_wip_title,
     approved_comment, delegate_comment, delegate_try_builds_comment, unapprove_non_open_pr_comment,
 };
-use crate::bors::handlers::has_permission;
 use crate::bors::handlers::labels::handle_label_trigger;
 use crate::bors::handlers::trybuild::cancel_build_workflows;
 use crate::bors::handlers::{PullRequestData, deny_request};
+use crate::bors::handlers::{has_permission, unapprove_pr};
 use crate::bors::merge_queue::MergeQueueSender;
 use crate::bors::{Comment, PullRequestStatus};
 use crate::database::DelegatedPermission;
@@ -172,8 +172,7 @@ pub(super) async fn command_unapprove(
         };
     }
 
-    db.unapprove(&pr.db).await?;
-    handle_label_trigger(&repo_state, pr.number(), LabelTrigger::Unapproved).await?;
+    unapprove_pr(&repo_state, &db, &pr.db).await?;
     notify_of_unapproval(&repo_state, pr, auto_build_cancel_message).await?;
 
     Ok(())


### PR DESCRIPTION
Just to make sure that we don't forget to set the corresponding label(s).