### PR TITLE
Centralize comment constructor

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -148,7 +148,7 @@ After that, you should commit the changes to the `.sqlx` directory.
 When modifying commands, make sure to update both:
 
 1. The help page in `templates/help.html`
-2. The `@bors help` command output in `src/bors/handlers/help.rs`
+2. The `@bors help` command output in `src/bors/comment.rs`
 
 ## Logs in tests
 By default, logs are disabled in tests. To enable them, add `#[traced_test]`

--- a/src/bors/command/mod.rs
+++ b/src/bors/command/mod.rs
@@ -88,7 +88,7 @@ impl FromStr for RollupMode {
 ///
 /// When modifying commands, remember to also update:
 /// - `templates/help.html` (HTML help page)
-/// - `src/bors/handlers/help.rs` (the `@bors help` command output)
+/// - [`crate::bors::comment::help_comment`] (the `@bors help` command output)
 #[derive(Debug, PartialEq)]
 pub enum BorsCommand {
     /// Approve a commit.

--- a/src/bors/comment.rs
+++ b/src/bors/comment.rs
@@ -301,12 +301,11 @@ pub fn try_build_cancelled_with_failed_workflow_cancel_comment() -> Comment {
 }
 
 pub fn try_build_cancelled_comment(workflow_urls: impl Iterator<Item = String>) -> Comment {
-    let mut try_build_cancelled_comment =
-        r#"Try build cancelled. Cancelled workflows:"#.to_string();
+    let mut comment = String::from("Try build cancelled. Cancelled workflows:");
     for url in workflow_urls {
-        try_build_cancelled_comment += format!("\n- {}", url).as_str();
+        write!(comment, "\n- {}", url).unwrap();
     }
-    Comment::new(try_build_cancelled_comment)
+    Comment::new(comment)
 }
 
 pub fn build_failed_comment(
@@ -511,7 +510,6 @@ fn list_workflows_status(workflows: &[WorkflowModel]) -> String {
                 }
             )
         })
-        .collect::<Vec<_>>()
         .join("\n")
 }
 
@@ -531,7 +529,6 @@ pub fn auto_build_succeeded_comment(
     let urls = workflows
         .iter()
         .map(|w| format!("[{}]({})", w.name, w.url))
-        .collect::<Vec<_>>()
         .join(", ");
 
     Comment::new(format!(

--- a/src/bors/handlers/help.rs
+++ b/src/bors/handlers/help.rs
@@ -1,6 +1,5 @@
-use crate::bors::Comment;
 use crate::bors::RepositoryState;
-use crate::bors::command::BorsCommand;
+use crate::bors::comment::help_comment;
 use crate::github::PullRequestNumber;
 use std::sync::Arc;
 
@@ -8,73 +7,8 @@ pub(super) async fn command_help(
     repo: Arc<RepositoryState>,
     pr_number: PullRequestNumber,
 ) -> anyhow::Result<()> {
-    let help = format_help();
-
-    repo.client
-        .post_comment(pr_number, Comment::new(help.to_string()))
-        .await?;
+    repo.client.post_comment(pr_number, help_comment()).await?;
     Ok(())
-}
-
-/// Format the bors command help in Markdown format.
-fn format_help() -> &'static str {
-    // The help is generated manually to have a nicer structure.
-    // We do a no-op destructuring of `BorsCommand` to make it harder to modify help in case new
-    // commands are added though.
-    match BorsCommand::Ping {
-        BorsCommand::Approve {
-            approver: _,
-            rollup: _,
-            priority: _,
-        } => {}
-        BorsCommand::Unapprove => {}
-        BorsCommand::Help => {}
-        BorsCommand::Ping => {}
-        BorsCommand::Try { parent: _, jobs: _ } => {}
-        BorsCommand::TryCancel => {}
-        BorsCommand::SetPriority(_) => {}
-        BorsCommand::Info => {}
-        BorsCommand::SetDelegate(_) => {}
-        BorsCommand::Undelegate => {}
-        BorsCommand::SetRollupMode(_) => {}
-        BorsCommand::OpenTree => {}
-        BorsCommand::TreeClosed(_) => {}
-    }
-
-    r#"
-You can use the following commands:
-
-## PR management
-- `r+ [p=<priority>] [rollup=<never|iffy|maybe|always>]`: Approve this PR on your behalf
-    - Optionally, you can specify the `<priority>` of the PR and if it is eligible for rollups (`<rollup>)`.
-- `r=<user> [p=<priority>] [rollup=<never|iffy|maybe|always>]`: Approve this PR on behalf of `<user>`
-    - Optionally, you can specify the `<priority>` of the PR and if it is eligible for rollups (`<rollup>)`.
-    - You can pass a comma-separated list of GitHub usernames.
-- `r-`: Unapprove this PR
-- `p=<priority>` or `priority=<priority>`: Set the priority of this PR
-- `rollup=<never|iffy|maybe|always>`: Set the rollup status of the PR
-- `rollup`: Short for `rollup=always`
-- `rollup-`: Short for `rollup=maybe`
-- `delegate=<try|review>`: Delegate permissions for running try builds or approving to the PR author
-    - `try` allows the PR author to start try builds.
-    - `review` allows the PR author to both start try builds and approve the PR.
-- `delegate+`: Delegate approval permissions to the PR author
-    - Shortcut for `delegate=review`
-- `delegate-`: Remove any previously granted permission delegation
-- `try [parent=<parent>] [jobs=<jobs>]`: Start a try build.
-    - Optionally, you can specify a `<parent>` SHA with which will the PR be merged. You can specify `parent=last` to use the same parent SHA as the previous try build.
-    - Optionally, you can select a comma-separated list of CI `<jobs>` to run in the try build.
-- `try cancel`: Cancel a running try build
-- `info`: Get information about the current PR
-
-## Repository management
-- `treeclosed=<priority>`: Close the tree for PRs with priority less than `<priority>`
-- `treeclosed-` or `treeopen`: Open the repository tree for merging
-
-## Meta commands
-- `ping`: Check if the bot is alive
-- `help`: Print this help message
-"#
 }
 
 #[cfg(test)]

--- a/src/bors/handlers/ping.rs
+++ b/src/bors/handlers/ping.rs
@@ -1,16 +1,14 @@
 use std::sync::Arc;
 
-use crate::bors::Comment;
 use crate::bors::RepositoryState;
+use crate::bors::comment::pong_message;
 use crate::github::PullRequestNumber;
 
 pub(super) async fn command_ping(
     repo: Arc<RepositoryState>,
     pr_number: PullRequestNumber,
 ) -> anyhow::Result<()> {
-    repo.client
-        .post_comment(pr_number, Comment::new("Pong 🏓!".to_string()))
-        .await?;
+    repo.client.post_comment(pr_number, pong_message()).await?;
     Ok(())
 }
 


### PR DESCRIPTION
@Kobzol proposed to attach `CommentTag` directly to the `Comment` struct ([comment](https://github.com/rust-lang/bors/pull/397#discussion_r2239766706)), so we need to give every comment a unique tag.

To make this easier, this PR makes `Comment::new` private, so that you cannot construct arbitary comments anywhere throughout the codebase. There are also some improvements:

- Make `Comment::new` accept `impl Into<String>`
- Remove duplicate `use std::dmt::Write`
- Use `itertools::Itertools::join` instead of `.collect::<Vec<_>>().join`

Then we can give every comment a tag with their constructor's name, either this or next PR.