### PR TITLE
Synchronize labels with homu

### DIFF
--- a/rust-bors.example.toml
+++ b/rust-bors.example.toml
@@ -10,14 +10,15 @@ merge_queue_enabled = true
 # Labels that should be set on a PR after an event happens.
 # "+<label>" adds the label, while "-<label>" removes the label after the event.
 # Supported events:
-# - try: Try build has started
-# - try_succeeded: Try build has finished
+# - approved: A PR was approved
+# - unapproved: A PR was unapproved
 # - try_failed: Try build has failed
+# - auto_build_succeeded: Auto build has succeeded, the PR was merged
+# - auto_build_failed: Auto build has failed
 # (Optional)
 [labels]
 approved = ["+approved"]
-try = ["+foo", "-bar"]
-try_succeeded = ["+foobar", "+foo", "+baz"]
+unapproved = ["-approved"]
 try_failed = []
 auto_build_succeeded = ["+foo", "+bar"]
 auto_build_failed = ["+foo", "+bar"]

--- a/src/config.rs
+++ b/src/config.rs
@@ -70,8 +70,6 @@ where
     enum Trigger {
         Approved,
         Unapproved,
-        Try,
-        TrySucceeded,
         TryFailed,
         AutoBuildSucceeded,
         AutoBuildFailed,
@@ -82,8 +80,6 @@ where
             match value {
                 Trigger::Approved => LabelTrigger::Approved,
                 Trigger::Unapproved => LabelTrigger::Unapproved,
-                Trigger::Try => LabelTrigger::TryBuildStarted,
-                Trigger::TrySucceeded => LabelTrigger::TryBuildSucceeded,
                 Trigger::TryFailed => LabelTrigger::TryBuildFailed,
                 Trigger::AutoBuildSucceeded => LabelTrigger::AutoBuildSucceeded,
                 Trigger::AutoBuildFailed => LabelTrigger::AutoBuildFailed,
@@ -211,8 +207,7 @@ mod tests {
     fn deserialize_labels() {
         let content = r#"[labels]
 approved = ["+approved"]
-try = ["+foo", "-bar"]
-try_succeeded = ["+foobar", "+foo", "+baz"]
+unapproved = ["-approved"]
 try_failed = []
 auto_build_succeeded = ["+foobar", "-foo"]
 auto_build_failed = ["+bar", "+baz"]
@@ -228,25 +223,6 @@ auto_build_failed = ["+bar", "+baz"]
             Unapproved: [
                 Remove(
                     "approved",
-                ),
-            ],
-            TryBuildStarted: [
-                Add(
-                    "foo",
-                ),
-                Remove(
-                    "bar",
-                ),
-            ],
-            TryBuildSucceeded: [
-                Add(
-                    "foobar",
-                ),
-                Add(
-                    "foo",
-                ),
-                Add(
-                    "baz",
                 ),
             ],
             TryBuildFailed: [],
@@ -274,7 +250,7 @@ auto_build_failed = ["+bar", "+baz"]
     #[should_panic(expected = "Label modification must start with `+` or `-`")]
     fn deserialize_labels_missing_prefix() {
         let content = r#"[labels]
-try = ["foo"]
+approved = ["foo"]
 "#;
         load_config(content);
     }

--- a/src/github/labels.rs
+++ b/src/github/labels.rs
@@ -1,12 +1,15 @@
 /// An event that may trigger some modifications of labels on a PR.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub enum LabelTrigger {
+    /// A PR was approved with r+.
     Approved,
+    /// A PR was unapproved, either with r- or it was automatically unapproved for some reason.
     Unapproved,
-    TryBuildStarted,
-    TryBuildSucceeded,
+    /// A try build has failed.
     TryBuildFailed,
+    /// An auto build triggered from the merge queue has succeeded and the PR was merged.
     AutoBuildSucceeded,
+    /// An auto build triggered from the merge queue has failed.
     AutoBuildFailed,
 }
 


### PR DESCRIPTION
We had some labels that were currently unused by homu. This PR removes those, and documents the existing labels.

If we find a use-case for more labels, we should add them on demand.