### PR TITLE
Refeactor merge queue tests and change how the merge queue is executed

### DIFF
--- a/src/bors/event.rs
+++ b/src/bors/event.rs
@@ -72,7 +72,7 @@ pub enum BorsGlobalEvent {
     RefreshPullRequestMergeability,
     /// Periodic event that serves for synchronizing PR state.
     RefreshPullRequestState,
-    /// Process the merge queue.
+    /// Try to process the merge queue.
     ProcessMergeQueue,
 }
 

--- a/src/bors/handlers/info.rs
+++ b/src/bors/handlers/info.rs
@@ -109,8 +109,7 @@ mod tests {
     #[sqlx::test]
     async fn info_for_approved_pr(pool: sqlx::PgPool) {
         run_test(pool, async |tester: &mut BorsTester| {
-            tester.post_comment("@bors r+").await?;
-            tester.expect_comments((), 1).await;
+            tester.approve(()).await?;
 
             tester.post_comment("@bors info").await?;
             insta::assert_snapshot!(

--- a/src/bors/handlers/mod.rs
+++ b/src/bors/handlers/mod.rs
@@ -300,7 +300,7 @@ pub async fn handle_bors_global_event(
             crate::bors::WAIT_FOR_PR_STATUS_REFRESH.mark();
         }
         BorsGlobalEvent::ProcessMergeQueue => {
-            merge_queue_tx.trigger().await?;
+            merge_queue_tx.maybe_perform_tick().await?;
         }
     }
     Ok(())

--- a/src/bors/handlers/mod.rs
+++ b/src/bors/handlers/mod.rs
@@ -122,6 +122,9 @@ pub async fn handle_bors_repository_event(
             handle_workflow_completed(repo, db, payload, &merge_queue_tx)
                 .instrument(span.clone())
                 .await?;
+
+            #[cfg(test)]
+            super::WAIT_FOR_WORKFLOW_COMPLETED.mark();
         }
         BorsRepositoryEvent::PullRequestEdited(payload) => {
             let span =

--- a/src/bors/handlers/review.rs
+++ b/src/bors/handlers/review.rs
@@ -493,8 +493,7 @@ mod tests {
     #[sqlx::test]
     async fn unapprove_lacking_permissions(pool: sqlx::PgPool) {
         run_test(pool, async |tester: &mut BorsTester| {
-            tester.post_comment("@bors r+").await?;
-            tester.expect_comments((), 1).await;
+            tester.approve(()).await?;
             tester
                 .post_comment(Comment::from("@bors r-").with_author(User::unprivileged()))
                 .await?;
@@ -515,8 +514,7 @@ mod tests {
     #[sqlx::test]
     async fn unapprove_merged_pr(pool: sqlx::PgPool) {
         run_test(pool, async |tester: &mut BorsTester| {
-            tester.post_comment("@bors r+").await?;
-            tester.expect_comments((), 1).await;
+            tester.approve(()).await?;
             tester.set_pr_status_closed(()).await?;
             tester.post_comment("@bors r-").await?;
             insta::assert_snapshot!(
@@ -581,8 +579,7 @@ mod tests {
             tester.post_comment("@bors p=5").await?;
             tester.wait_for_pr((), |pr| pr.priority == Some(5)).await?;
 
-            tester.post_comment("@bors r+").await?;
-            tester.expect_comments((), 1).await;
+            tester.approve(()).await?;
 
             tester.get_pr_copy(()).await.expect_priority(Some(5));
 
@@ -706,8 +703,7 @@ mod tests {
                     .await?;
                 tester.expect_comments((), 1).await;
 
-                tester.post_comment("@bors r+").await?;
-                tester.expect_comments((), 1).await;
+                tester.approve(()).await?;
 
                 tester
                     .get_pr_copy(())
@@ -830,8 +826,7 @@ mod tests {
                     .await?;
                 tester.expect_comments((), 1).await;
 
-                tester.post_comment("@bors r+").await?;
-                tester.expect_comments((), 1).await;
+                tester.approve(()).await?;
                 tester
                     .get_pr_copy(())
                     .await
@@ -1029,8 +1024,7 @@ mod tests {
                 .wait_for_pr((), |pr| pr.rollup == Some(RollupMode::Always))
                 .await?;
 
-            tester.post_comment("@bors r+").await?;
-            tester.expect_comments((), 1).await;
+            tester.approve(()).await?;
 
             tester
                 .get_pr_copy(())
@@ -1069,8 +1063,7 @@ mod tests {
     async fn approve_store_sha(pool: sqlx::PgPool) {
         run_test(pool, async |tester: &mut BorsTester| {
             let pr = tester.get_pr_copy(()).await.get_gh_pr();
-            tester.post_comment("@bors r+").await?;
-            tester.expect_comments((), 1).await;
+            tester.approve(()).await?;
 
             tester
                 .get_pr_copy(())
@@ -1086,8 +1079,7 @@ mod tests {
     async fn reapproved_pr_uses_latest_sha(pool: sqlx::PgPool) {
         run_test(pool, async |tester: &mut BorsTester| {
             let pr = tester.get_pr_copy(()).await.get_gh_pr();
-            tester.post_comment("@bors r+").await?;
-            tester.expect_comments((), 1).await;
+            tester.approve(()).await?;
 
             tester
                 .get_pr_copy(())
@@ -1100,8 +1092,7 @@ mod tests {
 
             tester.expect_comments((), 1).await;
 
-            tester.post_comment("@bors r+").await?;
-            tester.expect_comments((), 1).await;
+            tester.approve(()).await?;
 
             tester
                 .get_pr_copy(())
@@ -1326,8 +1317,9 @@ labels_blocking_approval = ["proposed-final-comment-period", "final-comment-peri
     #[sqlx::test]
     async fn unapprove_running_auto_build_pr_comment(pool: sqlx::PgPool) {
         run_test(pool, async |tester: &mut BorsTester| {
+            tester.approve(()).await?;
             tester.start_auto_build(()).await?;
-            tester.wait_for_pr((), |pr| pr.auto_build.is_some()).await?;
+            tester.get_pr_copy(()).await.expect_auto_build(|_| true);
             tester.workflow_start(tester.auto_branch().await).await?;
             tester.post_comment("@bors r-").await?;
             insta::assert_snapshot!(tester.get_comment_text(()).await?, @r"
@@ -1345,28 +1337,32 @@ labels_blocking_approval = ["proposed-final-comment-period", "final-comment-peri
     #[sqlx::test]
     async fn unapprove_running_auto_build_pr_failed_comment(pool: sqlx::PgPool) {
         run_test(pool, async |tester: &mut BorsTester| {
-                tester.modify_repo(&default_repo_name(), |pr| pr.workflow_cancel_error = true).await;
-                tester.start_auto_build(()).await?;
-                tester
-                    .wait_for_pr((), |pr| pr.auto_build.is_some())
-                    .await?;
-                tester.workflow_start(tester.auto_branch().await).await?;
-                tester.post_comment("@bors r-").await?;
-                insta::assert_snapshot!(tester.get_comment_text(()).await?, @r"
-                Commit pr-1-sha has been unapproved.
+            tester
+                .modify_repo(&default_repo_name(), |pr| pr.workflow_cancel_error = true)
+                .await;
 
-                Auto build cancelled due to unapproval. It was not possible to cancel some workflows.
-                ");
-                Ok(())
-            })
-            .await;
+            tester.approve(()).await?;
+            tester.start_auto_build(()).await?;
+            tester.get_pr_copy(()).await.expect_auto_build(|_| true);
+            tester.workflow_start(tester.auto_branch().await).await?;
+            tester.post_comment("@bors r-").await?;
+            insta::assert_snapshot!(tester.get_comment_text(()).await?, @r"
+            Commit pr-1-sha has been unapproved.
+
+            Auto build cancelled due to unapproval. It was not possible to cancel some workflows.
+            ");
+            Ok(())
+        })
+        .await;
     }
 
     #[sqlx::test]
     async fn unapprove_running_auto_build_updates_check_run(pool: sqlx::PgPool) {
         run_test(pool, async |tester: &mut BorsTester| {
+            tester.approve(()).await?;
             tester.start_auto_build(()).await?;
-            tester.wait_for_pr((), |pr| pr.auto_build.is_some()).await?;
+            tester.get_pr_copy(()).await.expect_auto_build(|_| true);
+
             tester.workflow_start(tester.auto_branch().await).await?;
             tester.post_comment("@bors r-").await?;
             tester.expect_comments((), 1).await;

--- a/src/bors/handlers/review.rs
+++ b/src/bors/handlers/review.rs
@@ -61,7 +61,7 @@ pub(super) async fn command_approve(
     db.approve(pr.db, approval_info, priority, rollup).await?;
     handle_label_trigger(&repo_state, pr.number(), LabelTrigger::Approved).await?;
 
-    merge_queue_tx.trigger().await?;
+    merge_queue_tx.notify().await?;
     notify_of_approval(ctx, &repo_state, pr, approver.as_str()).await
 }
 
@@ -248,7 +248,7 @@ pub(super) async fn command_close_tree(
     )
     .await?;
 
-    merge_queue_tx.trigger().await?;
+    merge_queue_tx.notify().await?;
     notify_of_tree_closed(&repo_state, pr.number(), priority).await
 }
 
@@ -267,7 +267,7 @@ pub(super) async fn command_open_tree(
     db.upsert_repository(repo_state.repository(), TreeState::Open)
         .await?;
 
-    merge_queue_tx.trigger().await?;
+    merge_queue_tx.notify().await?;
     notify_of_tree_open(&repo_state, pr.number()).await
 }
 

--- a/src/bors/handlers/trybuild.rs
+++ b/src/bors/handlers/trybuild.rs
@@ -584,7 +584,6 @@ try-job: Bar
     #[sqlx::test]
     async fn try_merge_conflict(pool: sqlx::PgPool) {
         run_test(pool, async |tester: &mut BorsTester| {
-            tester.create_branch(TRY_MERGE_BRANCH_NAME).await;
             tester.modify_branch(TRY_MERGE_BRANCH_NAME, |branch| branch.merge_conflict = true).await;
             tester
                 .post_comment("@bors try")

--- a/src/bors/handlers/workflow.rs
+++ b/src/bors/handlers/workflow.rs
@@ -245,7 +245,7 @@ async fn maybe_complete_build(
 
     // Trigger merge queue when an auto build completes
     if build_type == BuildType::Auto {
-        merge_queue_tx.trigger().await?;
+        merge_queue_tx.notify().await?;
     }
 
     db_workflow_runs.sort_by(|a, b| a.name.cmp(&b.name));
@@ -635,6 +635,7 @@ mod tests {
             tester
                 .workflow_full_success(tester.auto_branch().await)
                 .await?;
+            tester.process_merge_queue().await;
             tester.expect_comments((), 1).await;
             tester
                 .expect_check_run(
@@ -670,6 +671,7 @@ auto_build_succeeded = ["+foo", "+bar", "-baz"]
                 tester
                     .workflow_full_success(tester.auto_branch().await)
                     .await?;
+                tester.process_merge_queue().await;
                 tester.expect_comments((), 1).await;
 
                 tester

--- a/src/bors/merge_queue.rs
+++ b/src/bors/merge_queue.rs
@@ -341,7 +341,7 @@ async fn start_auto_build(
 }
 
 pub fn start_merge_queue(ctx: Arc<BorsContext>) -> (MergeQueueSender, impl Future<Output = ()>) {
-    let (tx, mut rx) = mpsc::channel::<MergeQueueEvent>(10);
+    let (tx, mut rx) = mpsc::channel::<MergeQueueEvent>(1024);
     let sender = MergeQueueSender { inner: tx };
 
     let fut = async move {

--- a/src/bors/merge_queue.rs
+++ b/src/bors/merge_queue.rs
@@ -183,7 +183,6 @@ async fn process_repository(repo: &RepositoryState, ctx: &BorsContext) -> anyhow
                     &commit_sha,
                     &pr.base_branch,
                 );
-                repo.client.post_comment(pr.number, comment).await?;
 
                 if let Err(error) = repo
                     .client
@@ -217,6 +216,8 @@ async fn process_repository(repo: &RepositoryState, ctx: &BorsContext) -> anyhow
                     ctx.db
                         .set_pr_status(&pr.repository, pr.number, PullRequestStatus::Merged)
                         .await?;
+
+                    repo.client.post_comment(pr.number, comment).await?;
                 }
 
                 // Break to give GitHub time to update the base branch.

--- a/src/bors/mod.rs
+++ b/src/bors/mod.rs
@@ -44,6 +44,9 @@ pub static WAIT_FOR_PR_STATUS_REFRESH: TestSyncMarker = TestSyncMarker::new();
 pub static WAIT_FOR_WORKFLOW_STARTED: TestSyncMarker = TestSyncMarker::new();
 
 #[cfg(test)]
+pub static WAIT_FOR_WORKFLOW_COMPLETED: TestSyncMarker = TestSyncMarker::new();
+
+#[cfg(test)]
 pub static WAIT_FOR_MERGE_QUEUE: TestSyncMarker = TestSyncMarker::new();
 
 /// Corresponds to a single execution of a workflow.

--- a/src/github/server.rs
+++ b/src/github/server.rs
@@ -212,6 +212,7 @@ pub fn create_bors_process(
     ctx: BorsContext,
     gh_client: Octocrab,
     team_api: TeamApiClient,
+    merge_queue_max_interval: chrono::Duration,
 ) -> BorsProcess {
     let (repository_tx, repository_rx) = mpsc::channel::<BorsRepositoryEvent>(1024);
     let (global_tx, global_rx) = mpsc::channel::<BorsGlobalEvent>(1024);
@@ -220,7 +221,8 @@ pub fn create_bors_process(
 
     let ctx = Arc::new(ctx);
 
-    let (merge_queue_tx, merge_queue_fut) = start_merge_queue(ctx.clone());
+    let (merge_queue_tx, merge_queue_fut) =
+        start_merge_queue(ctx.clone(), merge_queue_max_interval);
     let merge_queue_tx2 = merge_queue_tx.clone();
 
     let service = async move {

--- a/src/tests/mocks/mod.rs
+++ b/src/tests/mocks/mod.rs
@@ -1,7 +1,3 @@
-use std::collections::HashMap;
-use std::ops::Deref;
-use std::sync::Arc;
-
 use crate::TeamApiClient;
 use crate::github::GithubRepoName;
 use crate::github::api::client::HideCommentReason;
@@ -18,7 +14,6 @@ use std::collections::HashMap;
 use std::ops::Deref;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::time::error::Elapsed;
 use wiremock::matchers::{method, path_regex};
 use wiremock::{Mock, Request, ResponseTemplate};
 

--- a/src/tests/mocks/pull_request.rs
+++ b/src/tests/mocks/pull_request.rs
@@ -13,7 +13,7 @@ use octocrab::models::LabelId;
 use octocrab::models::pulls::{MergeableState as OctocrabMergeableState, MergeableState};
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
-use std::fmt::{Display, Formatter, Write};
+use std::fmt::{Display, Formatter};
 use std::sync::Arc;
 use std::time::SystemTime;
 use tokio::sync::mpsc::{Receiver, Sender};

--- a/src/tests/mocks/repository.rs
+++ b/src/tests/mocks/repository.rs
@@ -64,7 +64,7 @@ impl BranchPushBehaviour {
         }
     }
 
-    pub fn fail_after(count: u64, error_type: BranchPushError) -> Self {
+    pub fn fail_n_times(error_type: BranchPushError, count: u64) -> Self {
         Self {
             error: NonZeroU64::new(count).map(|remaining| (error_type, remaining)),
         }

--- a/src/tests/mocks/repository.rs
+++ b/src/tests/mocks/repository.rs
@@ -201,6 +201,7 @@ impl Default for Repo {
     fn default() -> Self {
         let config = r#"
 timeout = 3600
+merge_queue_enabled = true
 
 # Set labels on PR approvals
 [labels]


### PR DESCRIPTION
I went through the merge queue tests to examine what they are doing. While doing that, I found a lot of suboptiomal things in the test suite API, particularly around error reporting and error handling. I ran into many deadlocks and timeouts, so I tried to make the errors from the test suite be as nice as possible.

Apart from refactoring tests, I also changed how the merge queue is executed. Now the queue is checked every 5 seconds. If there was an interesting event in the meantime, or at least 30s has elapsed since the last tick, a new tick is executed. This provides an upper bound on the merge queue execution (it won't run more than once per 5 seconds), which is useful to avoid overloading the network APIs and to handle transient errors robustly.

It is also better for tests. Before, the merge queue was triggered kind of randomly by various events in tests, which wasn't ideal. Now if we don't call `process_merge_queue` in tests, the queue won't run.

@Sakib25800 Let me know what do you think!