### PR TITLE
Add `@bors retry`

### DIFF
--- a/.sqlx/query-aa9f3483df0d2ab722603300368e19a9ae88785203c49bc4622a704d9bef220d.json
+++ b/.sqlx/query-aa9f3483df0d2ab722603300368e19a9ae88785203c49bc4622a704d9bef220d.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE pull_request SET auto_build_id = NULL WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "aa9f3483df0d2ab722603300368e19a9ae88785203c49bc4622a704d9bef220d"
+}

--- a/src/bors/command/mod.rs
+++ b/src/bors/command/mod.rs
@@ -129,4 +129,6 @@ pub enum BorsCommand {
     OpenTree,
     /// Set the tree closed with a priority level.
     TreeClosed(Priority),
+    /// Retry a previously run (auto) build.
+    Retry,
 }

--- a/src/bors/command/parser.rs
+++ b/src/bors/command/parser.rs
@@ -142,6 +142,7 @@ const DEFAULT_PARSERS: &[ParserFn] = &[
     parser_info,
     parser_help,
     parser_ping,
+    parser_retry,
     parser_tree_ops,
 ];
 
@@ -406,6 +407,15 @@ fn parser_rollup(command: &CommandPart<'_>, _parts: &[CommandPart<'_>]) -> Parse
 fn parser_info(command: &CommandPart<'_>, _parts: &[CommandPart<'_>]) -> ParseResult {
     if *command == CommandPart::Bare("info") {
         Some(Ok(BorsCommand::Info))
+    } else {
+        None
+    }
+}
+
+/// Parses `@bors retry`
+fn parser_retry(command: &CommandPart<'_>, _parts: &[CommandPart<'_>]) -> ParseResult {
+    if let CommandPart::Bare("retry") = command {
+        Some(Ok(BorsCommand::Retry))
     } else {
         None
     }
@@ -1193,6 +1203,20 @@ for the crater",
         let cmds = parse_commands("@bors info a");
         assert_eq!(cmds.len(), 1);
         assert!(matches!(cmds[0], Ok(BorsCommand::Info)));
+    }
+
+    #[test]
+    fn parse_retry() {
+        let cmds = parse_commands("@bors retry");
+        assert_eq!(cmds.len(), 1);
+        assert!(matches!(cmds[0], Ok(BorsCommand::Retry)));
+    }
+
+    #[test]
+    fn parse_retry_unknown_arg() {
+        let cmds = parse_commands("@bors retry xyz");
+        assert_eq!(cmds.len(), 1);
+        assert!(matches!(cmds[0], Ok(BorsCommand::Retry)));
     }
 
     #[test]

--- a/src/bors/command/parser.rs
+++ b/src/bors/command/parser.rs
@@ -168,7 +168,7 @@ fn parse_command(input: &str, parsers: &[ParserFn]) -> ParseResult {
     }
 }
 
-fn parse_parts(input: &str) -> Result<Vec<CommandPart>, CommandParseError> {
+fn parse_parts(input: &str) -> Result<Vec<CommandPart<'_>>, CommandParseError> {
     let mut parts = vec![];
     let mut seen_keys = HashSet::new();
 

--- a/src/bors/handlers/help.rs
+++ b/src/bors/handlers/help.rs
@@ -39,6 +39,7 @@ fn format_help() -> &'static str {
         BorsCommand::SetRollupMode(_) => {}
         BorsCommand::OpenTree => {}
         BorsCommand::TreeClosed(_) => {}
+        BorsCommand::Retry => {}
     }
 
     r#"
@@ -65,6 +66,7 @@ You can use the following commands:
     - Optionally, you can specify a `<parent>` SHA with which will the PR be merged. You can specify `parent=last` to use the same parent SHA as the previous try build.
     - Optionally, you can select a comma-separated list of CI `<jobs>` to run in the try build.
 - `try cancel`: Cancel a running try build
+- `retry`: Retry a previously run (auto) build
 - `info`: Get information about the current PR
 
 ## Repository management
@@ -109,6 +111,7 @@ mod tests {
                 - Optionally, you can specify a `<parent>` SHA with which will the PR be merged. You can specify `parent=last` to use the same parent SHA as the previous try build.
                 - Optionally, you can select a comma-separated list of CI `<jobs>` to run in the try build.
             - `try cancel`: Cancel a running try build
+            - `retry`: Retry a previously run (auto) build
             - `info`: Get information about the current PR
 
             ## Repository management

--- a/src/bors/handlers/retry.rs
+++ b/src/bors/handlers/retry.rs
@@ -1,0 +1,95 @@
+use std::sync::Arc;
+
+use crate::PgDbClient;
+use crate::bors::handlers::{PullRequestData, deny_request, has_permission};
+use crate::bors::merge_queue::MergeQueueSender;
+use crate::bors::{Comment, RepositoryState};
+use crate::github::{GithubUser, PullRequestNumber};
+use crate::permissions::PermissionType;
+
+pub(super) async fn command_retry(
+    repo_state: Arc<RepositoryState>,
+    db: Arc<PgDbClient>,
+    pr: PullRequestData<'_>,
+    author: &GithubUser,
+    merge_queue_tx: &MergeQueueSender,
+) -> anyhow::Result<()> {
+    if !has_permission(&repo_state, author, pr, PermissionType::Try).await? {
+        deny_request(&repo_state, pr.number(), author, PermissionType::Try).await?;
+        return Ok(());
+    }
+
+    let pr_model = pr.db;
+
+    if pr_model.stalled() {
+        db.clear_auto_build(pr_model).await?;
+        merge_queue_tx.notify().await?;
+    } else {
+        notify_of_invalid_retry_state(&repo_state, pr.number()).await?;
+    }
+
+    Ok(())
+}
+
+async fn notify_of_invalid_retry_state(
+    repo: &RepositoryState,
+    pr_number: PullRequestNumber,
+) -> anyhow::Result<()> {
+    repo.client
+        .post_comment(
+            pr_number,
+            Comment::new(":exclamation: This PR must be approved and have a previously failed auto build to be retried".to_string())
+        )
+        .await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tests::{BorsTester, Comment, User, run_test};
+
+    #[sqlx::test]
+    async fn retry_command_insufficient_privileges(pool: sqlx::PgPool) {
+        run_test(pool, async |tester: &mut BorsTester| {
+            tester
+                .post_comment(Comment::from("@bors retry").with_author(User::unprivileged()))
+                .await?;
+            insta::assert_snapshot!(
+                tester.get_comment_text(()).await?,
+                @"@unprivileged-user: :key: Insufficient privileges: not in try users"
+            );
+            Ok(())
+        })
+        .await;
+    }
+
+    #[sqlx::test]
+    async fn retry_invalid_state_error(pool: sqlx::PgPool) {
+        run_test(pool, async |tester: &mut BorsTester| {
+            tester.post_comment(Comment::from("@bors retry")).await?;
+            insta::assert_snapshot!(
+                tester.get_comment_text(()).await?,
+                @":exclamation: This PR must be approved and have a previously failed auto build to be retried"
+            );
+            Ok(())
+        })
+        .await;
+    }
+
+    #[sqlx::test]
+    async fn retry_auto_build(pool: sqlx::PgPool) {
+        run_test(pool, async |tester: &mut BorsTester| {
+            tester.approve(()).await?;
+            tester.start_auto_build(()).await?;
+            tester
+                .workflow_full_failure(tester.auto_branch().await)
+                .await?;
+            tester.expect_comments((), 1).await;
+            tester.post_comment(Comment::from("@bors retry")).await?;
+            tester.process_merge_queue().await;
+            tester.expect_comments((), 1).await;
+            Ok(())
+        })
+        .await;
+    }
+}

--- a/src/database/client.rs
+++ b/src/database/client.rs
@@ -11,7 +11,7 @@ use crate::github::PullRequestNumber;
 use crate::github::{CommitSha, GithubRepoName};
 
 use super::operations::{
-    approve_pull_request, create_build, create_pull_request, create_workflow,
+    approve_pull_request, clear_auto_build, create_build, create_pull_request, create_workflow,
     delegate_pull_request, delete_tagged_bot_comment, find_build, find_pr_by_build,
     get_nonclosed_pull_requests, get_pending_builds, get_prs_with_unknown_mergeability_state,
     get_pull_request, get_repository, get_repository_by_name, get_tagged_bot_comments,
@@ -47,6 +47,10 @@ impl PgDbClient {
     /// Unapprove a pull request and remove its auto build status, if there is any attached.
     pub async fn unapprove(&self, pr: &PullRequestModel) -> anyhow::Result<()> {
         unapprove_pull_request(&self.pool, pr.id).await
+    }
+
+    pub async fn clear_auto_build(&self, pr: &PullRequestModel) -> anyhow::Result<()> {
+        clear_auto_build(&self.pool, pr.id).await
     }
 
     pub async fn set_priority(&self, pr: &PullRequestModel, priority: u32) -> anyhow::Result<()> {

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -381,6 +381,15 @@ impl PullRequestModel {
             ApprovalStatus::NotApproved => None,
         }
     }
+
+    /// Approved but with a failed auto build.
+    pub fn stalled(&self) -> bool {
+        self.is_approved()
+            && self
+                .auto_build
+                .as_ref()
+                .is_some_and(|build| build.status.is_failure())
+    }
 }
 
 /// Describes whether a workflow is a Github Actions workflow or if it's a job from some external

--- a/src/database/operations.rs
+++ b/src/database/operations.rs
@@ -1092,3 +1092,19 @@ pub(crate) async fn delete_tagged_bot_comment(
     })
     .await
 }
+
+pub(crate) async fn clear_auto_build(
+    executor: impl PgExecutor<'_>,
+    pr_id: i32,
+) -> anyhow::Result<()> {
+    measure_db_query("clear_pr_builds", || async {
+        sqlx::query!(
+            "UPDATE pull_request SET auto_build_id = NULL WHERE id = $1",
+            pr_id
+        )
+        .execute(executor)
+        .await?;
+        Ok(())
+    })
+    .await
+}

--- a/src/github/server.rs
+++ b/src/github/server.rs
@@ -103,10 +103,10 @@ async fn health_handler() -> impl IntoResponse {
 
 async fn index_handler(State(state): State<ServerStateRef>) -> impl IntoResponse {
     // If we manage exactly one repo, redirect to its queue page directly
-    if let Some(repo_name) = state.repositories.keys().next() {
-        if state.repositories.len() == 1 {
-            return Redirect::temporary(&format!("/queue/{}", repo_name.name)).into_response();
-        }
+    if let Some(repo_name) = state.repositories.keys().next()
+        && state.repositories.len() == 1
+    {
+        return Redirect::temporary(&format!("/queue/{}", repo_name.name)).into_response();
     }
     help_handler(State(state)).await.into_response()
 }

--- a/src/utils/text.rs
+++ b/src/utils/text.rs
@@ -15,7 +15,7 @@ pub fn suppress_github_mentions(text: &str) -> String {
 }
 
 /// Pluralizes a piece of text.
-pub fn pluralize(base: &str, count: usize) -> Cow<str> {
+pub fn pluralize(base: &str, count: usize) -> Cow<'_, str> {
     if count == 1 {
         base.into()
     } else {

--- a/templates/help.html
+++ b/templates/help.html
@@ -165,6 +165,11 @@
                     <td>review</td>
                     <td>Close the tree for PRs with priority less than <code>&lt;priority&gt;</code></td>
                 </tr>
+                <tr>
+                    <td><code>retry</code></td>
+                    <td>review</td>
+                    <td>Retry a previously run (auto) build</td>
+                </tr>
             </tbody>
         </table>
     </div>


### PR DESCRIPTION
If PR is approved and there is a previously failed auto build, it will be wiped so that the merge queue can pick it up again, 
else it will send an error comment. 

I believe the old bors had the ability to retry try builds as well, so this is a difference that should be noted. However, I've seen no one really use it for retrying try builds. 