### PR TITLE
Add links to GitHub on Bors Help and Queue Pages

### DIFF
--- a/templates/help.html
+++ b/templates/help.html
@@ -181,5 +181,9 @@
         <li><code>{{ cmd_prefix }} try parent=last</code>: Start a try build using the same parent as the last try</li>
         <li><code>{{ cmd_prefix }} try @rust-timer queue</code>: Short-hand for compile-perf benchmarking of PRs</li>
     </ul>
+
+    <div style="text-align: center; margin-top: 1em;">
+        <a href="https://github.com/rust-lang/bors">Contribute on GitHub</a>
+    </div>
 </main>
 {% endblock %}

--- a/templates/queue.html
+++ b/templates/queue.html
@@ -95,5 +95,9 @@
     {% endfor %}
     </tbody>
   </table>
+
+  <div style="text-align: center; margin-top: 1em;">
+    <a href="https://github.com/rust-lang/bors">Contribute on GitHub</a>
+  </div>
 </main>
 {% endblock %}


### PR DESCRIPTION
This resolves #409.

"`Contribute on GitHub`" links at the bottom of the help as well as queue template were added.