### PR TITLE
Reduce space taken by workflow URLs in try build started comment

### DIFF
--- a/src/bors/comment.rs
+++ b/src/bors/comment.rs
@@ -198,11 +198,14 @@ pub fn try_build_started_comment(
     Comment::new(msg)
 }
 
-pub fn append_workflow_links_to_comment(comment_content: &mut String, workflow_links: Vec<String>) {
-    comment_content.push_str("\n**Workflows**:\n\n");
-
-    for link in workflow_links {
-        comment_content.push_str(&format!("- {link}\n"));
+pub fn append_workflow_links_to_comment(comment_content: &mut String, workflow_urls: Vec<String>) {
+    if workflow_urls.len() == 1 {
+        comment_content.push_str(&format!("\n**Workflow**: {}", workflow_urls[0]));
+    } else {
+        comment_content.push_str("\n**Workflows**:\n\n");
+        for url in workflow_urls {
+            comment_content.push_str(&format!("- {url}\n"));
+        }
     }
 }
 

--- a/src/bors/handlers/trybuild.rs
+++ b/src/bors/handlers/trybuild.rs
@@ -1104,9 +1104,7 @@ try_failed = ["+foo", "+bar", "-baz"]
 
             To cancel the try build, run the command `@bors try cancel`.
 
-            **Workflows**:
-
-            - https://github.com/rust-lang/borstest/actions/runs/1
+            **Workflow**: https://github.com/rust-lang/borstest/actions/runs/1
             ");
 
             Ok(())

--- a/src/bors/handlers/workflow.rs
+++ b/src/bors/handlers/workflow.rs
@@ -95,16 +95,18 @@ async fn add_workflow_links_to_try_build_start_comment(
 
     let workflows = db.get_workflow_urls_for_build(build).await?;
 
-    let mut comment_content = repo
-        .client
-        .get_comment_content(&try_build_comment.node_id)
-        .await?;
+    if !workflows.is_empty() {
+        let mut comment_content = repo
+            .client
+            .get_comment_content(&try_build_comment.node_id)
+            .await?;
 
-    append_workflow_links_to_comment(&mut comment_content, workflows);
+        append_workflow_links_to_comment(&mut comment_content, workflows);
 
-    repo.client
-        .update_comment_content(&try_build_comment.node_id, &comment_content)
-        .await?;
+        repo.client
+            .update_comment_content(&try_build_comment.node_id, &comment_content)
+            .await?;
+    }
 
     Ok(())
 }


### PR DESCRIPTION
It was making try build started comments unnecessarily [large](https://github.com/rust-lang/rust/pull/146595#issuecomment-3334748444).