### PR TITLE
Fix example config file

### DIFF
--- a/rust-bors.example.toml
+++ b/rust-bors.example.toml
@@ -7,6 +7,10 @@ timeout = 3600
 # (Optional, defaults to false)
 merge_queue_enabled = true
 
+# Labels that will block approval when present on a PR
+# (Optional)
+labels_blocking_approval = ["final-comment-period", "proposed-final-comment-period"]
+
 # Labels that should be set on a PR after an event happens.
 # "+<label>" adds the label, while "-<label>" removes the label after the event.
 # Supported events:
@@ -22,7 +26,3 @@ unapproved = ["-approved"]
 try_failed = []
 auto_build_succeeded = ["+foo", "+bar"]
 auto_build_failed = ["+foo", "+bar"]
-
-# Labels that will block approval when present on a PR
-# (Optional)
-labels_blocking_approval = ["final-comment-period", "proposed-final-comment-period"]


### PR DESCRIPTION
The example config file currently fails since TOML section headers apply to all lines below it until another section header is declared. 