### PR TITLE
feat: Don't allow the merging of PRs when they don't have a clean state [WIP]

### DIFF
--- a/src/bors/comment.rs
+++ b/src/bors/comment.rs
@@ -277,7 +277,9 @@ Hint: Remove **{keyword}** from this PR's title when it is ready for review.
 }
 
 pub fn approve_non_clean_pr() -> Comment {
-    Comment::new(r":clipboard: Looks like this PR is not ready to be merged,.".to_string())
+    Comment::new(
+        r":clipboard: Looks like this PR is not ready to be merged, ignoring approval.".to_string(),
+    )
 }
 
 pub fn approve_blocking_labels_present(blocking_labels: &[&str]) -> Comment {

--- a/src/tests/mocks/pull_request.rs
+++ b/src/tests/mocks/pull_request.rs
@@ -206,6 +206,10 @@ impl PullRequest {
         self.status = PullRequestStatus::Draft;
     }
 
+    pub fn dirty_pull_request(&mut self) {
+        self.mergeable_state = MergeableState::Dirty;
+    }
+
     pub fn add_comment_to_history(&mut self, comment: Comment) {
         self.comment_history.push(comment);
     }


### PR DESCRIPTION
I still have some stuff do do before marking it as "Ready to Review"
- [x] Write some tests
- [ ] Validate locally everything works fine
- [ ] Validate the text message, I added some simple copy, might not be good enough

I am just starting with this so might take some time :) All advice is appreciated

Closes #452 

