### PR TITLE
Note about private key on local development experience

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -129,7 +129,7 @@ can still be done if needed.
 2. Run bors locally, and configure environment variables and/or command-line parameters for it:
    - Set `APP_ID` to the ID of the created GitHub app.
    - Set `WEBHOOK_SECRET` to the webhook secret of the app.
-   - Set `PRIVATE_KEY` to the private key of the app.
+   - Set `PRIVATE_KEY` to the private key of the app. **Note:** If you face an error related to the private key, you need to add `\n` at the beginning of environment variable: `\n-----BEGIN RSA PRIVATE KEY`
    - (optional) Set `WEB_URL` to the public URL of the website of the app.
    - (optional) Set `CMD_PREFIX` to the command prefix used to control the bot (e.g. `@bors`).
    - (optional) Set `PERMISSIONS` `"data/permissions"` directory path to list users with permissions to perform try/review.


### PR DESCRIPTION
Related to a [comment](https://github.com/rust-lang/bors/issues/468#issuecomment-3568404708)
It's about how to help people to setup local environment in terminal (bash, fish) to test bors.

I found essential part which triggered the fail, it's one `\n`  at the beginning of env var. Main reason for the cause is unknown - it may be terminal providing, arg parser... 