### PR TITLE
Unify help between GitHub comments and the webpage

### DIFF
--- a/src/bors/handlers/help.rs
+++ b/src/bors/handlers/help.rs
@@ -1,6 +1,5 @@
-use crate::bors::Comment;
 use crate::bors::RepositoryState;
-use crate::bors::command::BorsCommand;
+use crate::bors::{Comment, format_help};
 use crate::github::PullRequestNumber;
 use std::sync::Arc;
 
@@ -14,69 +13,6 @@ pub(super) async fn command_help(
         .post_comment(pr_number, Comment::new(help.to_string()))
         .await?;
     Ok(())
-}
-
-/// Format the bors command help in Markdown format.
-fn format_help() -> &'static str {
-    // The help is generated manually to have a nicer structure.
-    // We do a no-op destructuring of `BorsCommand` to make it harder to modify help in case new
-    // commands are added though.
-    match BorsCommand::Ping {
-        BorsCommand::Approve {
-            approver: _,
-            rollup: _,
-            priority: _,
-        } => {}
-        BorsCommand::Unapprove => {}
-        BorsCommand::Help => {}
-        BorsCommand::Ping => {}
-        BorsCommand::Try { parent: _, jobs: _ } => {}
-        BorsCommand::TryCancel => {}
-        BorsCommand::SetPriority(_) => {}
-        BorsCommand::Info => {}
-        BorsCommand::SetDelegate(_) => {}
-        BorsCommand::Undelegate => {}
-        BorsCommand::SetRollupMode(_) => {}
-        BorsCommand::OpenTree => {}
-        BorsCommand::TreeClosed(_) => {}
-        BorsCommand::Retry => {}
-    }
-
-    r#"
-You can use the following commands:
-
-## PR management
-- `r+ [p=<priority>] [rollup=<never|iffy|maybe|always>]`: Approve this PR on your behalf
-    - Optionally, you can specify the `<priority>` of the PR and if it is eligible for rollups (`<rollup>)`.
-- `r=<user> [p=<priority>] [rollup=<never|iffy|maybe|always>]`: Approve this PR on behalf of `<user>`
-    - Optionally, you can specify the `<priority>` of the PR and if it is eligible for rollups (`<rollup>)`.
-    - You can pass a comma-separated list of GitHub usernames.
-- `r-`: Unapprove this PR
-- `p=<priority>` or `priority=<priority>`: Set the priority of this PR
-- `rollup=<never|iffy|maybe|always>`: Set the rollup status of the PR
-- `rollup`: Short for `rollup=always`
-- `rollup-`: Short for `rollup=maybe`
-- `delegate=<try|review>`: Delegate permissions for running try builds or approving to the PR author
-    - `try` allows the PR author to start try builds.
-    - `review` allows the PR author to both start try builds and approve the PR.
-- `delegate+`: Delegate approval permissions to the PR author
-    - Shortcut for `delegate=review`
-- `delegate-`: Remove any previously granted permission delegation
-- `try [parent=<parent>] [jobs=<jobs>]`: Start a try build.
-    - Optionally, you can specify a `<parent>` SHA with which will the PR be merged. You can specify `parent=last` to use the same parent SHA as the previous try build.
-    - Optionally, you can select a comma-separated list of CI `<jobs>` to run in the try build.
-- `try cancel`: Cancel a running try build
-- `retry`: Clear a failed auto build status from an approved PR. This will cause the merge queue to attempt to start a new auto build and retry merging the PR again.
-- `info`: Get information about the current PR
-
-## Repository management
-- `treeclosed=<priority>`: Close the tree for PRs with priority less than `<priority>`
-- `treeclosed-` or `treeopen`: Open the repository tree for merging
-
-## Meta commands
-- `ping`: Check if the bot is alive
-- `help`: Print this help message
-"#
 }
 
 #[cfg(test)]

--- a/src/bors/mod.rs
+++ b/src/bors/mod.rs
@@ -27,8 +27,72 @@ mod handlers;
 pub mod merge_queue;
 pub mod mergeability_queue;
 
+use crate::bors::command::BorsCommand;
 use crate::database::{WorkflowModel, WorkflowStatus};
 pub use command::CommandPrefix;
+
+/// Format the bors command help in Markdown format.
+pub fn format_help() -> &'static str {
+    // The help is generated manually to have a nicer structure.
+    // We do a no-op destructuring of `BorsCommand` to make it harder to modify help in case new
+    // commands are added though.
+    match BorsCommand::Ping {
+        BorsCommand::Approve {
+            approver: _,
+            rollup: _,
+            priority: _,
+        } => {}
+        BorsCommand::Unapprove => {}
+        BorsCommand::Help => {}
+        BorsCommand::Ping => {}
+        BorsCommand::Try { parent: _, jobs: _ } => {}
+        BorsCommand::TryCancel => {}
+        BorsCommand::SetPriority(_) => {}
+        BorsCommand::Info => {}
+        BorsCommand::SetDelegate(_) => {}
+        BorsCommand::Undelegate => {}
+        BorsCommand::SetRollupMode(_) => {}
+        BorsCommand::OpenTree => {}
+        BorsCommand::TreeClosed(_) => {}
+        BorsCommand::Retry => {}
+    }
+
+    r#"
+You can use the following commands:
+
+## PR management
+- `r+ [p=<priority>] [rollup=<never|iffy|maybe|always>]`: Approve this PR on your behalf
+    - Optionally, you can specify the `<priority>` of the PR and if it is eligible for rollups (`<rollup>)`.
+- `r=<user> [p=<priority>] [rollup=<never|iffy|maybe|always>]`: Approve this PR on behalf of `<user>`
+    - Optionally, you can specify the `<priority>` of the PR and if it is eligible for rollups (`<rollup>)`.
+    - You can pass a comma-separated list of GitHub usernames.
+- `r-`: Unapprove this PR
+- `p=<priority>` or `priority=<priority>`: Set the priority of this PR
+- `rollup=<never|iffy|maybe|always>`: Set the rollup status of the PR
+- `rollup`: Short for `rollup=always`
+- `rollup-`: Short for `rollup=maybe`
+- `delegate=<try|review>`: Delegate permissions for running try builds or approving to the PR author
+    - `try` allows the PR author to start try builds.
+    - `review` allows the PR author to both start try builds and approve the PR.
+- `delegate+`: Delegate approval permissions to the PR author
+    - Shortcut for `delegate=review`
+- `delegate-`: Remove any previously granted permission delegation
+- `try [parent=<parent>] [jobs=<jobs>]`: Start a try build.
+    - Optionally, you can specify a `<parent>` SHA with which will the PR be merged. You can specify `parent=last` to use the same parent SHA as the previous try build.
+    - Optionally, you can select a comma-separated list of CI `<jobs>` to run in the try build.
+- `try cancel`: Cancel a running try build
+- `retry`: Clear a failed auto build status from an approved PR. This will cause the merge queue to attempt to start a new auto build and retry merging the PR again.
+- `info`: Get information about the current PR
+
+## Repository management
+- `treeclosed=<priority>`: Close the tree for PRs with priority less than `<priority>`
+- `treeclosed-` or `treeopen`: Open the repository tree for merging
+
+## Meta commands
+- `ping`: Check if the bot is alive
+- `help`: Print this help message
+"#
+}
 
 #[cfg(test)]
 pub static WAIT_FOR_REFRESH_PENDING_BUILDS: TestSyncMarker = TestSyncMarker::new();

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,5 +1,5 @@
 use crate::bors::event::BorsEvent;
-use crate::bors::{CommandPrefix, RepositoryState, RollupMode};
+use crate::bors::{CommandPrefix, RepositoryState, RollupMode, format_help};
 use crate::database::{ApprovalStatus, PullRequestModel, QueueStatus};
 use crate::github::{GithubRepoName, rollup};
 use crate::templates::{
@@ -14,6 +14,7 @@ use axum::response::{IntoResponse, Redirect, Response};
 use axum::routing::{get, post};
 use axum::{Json, Router};
 use http::StatusCode;
+use pulldown_cmark::Parser;
 use secrecy::{ExposeSecret, SecretString};
 use std::any::Any;
 use std::collections::HashMap;
@@ -255,8 +256,15 @@ async fn help_handler(State(state): State<ServerStateRef>) -> impl IntoResponse 
         });
     }
 
+    let help_md = format_help();
+    let markdown = Parser::new(help_md);
+
+    let mut help_html = String::new();
+    pulldown_cmark::html::push_html(&mut help_html, markdown);
+
     HtmlTemplate(HelpTemplate {
         repos,
+        help: help_html,
         cmd_prefix: state.get_cmd_prefix().as_ref().to_string(),
     })
 }

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -44,6 +44,7 @@ where
 pub struct HelpTemplate {
     pub repos: Vec<RepositoryView>,
     pub cmd_prefix: String,
+    pub help: String,
 }
 
 pub struct RepositoryView {

--- a/templates/help.html
+++ b/templates/help.html
@@ -17,9 +17,9 @@
         overflow-x: auto;
     }
 
-	tbody tr:last-child td {
-	    border-bottom: none;
-	}
+    tbody tr:last-child td {
+        border-bottom: none;
+    }
 
     th,
     td {
@@ -45,145 +45,26 @@
 
 {% block body %}
 <main>
-    <h1>Bors</h1>
+  <h1>Bors</h1>
 
-    <h2>Repositories</h2>
-    <ul class="repos">
-      {% for repo in repos %}
-      <li>
-        <a href="queue/{{ repo.name }}">{{ repo.name }}</a>
-        {% if repo.treeclosed %} [TREECLOSED] {% endif %}
-      </li>
-      {% endfor %}
-    </ul>
+  <h2>Repositories</h2>
+  <ul class="repos">
+    {% for repo in repos %}
+    <li>
+      <a href="queue/{{ repo.name }}">{{ repo.name }}</a>
+      {% if repo.treeclosed %} [TREECLOSED] {% endif %}
+    </li>
+    {% endfor %}
+  </ul>
 
-    <h2>Commands</h2>
-    <p>Commands must be posted as comments on the PR and mention the bot account (<code>{{ cmd_prefix }}</code>).</p>
+  <h2>Commands</h2>
+  <p>Commands must be posted as comments on the PR and mention the bot account (<code>{{ cmd_prefix
+    }}</code>).</p>
 
-    <div class="table-wrapper">
-        <table>
-            <thead>
-                <tr>
-                    <th>Command</th>
-                    <th>Permissions</th>
-                    <th>Description</th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr>
-                    <td><code>info</code></td>
-                    <td class="empty"></td>
-                    <td>Get information about the current PR</td>
-                </tr>
-                <tr>
-                    <td><code>ping</code></td>
-                    <td class="empty"></td>
-                    <td>Check if the bot is alive</td>
-                </tr>
-                <tr>
-                    <td><code>help</code></td>
-                    <td class="empty"></td>
-                    <td>Print help message</td>
-                </tr>
-                <tr>
-                    <td><code>r+</code></td>
-                    <td>review</td>
-                    <td>Approve this PR on your behalf</td>
-                </tr>
-                <tr>
-                    <td><code>r=&lt;user&gt;</code></td>
-                    <td>review</td>
-                    <td>Approve the PR on behalf of the specified user(s)</td>
-                </tr>
-                <tr>
-                    <td><code>r-</code></td>
-                    <td>review</td>
-                    <td>Unapprove the PR</td>
-                </tr>
-                <tr>
-                    <td><code>p=&lt;priority&gt;</code> or <code>priority=&lt;priority&gt;</code></td>
-                    <td>review</td>
-                    <td>Set the priority of the PR</td>
-                </tr>
-                <tr>
-                    <td><code>rollup</code></td>
-                    <td>review</td>
-                    <td>Short for <code>rollup=always</code></td>
-                </tr>
-                <tr>
-                    <td><code>rollup-</code></td>
-                    <td>review</td>
-                    <td>Short for <code>rollup=maybe</code></td>
-                </tr>
-                <tr>
-                    <td><code>rollup=&lt;never|iffy|maybe|always&gt;</code></td>
-                    <td>review</td>
-                    <td>Set the rollup status of the PR</td>
-                </tr>
-                <tr>
-                    <td><code>r+ [p=&lt;priority&gt;] [rollup=&lt;mode&gt;]</code></td>
-                    <td>review</td>
-                    <td>Approve this PR on your behalf with options</td>
-                </tr>
-                <tr>
-                    <td><code>r=&lt;user&gt; [p=&lt;priority&gt;] [rollup=&lt;mode&gt;]</code></td>
-                    <td>review</td>
-                    <td>Approve the PR on behalf of the specified user(s) with options</td>
-                </tr>
-                <tr>
-                    <td><code>try [parent=&lt;sha&gt;] [jobs=&lt;job1,job2,...&gt;]</code></td>
-                    <td>try</td>
-                    <td>Run a try build (max 10 jobs)</td>
-                </tr>
-                <tr>
-                    <td><code>try cancel</code></td>
-                    <td>try</td>
-                    <td>Cancel a running try build</td>
-                </tr>
-                <tr>
-                    <td><code>delegate+</code></td>
-                    <td>review</td>
-                    <td>Short for <code>delegate=review</code></td>
-                </tr>
-                <tr>
-                    <td><code>delegate-</code></td>
-                    <td>review</td>
-                    <td>Remove any previously granted delegated permissions</td>
-                </tr>
-                <tr>
-                    <td><code>delegate=&lt;try|review&gt;</code></td>
-                    <td>review</td>
-                    <td>Delegate permissions to the PR author (try or review)</td>
-                </tr>
-                <tr>
-                    <td><code>treeclosed-</code> or <code>treeopen</code></td>
-                    <td>review</td>
-                    <td>Open the repository tree for merging</td>
-                </tr>
-                <tr>
-                    <td><code>treeclosed=&lt;priority&gt;</code></td>
-                    <td>review</td>
-                    <td>Close the tree for PRs with priority less than <code>&lt;priority&gt;</code></td>
-                </tr>
-                <tr>
-                    <td><code>retry</code></td>
-                    <td>review</td>
-                    <td>Clear a failed auto build status from an approved PR. This will cause the merge queue to attempt to start a new auto build and retry merging the PR again.</td>
-                </tr>
-            </tbody>
-        </table>
-    </div>
+  {{ help | safe }}
 
-    <h2>Examples</h2>
-    <ul>
-        <li><code>{{ cmd_prefix }} r=user1,user2 p=5</code>: Approve on behalf of <code>user1</code> and <code>user2</code> with priority 5</li>
-        <li><code>{{ cmd_prefix }} r+ rollup p=1</code>: Approve with priority 1 and always rollup</li>
-        <li><code>{{ cmd_prefix }} try parent=last</code>: Start a try build using the same parent as the last try</li>
-        <li><code>{{ cmd_prefix }} try @rust-timer queue</code>: Short-hand for compile-perf benchmarking of PRs</li>
-    </ul>
-
-    <div style="text-align: center; margin-top: 1em;">
-        <a href="https://github.com/rust-lang/bors">Contribute on GitHub</a>
-    </div>
+  <div style="text-align: center; margin-top: 1em;">
+    <a href="https://github.com/rust-lang/bors">Contribute on GitHub</a>
+  </div>
 </main>
 {% endblock %}


### PR DESCRIPTION
So that they don't diverge.

This pull request was created in cooperation with students of the [Rust course](https://github.com/Kobzol/rust-course-fei) on the VSB-TUO university.