### PR TITLE
Add `try job=...` alias for `try jobs=...`

### DIFF
--- a/src/bors/command/parser.rs
+++ b/src/bors/command/parser.rs
@@ -290,7 +290,7 @@ fn parser_try(command: &CommandPart<'_>, parts: &[CommandPart<'_>]) -> ParseResu
                         ))));
                     }
                 },
-                ("jobs", value) => {
+                ("job" | "jobs", value) => {
                     let raw_jobs: Vec<_> = value.split(',').map(|s| s.to_string()).collect();
                     if raw_jobs.is_empty() {
                         return Some(Err(CommandParseError::ValidationError(

--- a/src/bors/handlers/help.rs
+++ b/src/bors/handlers/help.rs
@@ -43,7 +43,7 @@ mod tests {
             - `delegate+`: Delegate approval permissions to the PR author
                 - Shortcut for `delegate=review`
             - `delegate-`: Remove any previously granted permission delegation
-            - `try [parent=<parent>] [jobs=<jobs>]`: Start a try build.
+            - `try [parent=<parent>] [job|jobs=<jobs>]`: Start a try build.
                 - Optionally, you can specify a `<parent>` SHA with which will the PR be merged. You can specify `parent=last` to use the same parent SHA as the previous try build.
                 - Optionally, you can select a comma-separated list of CI `<jobs>` to run in the try build.
             - `try cancel`: Cancel a running try build

--- a/src/bors/mod.rs
+++ b/src/bors/mod.rs
@@ -90,7 +90,7 @@ You can use the following commands:
 - `delegate+`: Delegate approval permissions to the PR author
     - Shortcut for `delegate=review`
 - `delegate-`: Remove any previously granted permission delegation
-- `try [parent=<parent>] [jobs=<jobs>]`: Start a try build.
+- `try [parent=<parent>] [job|jobs=<jobs>]`: Start a try build.
     - Optionally, you can specify a `<parent>` SHA with which will the PR be merged. You can specify `parent=last` to use the same parent SHA as the previous try build.
     - Optionally, you can select a comma-separated list of CI `<jobs>` to run in the try build.
 - `try cancel`: Cancel a running try build


### PR DESCRIPTION
I've seen this done wrong quite a lot (such as in https://github.com/rust-lang/rust/pull/149354), so lets fix it :)
I'm also guilty of this mistake myself...

I'm not familiar with this codebase but seems like an easy change?