### PR TITLE
Fix workflow result URL shown in try/auto build completed comments

### DIFF
--- a/src/github/api/client.rs
+++ b/src/github/api/client.rs
@@ -336,7 +336,7 @@ impl GithubRepositoryClient {
                 let run = WorkflowRun {
                     id: run.id,
                     name: run.name,
-                    url: run.url.to_string(),
+                    url: run.html_url.to_string(),
                     status,
                 };
                 runs.push(run);


### PR DESCRIPTION
It broke during my recent refactorings, and tests didn't catch that. Fixed both.

Noticed [here](https://github.com/rust-lang/rust/pull/149921#issuecomment-3678046234).
