### PR TITLE
feat(rollups): add rollup_member mapping

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/.sqlx/*.json binary linguist-generated=true

--- a/.sqlx/query-198f38a0c02b6182fd42bcfd1151e03566d9788de02116b5a828680197757edb.json
+++ b/.sqlx/query-198f38a0c02b6182fd42bcfd1151e03566d9788de02116b5a828680197757edb.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO rollup_member (rollup, member)\n        VALUES ($1, $2)\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int4",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "198f38a0c02b6182fd42bcfd1151e03566d9788de02116b5a828680197757edb"
+}

--- a/.sqlx/query-768e828c9034881a9a6d162c9fb5be316c36d996e232733458234f4226e89295.json
+++ b/.sqlx/query-768e828c9034881a9a6d162c9fb5be316c36d996e232733458234f4226e89295.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT rollup.number AS rollup_num, member.number AS member_num\n        FROM rollup_member rm\n            JOIN pull_request rollup ON rollup.id = rm.rollup\n            JOIN pull_request member ON member.id = rm.member\n        WHERE rollup.status IN ('open', 'draft') AND\n              rollup.repository = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "rollup_num",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "member_num",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "768e828c9034881a9a6d162c9fb5be316c36d996e232733458234f4226e89295"
+}

--- a/migrations/20260123212918_rollup_member.down.sql
+++ b/migrations/20260123212918_rollup_member.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS rollup_member;

--- a/migrations/20260123212918_rollup_member.up.sql
+++ b/migrations/20260123212918_rollup_member.up.sql
@@ -1,0 +1,13 @@
+-- Add up migration script here
+CREATE TABLE IF NOT EXISTS rollup_member
+(
+    -- The rollup PR
+    rollup INT NOT NULL,
+    -- PR that is a member of that rollup
+    member INT NOT NULL,
+
+    CONSTRAINT fk_rollup_id FOREIGN KEY (rollup) REFERENCES pull_request (id),
+    CONSTRAINT fk_member_id FOREIGN KEY (member) REFERENCES pull_request (id),
+
+    PRIMARY KEY (rollup, member)
+);

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -4,6 +4,7 @@ use crate::database::{ApprovalStatus, QueueStatus};
 use crate::github::{GithubRepoName, rollup};
 use crate::templates::{
     HelpTemplate, HtmlTemplate, NotFoundTemplate, PullRequestStats, QueueTemplate, RepositoryView,
+    RollupsInfo,
 };
 use crate::utils::sort_queue::sort_queue_prs;
 use crate::{
@@ -356,6 +357,8 @@ pub async fn queue_handler(
         (in_queue + in_queue_inc, failed + failed_inc)
     });
 
+    let rollups = db.get_nonclosed_rollups(&repo.name).await?;
+
     Ok(HtmlTemplate(QueueTemplate {
         oauth_client_id: oauth
             .as_ref()
@@ -372,6 +375,7 @@ pub async fn queue_handler(
         prs,
         pending_workflow,
         selected_rollup_prs: params.pull_requests.map(|prs| prs.0).unwrap_or_default(),
+        rollups_info: RollupsInfo::from(rollups),
     })
     .into_response())
 }

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -3,9 +3,12 @@ use crate::database::{
     BuildModel, BuildStatus, MergeableState::*, PullRequestModel, QueueStatus, TreeState,
     WorkflowModel,
 };
+use crate::github::PullRequestNumber;
 use askama::Template;
 use axum::response::{Html, IntoResponse, Response};
 use http::StatusCode;
+use itertools::Itertools;
+use std::collections::{HashMap, HashSet};
 
 /// Build status to display on the queue page.
 pub fn status_text(pr: &PullRequestModel) -> String {
@@ -55,6 +58,17 @@ pub struct PullRequestStats {
     pub failed_count: usize,
 }
 
+/// A displayable view of a map of rollups to their members, meant to be used with data attributes
+pub struct RollupsInfo {
+    pub rollups: HashMap<PullRequestNumber, HashSet<PullRequestNumber>>,
+}
+
+impl From<HashMap<PullRequestNumber, HashSet<PullRequestNumber>>> for RollupsInfo {
+    fn from(rollups: HashMap<PullRequestNumber, HashSet<PullRequestNumber>>) -> Self {
+        Self { rollups }
+    }
+}
+
 #[derive(Template)]
 #[template(path = "queue.html", whitespace = "minimize")]
 pub struct QueueTemplate {
@@ -63,6 +77,7 @@ pub struct QueueTemplate {
     pub repo_url: String,
     pub stats: PullRequestStats,
     pub prs: Vec<PullRequestModel>,
+    pub rollups_info: RollupsInfo,
     pub tree_state: TreeState,
     pub oauth_client_id: Option<String>,
     // PRs that should be pre-selected for being included in a rollup

--- a/tests/data/migrations/20260123212918_rollup_member.sql
+++ b/tests/data/migrations/20260123212918_rollup_member.sql
@@ -1,0 +1,13 @@
+INSERT INTO pull_request (repository, number, base_branch, status)
+VALUES ('rust-lang/rust', 1, 'main', 'open'),
+       ('rust-lang/rust', 2, 'main', 'open'),
+       ('rust-lang/rust', 3, 'main', 'open'),
+       ('rust-lang/rust', 4, 'main', 'open');
+
+INSERT INTO rollup_member (rollup, member)
+VALUES (5,
+        6),
+       (5,
+        7),
+       (6,
+        8);

--- a/web/templates/queue.html
+++ b/web/templates/queue.html
@@ -93,6 +93,16 @@
     td.status[data-status="approved"]:before {
         background-color: #85DB7B;
     }
+    table.dataTable > tbody > tr.rollup-hover > td {
+        background-color: #C2D2FF;
+    }
+    table.dataTable > tbody > tr.rollup-hover:nth-child(2n+1) > td {
+        /* Override the striped overlay from DataTables to properly highlight the whole row when hovering a rollup PR */
+        box-shadow: none
+    }
+    table.dataTable.stripe > tbody > tr.rollup-hover > td:first-child {
+        box-shadow: inset 6px 0 0 #1d4ed8; /* left bar inside the cell */
+    }
     .marker {
         white-space: nowrap;
     }
@@ -215,7 +225,11 @@
 
         <tbody>
             {%- for pr in prs %}
-            <tr data-rollupable="{{ pr.is_rollupable() }}"
+            <tr data-pr-number="{{ pr.number.0 }}"
+                {% if let Some(rollup_members) = rollups_info.rollups.get(pr.number) %}
+                data-rollup-pr-members='{{ rollup_members.iter().join(",")  }}'
+                {% endif %}
+                data-rollupable="{{ pr.is_rollupable() }}"
                 data-preselected="{{ selected_rollup_prs.contains(pr.number.0 as u32) }}"
                 {% if let Some(priority) = tree_state.priority() &&
                       pr.priority.unwrap_or(0) < *priority as i32 &&
@@ -472,7 +486,42 @@
 
     let table = null;
     let detachRowClick = null;
+    let detachRowHover = null;
     let selectCheckbox = null;
+
+    // Highlight rollup members when hovering over the rollup row
+    function bindRollupHover() {
+        const tbody = document.querySelector("#table tbody");
+        if (!tbody) {
+            return () => {};
+        }
+        const clear = () => {
+            tbody.querySelectorAll(".rollup-hover").forEach(el => el.classList.remove("rollup-hover"));
+        };
+        const handler = (event) => {
+            // Reset highlight
+            clear();
+            const rowElement = event.target.closest("tr");
+            if (!rowElement) {
+                return;
+            }
+            let rollupPrMembers = rowElement.dataset.rollupPrMembers;
+            if (!rollupPrMembers) {
+                return;
+            }
+            rollupPrMembers = rollupPrMembers.split(",");
+            for (const rollupPrMember of rollupPrMembers) {
+                tbody.querySelector(`tr[data-pr-number="${rollupPrMember}"]`).classList.add("rollup-hover");
+            }
+        }
+        tbody.addEventListener("mouseover", handler);
+        tbody.addEventListener("mouseleave", clear);
+
+        return () => {
+            tbody.removeEventListener("mouseover", handler);
+            tbody.removeEventListener("mouseleave", clear);
+        };
+    }
 
     function handleSelectChange() {
         let groupByColumnName = this.value === "" ? null : this.value;
@@ -490,9 +539,13 @@
         if (selectCheckbox !== null) {
           selectCheckbox.removeEventListener("change", handleSelectChange);
         }
+        if (detachRowHover !== null) {
+          detachRowHover();
+        }
 
         table = initializeTable(groupByColumnName);
         detachRowClick = bindRowClick(table);
+        detachRowHover = bindRollupHover();
 
         // This dance is required because we want to put the select input into the DataTables
         // layout, which causes it to be removed from the DOM everytime we (re-)initiaize the table.


### PR DESCRIPTION
Closes #494.

I wasn't sure whether to use IDs from the pull_request table to represent PRs in the mapping, or just the GitHub PR number - I went with the latter as there would be no record for the rollup at the time of its creation, as that gets populated via GitHub events, if I understood correctly.

I haven't experienced rollups at all as I haven't (yet?) contributed to a project with bors, but I noticed there's no safety check for multiple rollups containing the same PR(s) being opened. I found a related comment [here](https://github.com/rust-lang/bors/issues/284#issuecomment-2905353395), but I kept it out of this PR to reduce its scope and simplify review. I think such a safety check could be added easily by checking for rollups associated to each candidate PR, and verifying the status of the rollup PR to ignore closed ones. That would still allow one to recreate the same scenario by reopening a previously closed rollup, though.

One thing I'm unsure about is how to handle the error when writing the rollup_contents records in the DB. I think that should only happen either in case of DB connection errors, or if the list of PRs contains duplicates. I assume the former can be propagated to the caller, whereas I'm not sure if the latter is realistic and should be accounted for. I'm thinking we can just ignore the conflicting records in such case - let me know if I should proceed with that.

Edit: sorry, I forgot the migration test files. Will push them tomorrow as soon as possible 