### PR TITLE
Require review permissions for creating rollups

### DIFF
--- a/src/github/oauth.rs
+++ b/src/github/oauth.rs
@@ -1,6 +1,6 @@
-use crate::github::GithubRepoName;
 use crate::github::api::DEFAULT_REQUEST_TIMEOUT;
 use crate::github::api::client::GithubRepositoryClient;
+use crate::github::{GithubRepoName, GithubUser};
 use anyhow::Context;
 use octocrab::OctocrabBuilder;
 use octocrab::service::middleware::retry::RetryConfig;
@@ -76,9 +76,9 @@ impl OAuthClient {
             .context("Cannot get user authenticated with OAuth")?;
 
         let client_repo = GithubRepoName::new(&user.login, repo.name());
-        let client = GithubRepositoryClient::new(user.html_url, user_client, client_repo);
+        let client = GithubRepositoryClient::new(user.html_url.clone(), user_client, client_repo);
         Ok(UserGitHubClient {
-            username: user.login,
+            user: user.into(),
             client,
         })
     }
@@ -86,7 +86,7 @@ impl OAuthClient {
 
 /// GitHub client authenticated to work with a user's fork of a repository managed by bors.
 pub struct UserGitHubClient {
-    pub username: String,
+    pub user: GithubUser,
     pub client: GithubRepositoryClient,
 }
 

--- a/src/tests/mock/mod.rs
+++ b/src/tests/mock/mod.rs
@@ -354,7 +354,7 @@ EjQJOzV2OIk4waurl+BsbOHP7C0Zhp7rpyWx4fUCgYEAp/4UceUfbJZGa8CcWZ8F
 34PVnCZP7HB3k2eBSpDp4vk=
 -----END PRIVATE KEY-----"###;
 
-fn oauth_user_from_request(request: &Request) -> User {
+fn oauth_user_from_request(github: Arc<Mutex<GitHub>>, request: &Request) -> User {
     let auth: &HeaderValue = request
         .headers
         .get(AUTHORIZATION)
@@ -362,8 +362,9 @@ fn oauth_user_from_request(request: &Request) -> User {
     let (_bearer, token) = auth.to_str().unwrap().split_once(" ").unwrap();
     let (user, rest) = token.split_once("-").unwrap();
     assert_eq!(rest, "access-token");
-    // TODO: load this from GitHub state
-    User::new(10000, user)
+
+    let gh = github.lock();
+    gh.get_user(user).expect("User not found").clone()
 }
 
 /// Create a mock that dynamically responds to its requests using the given function `f`.

--- a/src/tests/mock/oauth.rs
+++ b/src/tests/mock/oauth.rs
@@ -42,7 +42,7 @@ pub async fn mock_oauth(github: Arc<Mutex<GitHub>>, mock_server: &MockServer) {
     Mock::given(method("GET"))
         .and(path("/user"))
         .respond_with(move |req: &Request| {
-            let user = oauth_user_from_request(req);
+            let user = oauth_user_from_request(github.clone(), req);
             ResponseTemplate::new(200).set_body_json(GitHubUser::from(user))
         })
         .mount(mock_server)


### PR DESCRIPTION
Homu didn't do it, but I think that it makes sense, as the PR author is expected to approve the rollup anyway.