### PR TITLE
Do not show try build status in queue page

### DIFF
--- a/src/templates.rs
+++ b/src/templates.rs
@@ -9,16 +9,12 @@ use http::StatusCode;
 
 /// Build status to display on the queue page.
 pub fn status_text(pr: &PullRequestModel) -> String {
-    if let Some(try_build) = &pr.try_build {
-        try_build.status.to_string()
-    } else {
-        match pr.queue_status() {
-            QueueStatus::Approved(_) => "approved".to_string(),
-            QueueStatus::ReadyForMerge(_, _) => "ready for merge".to_string(),
-            QueueStatus::Pending(_, _) => "pending".to_string(),
-            QueueStatus::Failed(_, _) => "failed".to_string(),
-            QueueStatus::NotApproved => String::new(),
-        }
+    match pr.queue_status() {
+        QueueStatus::Approved(_) => "approved".to_string(),
+        QueueStatus::ReadyForMerge(_, _) => "ready for merge".to_string(),
+        QueueStatus::Pending(_, _) => "pending".to_string(),
+        QueueStatus::Failed(_, _) => "failed".to_string(),
+        QueueStatus::NotApproved => String::new(),
     }
 }
 

--- a/templates/queue.html
+++ b/templates/queue.html
@@ -204,11 +204,7 @@
                     title="Started at {{ to_local_time(*build.created_at).format("%d.%m.%Y %H:%M:%S") }}"
                     data-created-at="{{ build.created_at.timestamp_millis() }}"
                     {%- endif -%}>
-                    {%- if let Some(try_build) = pr.try_build -%}
-                    <a href="../results/{{ repo_name }}/{{ pr.number }}">{{ crate::templates::status_text(pr) }}</a> (try)
-                    {%- else -%}
                     {{ crate::templates::status_text(pr) }}
-                    {%- endif -%}
                     <span class="elapsed-time-display"></span>
                 </td>
                 <td class="marker {%~ match pr.mergeable_state -%}


### PR DESCRIPTION
We do not implement the /results page as in homu, and I don't think that try state should be in the queue page. We could show this in some other way in the future if there is some use-case for it.
