### PR TITLE
Increase timeout for fetching non-closed PRs

### DIFF
--- a/src/github/api/client.rs
+++ b/src/github/api/client.rs
@@ -5,6 +5,7 @@ use octocrab::models::{CheckRunId, Repository, RunId};
 use octocrab::params::checks::{CheckRunConclusion, CheckRunStatus};
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
+use std::time::Duration;
 use tracing::log;
 
 use crate::bors::event::PullRequestComment;
@@ -458,7 +459,8 @@ impl GithubRepositoryClient {
     pub async fn fetch_nonclosed_pull_requests(&self) -> anyhow::Result<Vec<PullRequest>> {
         let prs = perform_retryable(
             "fetch_nonclosed_pull_requests",
-            RetryMethod::default(),
+            // This operation can take a long time
+            RetryMethod::default().with_timeout(Duration::from_secs(40)),
             || async {
                 let stream = self
                     .client

--- a/src/github/api/mod.rs
+++ b/src/github/api/mod.rs
@@ -18,6 +18,7 @@ use client::GithubRepositoryClient;
 pub mod client;
 pub(crate) mod operations;
 
+/// GitHub requests will be timed out after this time by default
 pub const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 
 pub fn create_github_client(

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -8,6 +8,7 @@ use octocrab::{
 };
 use std::fmt::{Debug, Display, Formatter};
 use std::str::FromStr;
+use std::time::Duration;
 use url::Url;
 
 pub mod api;
@@ -24,7 +25,6 @@ pub use error::AppError;
 pub use labels::{LabelModification, LabelTrigger};
 
 use crate::bors::PullRequestStatus;
-use crate::github::api::DEFAULT_REQUEST_TIMEOUT;
 
 /// Unique identifier of a GitHub repository
 #[derive(Debug, PartialEq, Eq, Hash, Clone, PartialOrd, Ord)]
@@ -196,11 +196,12 @@ impl Display for PullRequestNumber {
 fn prepare_octocrab_client(
     base_uri: &str,
 ) -> anyhow::Result<OctocrabBuilder<NoSvc, DefaultOctocrabBuilderConfig, NoAuth, NotLayerReady>> {
+    let timeout = Duration::from_secs(10);
     Ok(Octocrab::builder()
         .base_uri(base_uri)?
-        .set_read_timeout(Some(DEFAULT_REQUEST_TIMEOUT))
-        .set_write_timeout(Some(DEFAULT_REQUEST_TIMEOUT))
-        .set_connect_timeout(Some(DEFAULT_REQUEST_TIMEOUT))
+        .set_read_timeout(Some(timeout))
+        .set_write_timeout(Some(timeout))
+        .set_connect_timeout(Some(timeout))
         // Disable retrying, as we do our own retries
         .add_retry_config(RetryConfig::None))
 }

--- a/src/utils/timing.rs
+++ b/src/utils/timing.rs
@@ -68,6 +68,11 @@ impl RetryMethod {
             ..Default::default()
         }
     }
+
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.timeout_after = timeout;
+        self
+    }
 }
 
 impl Default for RetryMethod {


### PR DESCRIPTION
It was timing out on rust-lang/rust (locally it takes ~20s on that repo).
