### PR TITLE
fix(ci): fail if deployment goes wrong

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -42,4 +42,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Kick ECS to deploy new version
-        run: aws ecs update-service --service bors --cluster bors --force-new-deployment
+        run: |
+          aws ecs update-service --service bors --cluster bors --force-new-deployment
+          # Poll every 15 seconds until a successful state has been reached. Fail after 40 failed checks.
+          aws ecs wait services-stable --services bors --cluster bors

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -44,4 +44,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Kick ECS to deploy new version
-        run: aws ecs update-service --service bors --cluster bors --force-new-deployment
+        run: |
+          aws ecs update-service --service bors --cluster bors --force-new-deployment
+          # Poll every 15 seconds until a successful state has been reached. Fail after 40 failed checks.
+          aws ecs wait services-stable --services bors --cluster bors


### PR DESCRIPTION
In https://docs.aws.amazon.com/cli/latest/reference/ecs/wait/services-stable.html I didn't find a way to override the default values (15 seconds and 40 attempts).