### PR TITLE
Hardcode `@bors2` prefix

### DIFF
--- a/src/bors/handlers/mod.rs
+++ b/src/bors/handlers/mod.rs
@@ -341,7 +341,7 @@ async fn handle_comment(
     let pr_number = comment.pr_number;
     let mut commands = ctx.parser.parse_commands(&comment.text);
 
-    // Temporary special case for migration from homu on rust-lang/rust.
+    // Temporary special cases for migration from homu on rust-lang/rust.
     // Try to parse `@bors try` commands with a hardcoded prefix normally assigned to homu.
     if ctx.parser.prefix().as_ref() != "@bors" {
         let homu_commands = CommandParser::new_try_only(CommandPrefix::from("@bors".to_string()))
@@ -355,6 +355,14 @@ async fn handle_comment(
                 _ => true,
             });
         commands.extend(homu_commands);
+    }
+    // Try to parse `@bors2` commands to allow passing commands *only* to bors, and not to homu,
+    // once we switch bors from `@bors2` to `@bors`.
+    if ctx.parser.prefix().as_ref() != "@bors2" {
+        commands.extend(
+            CommandParser::new(CommandPrefix::from("@bors2".to_string()))
+                .parse_commands(&comment.text),
+        );
     }
 
     // Bail if no commands


### PR DESCRIPTION
Temporary measure to have a way to control *only* bors, without controlling homu, once we switch bors to the `@bors` command prefix.
