### PR TITLE
Ignore homu commands

### DIFF
--- a/src/bors/handlers/mod.rs
+++ b/src/bors/handlers/mod.rs
@@ -71,6 +71,12 @@ pub async fn handle_bors_repository_event(
                 return Ok(());
             }
 
+            // Also ignore comments made by homu
+            if comment.author.username == "bors" {
+                tracing::trace!("Ignoring comment {comment:?} because it was authored by homu");
+                return Ok(());
+            }
+
             let span = tracing::info_span!(
                 "Comment",
                 pr = format!("{}#{}", comment.repository, comment.pr_number),


### PR DESCRIPTION
Homu sends commands in HTML comments, and new bors [reacts](https://github.com/rust-lang/rust/pull/150708#issuecomment-3714326717) to them. We could disable parsing commands from HTML, but sometimes it's used to approve with funny images, etc. This ensures that we will just ignore homu, as we should.
