### PR TITLE
Fix renovatebot cron

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -23,7 +23,7 @@
         "github-actions"
       ],
       // Every month
-      schedule: "0 0 1 * *",
+      schedule: "* 0 1 * *",
       groupName: "Github Actions",
     }
   ],


### PR DESCRIPTION
Apparently, it can't deal with `0` being used as the minute value...
