### PR TITLE
Remove pause/resume functionality

### DIFF
--- a/src/bors/command/mod.rs
+++ b/src/bors/command/mod.rs
@@ -132,9 +132,4 @@ pub enum BorsCommand {
     /// Clear a failed auto build status from an approved PR.
     /// This will cause the merge queue to attempt to start a new auto build and retry merging the PR again.
     Retry,
-    /// Pause the merge queue and related functionality ([un]approving, delegation, tree closing,
-    /// etc.).
-    Pause,
-    /// Resume the merge queue and related functionality.
-    Resume,
 }

--- a/src/bors/command/parser.rs
+++ b/src/bors/command/parser.rs
@@ -144,8 +144,6 @@ const DEFAULT_PARSERS: &[ParserFn] = &[
     parser_ping,
     parser_retry,
     parser_tree_ops,
-    parser_pause,
-    parser_resume,
 ];
 
 const ONLY_TRY_PARSERS: &[ParserFn] = &[parser_try_cancel, parser_try];
@@ -439,22 +437,6 @@ fn parser_tree_ops(command: &CommandPart<'_>, _parts: &[CommandPart<'_>]) -> Par
             };
             Some(Ok(BorsCommand::TreeClosed(priority)))
         }
-        _ => None,
-    }
-}
-
-/// Parses `@bors pause` command.
-fn parser_pause(command: &CommandPart<'_>, _parts: &[CommandPart<'_>]) -> ParseResult {
-    match command {
-        CommandPart::Bare("pause") => Some(Ok(BorsCommand::Pause)),
-        _ => None,
-    }
-}
-
-/// Parses `@bors resume` command.
-fn parser_resume(command: &CommandPart<'_>, _parts: &[CommandPart<'_>]) -> ParseResult {
-    match command {
-        CommandPart::Bare("resume") => Some(Ok(BorsCommand::Resume)),
         _ => None,
     }
 }

--- a/src/bors/handlers/mod.rs
+++ b/src/bors/handlers/mod.rs
@@ -521,28 +521,6 @@ async fn handle_comment(
                             .instrument(span)
                             .await
                     }
-                    BorsCommand::Pause => {
-                        if repo
-                            .permissions
-                            .load()
-                            .has_permission(comment.author.id, PermissionType::Review)
-                        {
-                            tracing::info!("Pausing {}", repo.repository());
-                            repo.set_paused(true);
-                        }
-                        Ok(())
-                    }
-                    BorsCommand::Resume => {
-                        if repo
-                            .permissions
-                            .load()
-                            .has_permission(comment.author.id, PermissionType::Review)
-                        {
-                            tracing::info!("Resuming {}", repo.repository());
-                            repo.set_paused(false);
-                        }
-                        Ok(())
-                    }
                 };
                 if result.is_err() {
                     return result.context("Cannot execute Bors command");

--- a/src/bors/handlers/ping.rs
+++ b/src/bors/handlers/ping.rs
@@ -8,12 +8,8 @@ pub(super) async fn command_ping(
     repo: Arc<RepositoryState>,
     pr_number: PullRequestNumber,
 ) -> anyhow::Result<()> {
-    let mut msg = "Pong 🏓!".to_string();
-    if repo.is_paused() {
-        msg.push_str(" (bors is paused)");
-    }
     repo.client
-        .post_comment(pr_number, Comment::new(msg))
+        .post_comment(pr_number, Comment::new("Pong 🏓!".to_string()))
         .await?;
     Ok(())
 }

--- a/src/bors/handlers/retry.rs
+++ b/src/bors/handlers/retry.rs
@@ -25,7 +25,7 @@ pub(super) async fn command_retry(
     if matches!(pr_model.queue_status(), QueueStatus::Failed(_, _)) {
         db.clear_auto_build(pr_model).await?;
         merge_queue_tx.notify().await?;
-    } else if !repo_state.is_paused() {
+    } else {
         notify_of_invalid_retry_state(&repo_state, pr.number()).await?;
     }
 

--- a/src/bors/merge_queue.rs
+++ b/src/bors/merge_queue.rs
@@ -98,7 +98,7 @@ pub async fn merge_queue_tick(ctx: Arc<BorsContext>) -> anyhow::Result<()> {
 }
 
 async fn process_repository(repo: &RepositoryState, ctx: &BorsContext) -> anyhow::Result<()> {
-    if !repo.config.load().merge_queue_enabled || repo.is_paused() {
+    if !repo.config.load().merge_queue_enabled {
         return Ok(());
     }
 

--- a/src/bors/mod.rs
+++ b/src/bors/mod.rs
@@ -19,7 +19,6 @@ use serde::Serialize;
 use std::collections::HashMap;
 use std::fmt;
 use std::str::FromStr;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, LazyLock, RwLock};
 use std::time::Duration;
 
@@ -76,8 +75,6 @@ pub fn format_help() -> &'static str {
         BorsCommand::OpenTree => {}
         BorsCommand::TreeClosed(_) => {}
         BorsCommand::Retry => {}
-        BorsCommand::Pause => {}
-        BorsCommand::Resume => {}
     }
 
     r#"
@@ -183,19 +180,11 @@ pub struct RepositoryState {
     pub client: GithubRepositoryClient,
     pub permissions: ArcSwap<UserPermissions>,
     pub config: ArcSwap<RepositoryConfig>,
-    pub paused: AtomicBool,
 }
 
 impl RepositoryState {
     pub fn repository(&self) -> &GithubRepoName {
         self.client.repository()
-    }
-
-    pub fn set_paused(&self, state: bool) {
-        self.paused.store(state, Ordering::SeqCst);
-    }
-    pub fn is_paused(&self) -> bool {
-        self.paused.load(Ordering::SeqCst)
     }
 }
 

--- a/src/github/api/mod.rs
+++ b/src/github/api/mod.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::sync::atomic::AtomicBool;
 use std::time::Duration;
 
 use anyhow::Context;
@@ -159,7 +158,6 @@ async fn create_repo_state(
         client,
         config: ArcSwap::new(Arc::new(config)),
         permissions: ArcSwap::new(Arc::new(permissions)),
-        paused: AtomicBool::new(false),
     })
 }
 


### PR DESCRIPTION
Should no longer be needed, we can pause the bot by just closing the tree.
