### PR TITLE
Add `BuildCompleted` homu-compatible comment metadata to test successful comments

### DIFF
--- a/src/bors/build_queue.rs
+++ b/src/bors/build_queue.rs
@@ -384,11 +384,12 @@ mod tests {
 
             // The auto build should be completed
             let comment = ctx.get_next_comment_text(()).await?;
-            insta::assert_snapshot!(comment, @"
+            insta::assert_snapshot!(comment, @r#"
             :sunny: Test successful - [Workflow1](https://github.com/rust-lang/borstest/actions/runs/1)
             Approved by: `default-user`
             Pushing merge-0-pr-1 to `main`...
-            ");
+            <!-- homu: {"type":"BuildCompleted","base_ref":"main","merge_sha":"merge-0-pr-1"} -->
+            "#);
 
             ctx.pr(()).await.expect_status(PullRequestStatus::Merged);
 
@@ -414,11 +415,12 @@ mod tests {
 
             // The auto build should be completed
             let comment = ctx.get_next_comment_text(()).await?;
-            insta::assert_snapshot!(comment, @"
+            insta::assert_snapshot!(comment, @r#"
             :sunny: Test successful - [Workflow1](https://github.com/rust-lang/borstest/actions/runs/1)
             Approved by: `default-user`
             Pushing merge-0-pr-1 to `main`...
-            ");
+            <!-- homu: {"type":"BuildCompleted","base_ref":"main","merge_sha":"merge-0-pr-1"} -->
+            "#);
 
             ctx.pr(()).await.expect_status(PullRequestStatus::Merged);
 

--- a/src/bors/comment.rs
+++ b/src/bors/comment.rs
@@ -19,6 +19,7 @@ pub struct Comment {
 #[serde(tag = "type")]
 pub enum CommentMetadata {
     TryBuildCompleted { merge_sha: String },
+    BuildCompleted { base_ref: String, merge_sha: String },
 }
 
 /// A tag for a comment, used to identify the comment.
@@ -367,11 +368,17 @@ pub fn auto_build_succeeded_comment(
         .collect::<Vec<_>>()
         .join(", ");
 
-    Comment::new(format!(
-        r#":sunny: Test successful - {urls}
+    Comment {
+        text: format!(
+            r#":sunny: Test successful - {urls}
 Approved by: `{approved_by}`
 Pushing {merge_sha} to `{base_ref}`..."#
-    ))
+        ),
+        metadata: Some(CommentMetadata::BuildCompleted {
+            base_ref: base_ref.to_owned(),
+            merge_sha: merge_sha.0.clone(),
+        }),
+    }
 }
 
 pub fn auto_build_push_failed_comment(error: &str) -> Comment {

--- a/src/bors/merge_queue.rs
+++ b/src/bors/merge_queue.rs
@@ -626,11 +626,12 @@ merge_queue_enabled = false
 
             insta::assert_snapshot!(
                 ctx.get_next_comment_text(()).await?,
-                @"
+                @r#"
             :sunny: Test successful - [Workflow1](https://github.com/rust-lang/borstest/actions/runs/1)
             Approved by: `default-user`
             Pushing merge-0-pr-1 to `main`...
-            "
+            <!-- homu: {"type":"BuildCompleted","base_ref":"main","merge_sha":"merge-0-pr-1"} -->
+            "#
             );
             Ok(())
         })


### PR DESCRIPTION
It is currently required by triagebot, although I would like to get rid of it eventually.
