### PR TITLE
Correctly handle 422 error from the update reference GitHub endpoint

### DIFF
--- a/src/bors/merge_queue.rs
+++ b/src/bors/merge_queue.rs
@@ -193,9 +193,6 @@ async fn handle_successful_build(
                     "the tested commit was behind the `{branch_name}` branch"
                 )))
             }
-            BranchUpdateError::BranchNotFound(branch_name) => Some(auto_build_push_failed_comment(
-                &format!("the branch {branch_name} was not found"),
-            )),
             // If a transient error happened, try again next time
             _ => None,
         };

--- a/src/github/api/client.rs
+++ b/src/github/api/client.rs
@@ -216,8 +216,7 @@ impl GithubRepositoryClient {
                 .await
                 .map_err(|e| match e {
                     error @ (BranchUpdateError::Conflict(_)
-                    | BranchUpdateError::ValidationFailed(_)
-                    | BranchUpdateError::BranchNotFound(_)) => ShouldRetry::No(error),
+                    | BranchUpdateError::ValidationFailed(_)) => ShouldRetry::No(error),
                     error => ShouldRetry::Yes(error),
                 })
         })

--- a/src/tests/mock/repository.rs
+++ b/src/tests/mock/repository.rs
@@ -214,7 +214,8 @@ async fn mock_update_branch(repo: Arc<Mutex<Repo>>, mock_server: &MockServer) {
                 let commit = repo.get_commit_by_sha(&sha);
                 repo.push_commit(branch_name, commit);
             } else {
-                return ResponseTemplate::new(404);
+                // GitHub uses this error code in this endpoint when the branch does not exist
+                return ResponseTemplate::new(422);
             }
 
             ResponseTemplate::new(200)


### PR DESCRIPTION
Turns out that GitHub doesn't actually return 404 here if the branch doesn't exist. Since the corresponding bors branches now exist on `rust-lang/rust`, and rollups create a new branch explicitly, this shouldn't be a problem in practice, but it's still good to handle this properly.
