### PR TITLE
Use snapshot testing for branch SHA history

### DIFF
--- a/src/bors/handlers/review.rs
+++ b/src/bors/handlers/review.rs
@@ -827,16 +827,14 @@ approved = ["+foo", "+baz", "-bar", "-foo2"]
                 Ok(())
             })
             .await;
-        gh.check_sha_history(
-            default_repo_name(),
+        insta::assert_snapshot!(gh.get_sha_history(
+            (),
             TRY_MERGE_BRANCH_NAME,
-            &["main-sha1", "merge-0-pr-1-42cd8de2"],
-        );
-        gh.check_sha_history(
-            default_repo_name(),
-            TRY_BRANCH_NAME,
-            &["merge-0-pr-1-42cd8de2"],
-        );
+        ), @"
+        main-sha1
+        merge-0-pr-1-42cd8de2
+        ");
+        insta::assert_snapshot!(gh.get_sha_history((), TRY_BRANCH_NAME), @"merge-0-pr-1-42cd8de2");
     }
 
     #[sqlx::test]

--- a/src/bors/handlers/trybuild.rs
+++ b/src/bors/handlers/trybuild.rs
@@ -495,16 +495,17 @@ try-job: Bar
             Ok(())
         })
         .await;
-        gh.check_sha_history(
-            default_repo_name(),
+        insta::assert_snapshot!(gh.get_sha_history(
+            (),
             TRY_MERGE_BRANCH_NAME,
-            &["main-sha1", "merge-0-pr-1-42cd8de2"],
-        );
-        gh.check_sha_history(
-            default_repo_name(),
+        ), @"
+        main-sha1
+        merge-0-pr-1-42cd8de2
+        ");
+        insta::assert_snapshot!(gh.get_sha_history(
+            (),
             TRY_BRANCH_NAME,
-            &["merge-0-pr-1-42cd8de2"],
-        );
+        ), @"merge-0-pr-1-42cd8de2");
     }
 
     #[sqlx::test]
@@ -522,14 +523,13 @@ try-job: Bar
             Ok(())
         })
         .await;
-        gh.check_sha_history(
-            default_repo_name(),
+        insta::assert_snapshot!(gh.get_sha_history(
+            (),
             TRY_MERGE_BRANCH_NAME,
-            &[
-                "ea9c1b050cc8b420c2c211d2177811e564a4dc60",
-                "merge-0-pr-1-42cd8de2",
-            ],
-        );
+        ), @"
+        ea9c1b050cc8b420c2c211d2177811e564a4dc60
+        merge-0-pr-1-42cd8de2
+        ");
     }
 
     #[sqlx::test]
@@ -555,16 +555,15 @@ try-job: Bar
             Ok(())
         })
         .await;
-        gh.check_sha_history(
+        insta::assert_snapshot!(gh.get_sha_history(
             (),
             TRY_MERGE_BRANCH_NAME,
-            &[
-                "ea9c1b050cc8b420c2c211d2177811e564a4dc60",
-                "merge-0-pr-1-42cd8de2",
-                "ea9c1b050cc8b420c2c211d2177811e564a4dc60",
-                "merge-1-pr-1-42cd8de2",
-            ],
-        );
+        ), @"
+        ea9c1b050cc8b420c2c211d2177811e564a4dc60
+        merge-0-pr-1-42cd8de2
+        ea9c1b050cc8b420c2c211d2177811e564a4dc60
+        merge-1-pr-1-42cd8de2
+        ");
     }
 
     #[sqlx::test]

--- a/src/bors/merge_queue.rs
+++ b/src/bors/merge_queue.rs
@@ -696,21 +696,24 @@ merge_queue_enabled = false
             Ok(())
         })
         .await;
-        gh.check_sha_history(
-            default_repo_name(),
+        insta::assert_snapshot!(gh.get_sha_history(
+            (),
             "main",
-            &["main-sha1", "merge-0-pr-1-577acb30"],
-        );
-        gh.check_sha_history(
-            default_repo_name(),
-            AUTO_MERGE_BRANCH_NAME,
-            &["main-sha1", "merge-0-pr-1-577acb30"],
-        );
-        gh.check_sha_history(
-            default_repo_name(),
+        ), @"
+        main-sha1
+        merge-0-pr-1-577acb30
+        ");
+        insta::assert_snapshot!(gh.get_sha_history(
+            (),
+            AUTO_MERGE_BRANCH_NAME
+        ), @"
+        main-sha1
+        merge-0-pr-1-577acb30
+        ");
+        insta::assert_snapshot!(gh.get_sha_history(
+            (),
             AUTO_BRANCH_NAME,
-            &["merge-0-pr-1-577acb30"],
-        );
+        ), @"merge-0-pr-1-577acb30");
     }
 
     #[sqlx::test]
@@ -737,17 +740,17 @@ merge_queue_enabled = false
         })
         .await;
 
-        gh.check_sha_history(
-            default_repo_name(),
+        insta::assert_snapshot!(gh.get_sha_history(
+            (),
             "main",
-            &[
-                "main-sha1",
-                "merge-0-pr-1-577acb30",
-                "merge-1-pr-2-5f8fa650",
-                "merge-2-pr-3-2ded0de1",
-                "merge-3-pr-4-0d736c05",
-            ],
-        );
+
+        ), @"
+        main-sha1
+        merge-0-pr-1-577acb30
+        merge-1-pr-2-5f8fa650
+        merge-2-pr-3-2ded0de1
+        merge-3-pr-4-0d736c05
+        ");
     }
 
     #[sqlx::test]
@@ -771,16 +774,16 @@ merge_queue_enabled = false
         })
         .await;
 
-        gh.check_sha_history(
-            default_repo_name(),
+        insta::assert_snapshot!(gh.get_sha_history(
+            (),
             "main",
-            &[
-                "main-sha1",
-                "merge-0-pr-4-0d736c05",
-                "merge-1-pr-2-5f8fa650",
-                "merge-2-pr-3-2ded0de1",
-            ],
-        );
+
+        ), @"
+        main-sha1
+        merge-0-pr-4-0d736c05
+        merge-1-pr-2-5f8fa650
+        merge-2-pr-3-2ded0de1
+        ");
     }
 
     #[sqlx::test]
@@ -838,7 +841,7 @@ merge_queue_enabled = false
             Ok(())
         })
         .await;
-        gh.check_sha_history((), default_branch_name(), &["main-sha1"]);
+        insta::assert_snapshot!(gh.get_sha_history((), default_branch_name()), @"main-sha1");
     }
 
     #[sqlx::test]

--- a/src/tests/github.rs
+++ b/src/tests/github.rs
@@ -93,12 +93,8 @@ impl GitHub {
         func(self.comments.get_mut(node_id).unwrap());
     }
 
-    pub fn check_sha_history<Id: Into<RepoIdentifier>>(
-        &self,
-        repo: Id,
-        branch: &str,
-        expected_shas: &[&str],
-    ) {
+    /// Get SHA history as a list of lines, for easier snapshot testing.
+    pub fn get_sha_history<Id: Into<RepoIdentifier>>(&self, repo: Id, branch: &str) -> String {
         let actual_shas = self
             .get_repo(repo)
             .lock()
@@ -108,8 +104,7 @@ impl GitHub {
             .into_iter()
             .map(|b| b.sha)
             .collect::<Vec<_>>();
-        let actual_shas: Vec<&str> = actual_shas.iter().map(|s| s.as_str()).collect();
-        assert_eq!(actual_shas, expected_shas);
+        actual_shas.join("\n")
     }
 
     pub fn check_cancelled_workflows(&self, repo: GithubRepoName, expected_run_ids: &[RunId]) {


### PR DESCRIPTION
That should make it much easier to update it in the future and add new test assertions for it.
