### PR TITLE
Mark timeouted builds as timeouted, rather than cancelled

### DIFF
--- a/src/bors/build_queue.rs
+++ b/src/bors/build_queue.rs
@@ -10,8 +10,8 @@
 //! other background sync processes. We want to finish builds as fast as possible.
 
 use crate::bors::build::{
-    CancelBuildError, cancel_build, get_failed_jobs, hide_build_started_comments,
-    load_workflow_runs,
+    CancelBuildConclusion, CancelBuildError, cancel_build, get_failed_jobs,
+    hide_build_started_comments, load_workflow_runs,
 };
 use crate::bors::comment::{
     CommentTag, build_failed_comment, build_timed_out_comment, try_build_succeeded_comment,
@@ -157,7 +157,7 @@ async fn maybe_timeout_build(
 ) -> anyhow::Result<()> {
     if elapsed_time_since(build.created_at) >= timeout {
         tracing::info!("Cancelling build {build:?}");
-        match cancel_build(&repo.client, db, build, CheckRunConclusion::TimedOut).await {
+        match cancel_build(&repo.client, db, build, CancelBuildConclusion::Timeout).await {
             Ok(_) => {}
             Err(
                 CancelBuildError::FailedToMarkBuildAsCancelled(error)

--- a/src/bors/handlers/workflow.rs
+++ b/src/bors/handlers/workflow.rs
@@ -1,6 +1,6 @@
 use crate::PgDbClient;
 use crate::bors::RepositoryState;
-use crate::bors::build::CancelBuildError;
+use crate::bors::build::{CancelBuildConclusion, CancelBuildError};
 use crate::bors::build_queue::BuildQueueSender;
 use crate::bors::comment::{CommentTag, append_workflow_links_to_comment};
 use crate::bors::event::{WorkflowRunCompleted, WorkflowRunStarted};
@@ -8,7 +8,6 @@ use crate::bors::handlers::is_bors_observed_branch;
 use crate::bors::{BuildKind, build};
 use crate::database::{BuildModel, BuildStatus, PullRequestModel, QueueStatus, WorkflowStatus};
 use crate::github::api::client::GithubRepositoryClient;
-use octocrab::params::checks::CheckRunConclusion;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -175,7 +174,7 @@ pub async fn maybe_cancel_auto_build(
 
     tracing::info!("Cancelling auto build {auto_build:?}");
 
-    match build::cancel_build(client, db, auto_build, CheckRunConclusion::Cancelled).await {
+    match build::cancel_build(client, db, auto_build, CancelBuildConclusion::Cancel).await {
         Ok(workflows) => {
             tracing::info!("Auto build cancelled");
             let workflow_urls = workflows.into_iter().map(|w| w.url).collect();


### PR DESCRIPTION
Because we need to treat them as failed for the merge queue.
