### PR TITLE
Do not allow rolling up PRs with a failed auto build

### DIFF
--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -453,7 +453,16 @@ impl PullRequestModel {
     /// Determines if this PR can be included in a rollup.
     /// A PR is rollupable if it has been approved and is not marked as `RollupMode::Never`.
     pub fn is_rollupable(&self) -> bool {
-        self.is_approved() && !matches!(self.rollup, Some(RollupMode::Never))
+        if let Some(RollupMode::Never) = self.rollup {
+            return false;
+        }
+
+        match self.queue_status() {
+            QueueStatus::Approved(_) | QueueStatus::Pending(_, _) => true,
+            QueueStatus::Failed(_, _)
+            | QueueStatus::ReadyForMerge(_, _)
+            | QueueStatus::NotApproved => false,
+        }
     }
 }
 


### PR DESCRIPTION
I think that rolling these up might be useful in theory if there's a cascading CI failure and we don't stop the tree soon enough, so that there are a lot of failed PRs that would have to be retried one by one. But in the common case, we should probably require resetting failed PRs with `@bors retry`.

Fixes: https://github.com/rust-lang/bors/issues/586