### PR TITLE
Override git commit author for try/auto merge commits

### DIFF
--- a/src/bors/handlers/autobuild.rs
+++ b/src/bors/handlers/autobuild.rs
@@ -148,7 +148,7 @@ mod tests {
             ctx.run_merge_queue_now().await;
             insta::assert_snapshot!(
                 ctx.get_next_comment_text(()).await?,
-                @":hourglass: Testing commit pr-1-sha with merge merge-1-pr-1-bc4b41f8..."
+                @":hourglass: Testing commit pr-1-sha with merge merge-1-pr-1-d7d45f1f-reauthored-to-bors..."
             );
             Ok(())
         })

--- a/src/bors/handlers/refresh.rs
+++ b/src/bors/handlers/refresh.rs
@@ -480,9 +480,9 @@ auto_build_failed = ["+failed"]
                 // The try build was completed successfully, not timed out
                 insta::assert_snapshot!(ctx.get_next_comment_text(()).await?, @r#"
                 :sunny: Try build successful ([Workflow1](https://github.com/rust-lang/borstest/actions/runs/1))
-                Build commit: merge-0-pr-1-e54ad984 (`merge-0-pr-1-e54ad984`, parent: `main-sha1`)
+                Build commit: merge-0-pr-1-d7d45f1f-reauthored-to-bors (`merge-0-pr-1-d7d45f1f-reauthored-to-bors`, parent: `main-sha1`)
 
-                <!-- homu: {"type":"TryBuildCompleted","merge_sha":"merge-0-pr-1-e54ad984"} -->
+                <!-- homu: {"type":"TryBuildCompleted","merge_sha":"merge-0-pr-1-d7d45f1f-reauthored-to-bors"} -->
                 "#);
 
                 Ok(())
@@ -512,8 +512,8 @@ auto_build_failed = ["+failed"]
             insta::assert_snapshot!(comment, @r#"
             :sunny: Test successful - [Workflow1](https://github.com/rust-lang/borstest/actions/runs/1)
             Approved by: `default-user`
-            Pushing merge-0-pr-1-bc4b41f8 to `main`...
-            <!-- homu: {"type":"BuildCompleted","base_ref":"main","merge_sha":"merge-0-pr-1-bc4b41f8"} -->
+            Pushing merge-0-pr-1-d7d45f1f-reauthored-to-bors to `main`...
+            <!-- homu: {"type":"BuildCompleted","base_ref":"main","merge_sha":"merge-0-pr-1-d7d45f1f-reauthored-to-bors"} -->
             "#);
 
             ctx.pr(()).await.expect_status(PullRequestStatus::Merged);
@@ -543,8 +543,8 @@ auto_build_failed = ["+failed"]
             insta::assert_snapshot!(comment, @r#"
             :sunny: Test successful - [Workflow1](https://github.com/rust-lang/borstest/actions/runs/1)
             Approved by: `default-user`
-            Pushing merge-0-pr-1-bc4b41f8 to `main`...
-            <!-- homu: {"type":"BuildCompleted","base_ref":"main","merge_sha":"merge-0-pr-1-bc4b41f8"} -->
+            Pushing merge-0-pr-1-d7d45f1f-reauthored-to-bors to `main`...
+            <!-- homu: {"type":"BuildCompleted","base_ref":"main","merge_sha":"merge-0-pr-1-d7d45f1f-reauthored-to-bors"} -->
             "#);
 
             ctx.pr(()).await.expect_status(PullRequestStatus::Merged);

--- a/src/bors/handlers/review.rs
+++ b/src/bors/handlers/review.rs
@@ -394,6 +394,7 @@ async fn notify_of_delegation(
 #[cfg(test)]
 mod tests {
     use octocrab::params::checks::{CheckRunConclusion, CheckRunStatus};
+    use tracing_test::traced_test;
 
     use crate::bors::TRY_BRANCH_NAME;
     use crate::bors::merge_queue::AUTO_BUILD_CHECK_RUN_NAME;
@@ -799,6 +800,7 @@ approved = { modifications = ["+foo", "+baz"], unless = ["label1", "label2"] }
     }
 
     #[sqlx::test]
+    #[traced_test]
     async fn delegatee_can_approve(pool: sqlx::PgPool) {
         BorsBuilder::new(pool)
             .github(GitHub::unauthorized_pr_author())
@@ -834,9 +836,9 @@ approved = { modifications = ["+foo", "+baz"], unless = ["label1", "label2"] }
             TRY_MERGE_BRANCH_NAME,
         ), @"
         main-sha1
-        merge-0-pr-1-e54ad984
+        merge-0-pr-1-d7d45f1f
         ");
-        insta::assert_snapshot!(gh.get_sha_history((), TRY_BRANCH_NAME), @"merge-0-pr-1-e54ad984");
+        insta::assert_snapshot!(gh.get_sha_history((), TRY_BRANCH_NAME), @"merge-0-pr-1-d7d45f1f-reauthored-to-bors");
     }
 
     #[sqlx::test]
@@ -1209,7 +1211,7 @@ approved = { modifications = ["+foo", "+baz"], unless = ["label1", "label2"] }
 
                 ctx.post_comment("@bors try").await?;
                 insta::assert_snapshot!(ctx.get_next_comment_text(()).await?, @"
-                :hourglass: Trying commit pr-1-sha with merge merge-0-pr-1-e54ad984…
+                :hourglass: Trying commit pr-1-sha with merge merge-0-pr-1-d7d45f1f-reauthored-to-bors…
 
                 To cancel the try build, run the command `@bors try cancel`.
                 ");

--- a/src/bors/handlers/workflow.rs
+++ b/src/bors/handlers/workflow.rs
@@ -300,9 +300,9 @@ mod tests {
             :sunny: Try build successful
             - [Workflow1](https://github.com/rust-lang/borstest/actions/runs/1) :white_check_mark:
             - [Workflow1](https://github.com/rust-lang/borstest/actions/runs/2) :white_check_mark:
-            Build commit: merge-0-pr-1-e54ad984 (`merge-0-pr-1-e54ad984`, parent: `main-sha1`)
+            Build commit: merge-0-pr-1-d7d45f1f-reauthored-to-bors (`merge-0-pr-1-d7d45f1f-reauthored-to-bors`, parent: `main-sha1`)
 
-            <!-- homu: {"type":"TryBuildCompleted","merge_sha":"merge-0-pr-1-e54ad984"} -->
+            <!-- homu: {"type":"TryBuildCompleted","merge_sha":"merge-0-pr-1-d7d45f1f-reauthored-to-bors"} -->
             "#
             );
             Ok(())
@@ -330,9 +330,9 @@ mod tests {
             :sunny: Try build successful
             - [Workflow1](https://github.com/rust-lang/borstest/actions/runs/1) :white_check_mark:
             - [Workflow1](https://github.com/rust-lang/borstest/actions/runs/2) :white_check_mark:
-            Build commit: merge-0-pr-1-e54ad984 (`merge-0-pr-1-e54ad984`, parent: `main-sha1`)
+            Build commit: merge-0-pr-1-d7d45f1f-reauthored-to-bors (`merge-0-pr-1-d7d45f1f-reauthored-to-bors`, parent: `main-sha1`)
 
-            <!-- homu: {"type":"TryBuildCompleted","merge_sha":"merge-0-pr-1-e54ad984"} -->
+            <!-- homu: {"type":"TryBuildCompleted","merge_sha":"merge-0-pr-1-d7d45f1f-reauthored-to-bors"} -->
             "#
             );
             Ok(())
@@ -355,7 +355,7 @@ mod tests {
             ctx.workflow_event(WorkflowEvent::failure(w2)).await?;
             insta::assert_snapshot!(
                 ctx.get_next_comment_text(()).await?,
-                @":broken_heart: Test for merge-0-pr-1-e54ad984 failed: [Workflow1](https://github.com/rust-lang/borstest/actions/runs/1), [Workflow1](https://github.com/rust-lang/borstest/actions/runs/2)"
+                @":broken_heart: Test for merge-0-pr-1-d7d45f1f-reauthored-to-bors failed: [Workflow1](https://github.com/rust-lang/borstest/actions/runs/1), [Workflow1](https://github.com/rust-lang/borstest/actions/runs/2)"
             );
             Ok(())
         })
@@ -382,7 +382,7 @@ min_ci_time = 10
                     .workflow_full_success(w1)
                     .await?;
                 insta::assert_snapshot!(ctx.get_next_comment_text(()).await?, @"
-                :broken_heart: Test for merge-0-pr-1-e54ad984 failed: [Workflow1](https://github.com/rust-lang/borstest/actions/runs/1)
+                :broken_heart: Test for merge-0-pr-1-d7d45f1f-reauthored-to-bors failed: [Workflow1](https://github.com/rust-lang/borstest/actions/runs/1)
                 A workflow was considered to be a failure because it took only `1s`. The minimum duration for CI workflows is configured to be `10s`.
                 ");
                 Ok(())
@@ -409,7 +409,7 @@ min_ci_time = 10
                 ctx
                     .workflow_full_failure(w1)
                     .await?;
-                insta::assert_snapshot!(ctx.get_next_comment_text(()).await?, @":broken_heart: Test for merge-0-pr-1-e54ad984 failed: [Workflow1](https://github.com/rust-lang/borstest/actions/runs/1)");
+                insta::assert_snapshot!(ctx.get_next_comment_text(()).await?, @":broken_heart: Test for merge-0-pr-1-d7d45f1f-reauthored-to-bors failed: [Workflow1](https://github.com/rust-lang/borstest/actions/runs/1)");
                 Ok(())
             })
             .await;
@@ -434,9 +434,9 @@ min_ci_time = 20
                     .await?;
                 insta::assert_snapshot!(ctx.get_next_comment_text(()).await?, @r#"
                 :sunny: Try build successful ([Workflow1](https://github.com/rust-lang/borstest/actions/runs/1))
-                Build commit: merge-0-pr-1-e54ad984 (`merge-0-pr-1-e54ad984`, parent: `main-sha1`)
+                Build commit: merge-0-pr-1-d7d45f1f-reauthored-to-bors (`merge-0-pr-1-d7d45f1f-reauthored-to-bors`, parent: `main-sha1`)
 
-                <!-- homu: {"type":"TryBuildCompleted","merge_sha":"merge-0-pr-1-e54ad984"} -->
+                <!-- homu: {"type":"TryBuildCompleted","merge_sha":"merge-0-pr-1-d7d45f1f-reauthored-to-bors"} -->
                 "#);
                 Ok(())
             })

--- a/src/bors/mod.rs
+++ b/src/bors/mod.rs
@@ -1,6 +1,6 @@
 use crate::config::RepositoryConfig;
 use crate::github::GithubRepoName;
-use crate::github::api::client::GithubRepositoryClient;
+use crate::github::api::client::{CommitAuthor, GithubRepositoryClient};
 use crate::permissions::UserPermissions;
 #[cfg(test)]
 use crate::tests::TestSyncMarker;
@@ -284,6 +284,14 @@ impl FromStr for PullRequestStatus {
 pub enum MergeType {
     Try { try_jobs: Vec<String> },
     Auto,
+}
+
+/// Commit author used to emulate old bors (homu).
+fn bors_commit_author() -> CommitAuthor {
+    CommitAuthor {
+        name: "bors".to_string(),
+        email: "bors@rust-lang.org".to_string(),
+    }
 }
 
 /// HTML comment that marks the start of a bors ignore block.

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -115,6 +115,25 @@ impl Display for CommitSha {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct TreeSha(pub String);
+
+impl From<String> for TreeSha {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+impl AsRef<str> for TreeSha {
+    fn as_ref(&self) -> &str {
+        self.0.as_str()
+    }
+}
+impl Display for TreeSha {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(&self.0, f)
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct Branch {
     pub name: String,

--- a/src/tests/github.rs
+++ b/src/tests/github.rs
@@ -463,9 +463,13 @@ impl Repo {
     }
 
     pub fn push_commit(&mut self, branch_name: &str, commit: Commit) {
+        self.create_commit(commit.clone());
         self.get_branch_by_name(branch_name)
             .expect("Pushing to a non-existing branch")
-            .push_commit(commit.clone());
+            .push_commit(commit);
+    }
+
+    pub fn create_commit(&mut self, commit: Commit) {
         if let Some(old) = self.commits.insert(commit.commit_sha(), commit.clone()) {
             assert_eq!(old, commit);
         }
@@ -763,9 +767,25 @@ impl Default for Branch {
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
+pub struct GitUser {
+    pub name: String,
+    pub email: String,
+}
+
+impl Default for GitUser {
+    fn default() -> Self {
+        Self {
+            name: "git-user".to_string(),
+            email: "git-user@git.com".to_string(),
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Commit {
     sha: String,
     message: String,
+    author: GitUser,
 }
 
 impl Commit {
@@ -773,7 +793,13 @@ impl Commit {
         Self {
             sha: sha.to_owned(),
             message: message.to_owned(),
+            author: GitUser::default(),
         }
+    }
+
+    pub fn with_author(mut self, author: GitUser) -> Self {
+        self.author = author;
+        self
     }
 
     pub fn sha(&self) -> &str {
@@ -781,6 +807,9 @@ impl Commit {
     }
     pub fn commit_sha(&self) -> CommitSha {
         CommitSha(self.sha.to_owned())
+    }
+    pub fn author(&self) -> &GitUser {
+        &self.author
     }
 
     pub fn message(&self) -> &str {


### PR DESCRIPTION
This allows us to reuse the old bors@rust-lang.org commit author e-mail, thus retaining compatibility with various tools that scan rust-lang/rust git history and expect the old bors e-mail.
