### PR TITLE
Send approval comment before the label

### DIFF
--- a/src/bors/handlers/review.rs
+++ b/src/bors/handlers/review.rs
@@ -63,9 +63,8 @@ pub(super) async fn command_approve(
     let priority = priority.or(pr.db.priority.map(|p| p as u32));
 
     merge_queue_tx.notify().await?;
-    handle_label_trigger(&repo_state, pr.github, LabelTrigger::Approved).await?;
-
-    notify_of_approval(ctx, &repo_state, pr, priority, approver.as_str()).await
+    notify_of_approval(ctx, &repo_state, pr, priority, approver.as_str()).await?;
+    handle_label_trigger(&repo_state, pr.github, LabelTrigger::Approved).await
 }
 
 /// Keywords that will prevent an approval if they appear in the PR's title.


### PR DESCRIPTION
Otherwise it looks a bit weird. Before we had to do this to synchronize comments in tests, but they are now globally synchronized through a test marker.
