### PR TITLE
Use Postgres session advisory lock to ensure that try builds and the merge queue never run concurrently

### DIFF
--- a/src/bors/handlers/trybuild.rs
+++ b/src/bors/handlers/trybuild.rs
@@ -15,7 +15,7 @@ use crate::bors::{
     MergeType, RepositoryState, TRY_BRANCH_NAME, bors_commit_author, create_merge_commit_message,
     hide_tagged_comments,
 };
-use crate::database::{BuildModel, BuildStatus, PullRequestModel};
+use crate::database::{BuildModel, BuildStatus, ExclusiveOperationOutcome, PullRequestModel};
 use crate::github::api::client::{CheckRunOutput, GithubRepositoryClient};
 use crate::github::api::operations::ForcePush;
 use crate::github::{CommitSha, GithubUser, PullRequestNumber};
@@ -71,101 +71,119 @@ pub(super) async fn command_try_build(
             .context(format!("Cannot get SHA for branch {}", pr.github.base.name))?,
     };
 
-    // Try to cancel any previously running try build workflows
-    let cancelled_workflow_urls = if let Some(build) = get_pending_try_build(pr.db) {
-        let res = cancel_previous_try_build(repo, &db, build).await?;
-        // Also try to hide previous "Try build started" comments that weren't hidden yet
-        if let Err(error) =
-            hide_tagged_comments(repo, &db, pr.db, CommentTag::TryBuildStarted).await
-        {
-            tracing::error!("Failed to hide previous try build started comment(s): {error:?}");
-        }
+    let res = db
+        .ensure_not_concurrent(&format!("{}-try-build", repo.repository()), async |proof| {
+            // Try to cancel any previously running try build workflows
+            let cancelled_workflow_urls = if let Some(build) = get_pending_try_build(pr.db) {
+                let res = cancel_previous_try_build(repo, &db, build).await?;
+                // Also try to hide previous "Try build started" comments that weren't hidden yet
+                if let Err(error) =
+                    hide_tagged_comments(repo, &db, pr.db, CommentTag::TryBuildStarted).await
+                {
+                    tracing::error!(
+                        "Failed to hide previous try build started comment(s): {error:?}"
+                    );
+                }
 
-        res
-    } else {
-        vec![]
-    };
+                res
+            } else {
+                vec![]
+            };
 
-    // First, create the merge commit, using a temporary message that will not reference/spam any
-    // issue.
-    match attempt_merge(
-        &repo.client,
-        TRY_MERGE_BRANCH_NAME,
-        &pr.github.head.sha,
-        &base_sha,
-        "merge commit",
-    )
-    .await?
-    {
-        MergeResult::Success(merged_commit) => {
-            // Then, create the actual merge commit with an explicit author, so that we can override
-            // the author information to the bors account, to keep compatibility with various tools
-            // that depend on it.
-            let merged_commit = repo
-                .client
-                .create_commit(
-                    &merged_commit.tree,
-                    &merged_commit.parents,
-                    &create_merge_commit_message(pr, MergeType::Try { try_jobs: jobs }),
-                    &bors_commit_author(),
-                )
-                .await?;
-
-            // If the merge was succesful, run CI with merged commit
-            let build_id =
-                run_try_build(&repo.client, &db, pr.db, merged_commit.clone(), base_sha).await?;
-
-            // Create a check run to track the try build status in GitHub's UI.
-            // This gets added to the PR's head SHA so GitHub shows UI in the checks tab and
-            // the bottom of the PR.
-            match repo
-                .client
-                .create_check_run(
-                    TRY_BUILD_CHECK_RUN_NAME,
-                    &pr.github.head.sha,
-                    CheckRunStatus::InProgress,
-                    CheckRunOutput {
-                        title: "Bors try build".to_string(),
-                        summary: "".to_string(),
-                    },
-                    &build_id.to_string(),
-                )
-                .await
+            // First, create the merge commit, using a temporary message that will not reference/spam any
+            // issue.
+            match attempt_merge(
+                &repo.client,
+                TRY_MERGE_BRANCH_NAME,
+                &pr.github.head.sha,
+                &base_sha,
+                "merge commit",
+                &proof,
+            )
+            .await?
             {
-                Ok(check_run) => {
-                    db.update_build_check_run_id(build_id, check_run.id.into_inner() as i64)
+                MergeResult::Success(merged_commit) => {
+                    // Then, create the actual merge commit with an explicit author, so that we can override
+                    // the author information to the bors account, to keep compatibility with various tools
+                    // that depend on it.
+                    let merged_commit = repo
+                        .client
+                        .create_commit(
+                            &merged_commit.tree,
+                            &merged_commit.parents,
+                            &create_merge_commit_message(pr, MergeType::Try { try_jobs: jobs }),
+                            &bors_commit_author(),
+                        )
+                        .await?;
+
+                    // If the merge was succesful, run CI with merged commit
+                    let build_id =
+                        run_try_build(&repo.client, &db, pr.db, merged_commit.clone(), base_sha)
+                            .await?;
+
+                    // Create a check run to track the try build status in GitHub's UI.
+                    // This gets added to the PR's head SHA so GitHub shows UI in the checks tab and
+                    // the bottom of the PR.
+                    match repo
+                        .client
+                        .create_check_run(
+                            TRY_BUILD_CHECK_RUN_NAME,
+                            &pr.github.head.sha,
+                            CheckRunStatus::InProgress,
+                            CheckRunOutput {
+                                title: "Bors try build".to_string(),
+                                summary: "".to_string(),
+                            },
+                            &build_id.to_string(),
+                        )
+                        .await
+                    {
+                        Ok(check_run) => {
+                            db.update_build_check_run_id(
+                                build_id,
+                                check_run.id.into_inner() as i64,
+                            )
+                            .await?;
+                        }
+                        Err(error) => {
+                            // Check runs aren't critical, don't block progress if they fail
+                            log::error!("Cannot create check run: {error:?}");
+                        }
+                    }
+
+                    repo.client
+                        .post_comment(
+                            pr.number(),
+                            try_build_started_comment(
+                                &pr.github.head.sha,
+                                &merged_commit,
+                                bot_prefix,
+                                cancelled_workflow_urls,
+                            ),
+                            &db,
+                        )
                         .await?;
                 }
-                Err(error) => {
-                    // Check runs aren't critical, don't block progress if they fail
-                    log::error!("Cannot create check run: {error:?}");
+                MergeResult::Conflict => {
+                    repo.client
+                        .post_comment(
+                            pr.number(),
+                            merge_attempt_merge_conflict_comment(&pr.github.head.name),
+                            &db,
+                        )
+                        .await?;
                 }
-            }
-
-            repo.client
-                .post_comment(
-                    pr.number(),
-                    try_build_started_comment(
-                        &pr.github.head.sha,
-                        &merged_commit,
-                        bot_prefix,
-                        cancelled_workflow_urls,
-                    ),
-                    &db,
-                )
-                .await?;
-        }
-        MergeResult::Conflict => {
-            repo.client
-                .post_comment(
-                    pr.number(),
-                    merge_attempt_merge_conflict_comment(&pr.github.head.name),
-                    &db,
-                )
-                .await?;
+            };
+            Ok(())
+        })
+        .await?;
+    match res {
+        ExclusiveOperationOutcome::Performed(res) => res,
+        ExclusiveOperationOutcome::Skipped => {
+            tracing::warn!("Try build was not performed due to other concurrent bors instance");
+            Ok(())
         }
     }
-    Ok(())
 }
 
 /// Cancels a previously running try build and returns a list of cancelled workflow URLs.

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -11,7 +11,7 @@ use crate::{
     github::{GithubRepoName, PullRequest, PullRequestNumber},
 };
 use chrono::{DateTime, Utc};
-pub use client::PgDbClient;
+pub use client::{ExclusiveLockProof, ExclusiveOperationOutcome, PgDbClient};
 pub use octocrab::models::pulls::MergeableState as OctocrabMergeableState;
 use sqlx::error::BoxDynError;
 use sqlx::{Database, Postgres};

--- a/src/github/api/operations.rs
+++ b/src/github/api/operations.rs
@@ -1,12 +1,12 @@
+use crate::database::ExclusiveLockProof;
+use crate::github::api::client::{CheckRunOutput, CommitAuthor, GithubRepositoryClient};
+use crate::github::{CommitSha, TreeSha};
 use http::StatusCode;
 use octocrab::models::CheckRunId;
 use octocrab::models::checks::CheckRun;
 use octocrab::params::checks::{CheckRunConclusion, CheckRunStatus};
 use octocrab::params::repos::Reference;
 use thiserror::Error;
-
-use crate::github::api::client::{CheckRunOutput, CommitAuthor, GithubRepositoryClient};
-use crate::github::{CommitSha, TreeSha};
 
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub enum ForcePush {
@@ -412,6 +412,7 @@ pub async fn attempt_merge(
     head_sha: &CommitSha,
     base_sha: &CommitSha,
     merge_message: &str,
+    _merge_lock_is_held: &ExclusiveLockProof,
 ) -> anyhow::Result<MergeResult> {
     tracing::debug!(
         "Attempting to merge {head_sha} into base SHA {base_sha} using branch {branch_name}"

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -35,6 +35,7 @@ mod mock;
 mod utils;
 
 // Public re-exports for use in tests
+use crate::bors::merge_queue::merge_queue_tick;
 use crate::bors::mergeability_queue::{MergeabilityQueueReceiver, check_mergeability};
 use crate::bors::process::QueueSenders;
 use crate::github::api::client::HideCommentReason;
@@ -541,6 +542,21 @@ impl BorsTester {
         wait_for_marker(
             async || {
                 self.senders.merge_queue().perform_tick().await.unwrap();
+                Ok(())
+            },
+            &WAIT_FOR_MERGE_QUEUE,
+        )
+        .await
+        .unwrap();
+    }
+
+    /// Run the merge queue tick directly, without going through the command queue.
+    pub async fn run_merge_queue_directly(&self) {
+        wait_for_marker(
+            async || {
+                merge_queue_tick(self.ctx.clone(), self.senders.mergeability_queue())
+                    .await
+                    .unwrap();
                 Ok(())
             },
             &WAIT_FOR_MERGE_QUEUE,


### PR DESCRIPTION
To ensure that if we get concurrently deployed bors instances (for a few seconds/minutes), they will not attempt to do a try build or run the merge queue concurrently.
