### PR TITLE
Implement `@bors squash` command

### DIFF
--- a/src/bors/command/mod.rs
+++ b/src/bors/command/mod.rs
@@ -134,4 +134,6 @@ pub enum BorsCommand {
     Retry,
     /// Cancel an auto build currently running on a given PR (without removing it from the queue).
     Cancel,
+    /// Squash all commits of a pull request into a single commit.
+    Squash,
 }

--- a/src/bors/command/parser.rs
+++ b/src/bors/command/parser.rs
@@ -138,6 +138,7 @@ const DEFAULT_PARSERS: &[ParserFn] = &[
     parser_retry,
     parser_tree_ops,
     parser_cancel,
+    parser_squash,
 ];
 
 fn parse_command(input: &str, parsers: &[ParserFn]) -> ParseResult {
@@ -438,6 +439,14 @@ fn parser_tree_ops(command: &CommandPart<'_>, _parts: &[CommandPart<'_>]) -> Par
 fn parser_cancel(command: &CommandPart<'_>, _parts: &[CommandPart<'_>]) -> ParseResult {
     match command {
         CommandPart::Bare("cancel" | "yield") => Some(Ok(BorsCommand::Cancel)),
+        _ => None,
+    }
+}
+
+/// Parses `@bors squash` command.
+fn parser_squash(command: &CommandPart<'_>, _parts: &[CommandPart<'_>]) -> ParseResult {
+    match command {
+        CommandPart::Bare("squash") => Some(Ok(BorsCommand::Squash)),
         _ => None,
     }
 }
@@ -1352,6 +1361,13 @@ for the crater",
         let cmds = parse_commands("@bors yield");
         assert_eq!(cmds.len(), 1);
         assert_eq!(cmds[0], Ok(BorsCommand::Cancel));
+    }
+
+    #[test]
+    fn parse_squash() {
+        let cmds = parse_commands("@bors squash");
+        assert_eq!(cmds.len(), 1);
+        assert_eq!(cmds[0], Ok(BorsCommand::Squash));
     }
 
     #[test]

--- a/src/bors/handlers/help.rs
+++ b/src/bors/handlers/help.rs
@@ -52,6 +52,7 @@ mod tests {
             - `try cancel`: Cancel a running try build on the current PR.
             - `retry`: Clear a failed auto build status from an approved PR. This will cause the merge queue to eventually attempt to merge the PR again.
             - `cancel` | `yield`: Cancel a running auto build on the current PR.
+            - `squash`: Squash the commits of a PR into a single commit.
             - `info`: Get information about the current PR
 
             ## Repository management

--- a/src/bors/handlers/mod.rs
+++ b/src/bors/handlers/mod.rs
@@ -15,6 +15,7 @@ use crate::bors::handlers::refresh::{
 use crate::bors::handlers::review::{
     command_approve, command_close_tree, command_open_tree, command_unapprove,
 };
+use crate::bors::handlers::squash::command_squash;
 use crate::bors::handlers::trybuild::{command_try_build, command_try_cancel};
 use crate::bors::handlers::workflow::{handle_workflow_completed, handle_workflow_started};
 use crate::bors::labels::handle_label_trigger;
@@ -46,6 +47,7 @@ mod ping;
 mod pr_events;
 mod refresh;
 mod review;
+mod squash;
 mod trybuild;
 mod workflow;
 
@@ -534,6 +536,12 @@ async fn handle_comment(
                         )
                         .instrument(span)
                         .await
+                    }
+                    BorsCommand::Squash => {
+                        let span = tracing::info_span!("Squash");
+                        command_squash(repo, database, pr, &comment.author, ctx.parser.prefix())
+                            .instrument(span)
+                            .await
                     }
                 };
                 if result.is_err() {

--- a/src/bors/handlers/squash.rs
+++ b/src/bors/handlers/squash.rs
@@ -1,0 +1,144 @@
+use crate::PgDbClient;
+use crate::bors::handlers::{PullRequestData, unapprove_pr};
+use crate::bors::{CommandPrefix, Comment, RepositoryState, bors_commit_author};
+use crate::database::BuildStatus;
+use crate::github::GithubUser;
+use crate::github::api::client::CommitAuthor;
+use crate::github::api::operations::ForcePush;
+use std::fmt::Write;
+use std::sync::Arc;
+
+pub(super) async fn command_squash(
+    repo_state: Arc<RepositoryState>,
+    db: Arc<PgDbClient>,
+    pr: PullRequestData<'_>,
+    author: &GithubUser,
+    bot_prefix: &CommandPrefix,
+) -> anyhow::Result<()> {
+    let send_comment = async |text: String| {
+        repo_state
+            .client
+            .post_comment(pr.number(), Comment::new(text), &db)
+            .await?;
+        anyhow::Ok(())
+    };
+
+    if author.id != pr.github.author.id {
+        send_comment(":key: Only the PR author can squash its commits.".to_string()).await?;
+        return Ok(());
+    }
+
+    let pr_model = pr.db;
+    if pr_model
+        .auto_build
+        .as_ref()
+        .map(|build| build.status == BuildStatus::Pending)
+        .unwrap_or(false)
+    {
+        send_comment(
+            format!(":exclamation: Cannot squash a PR that is currently being tested. Unapprove the PR first using `{bot_prefix} r-`."),
+        )
+        .await?;
+        return Ok(());
+    }
+
+    if pr.github.commit_count > 250 {
+        send_comment(format!(
+            ":exclamation: The PR has too many commits ({}). At most 250 commits can be squashed.",
+            pr.github.commit_count
+        ))
+        .await?;
+        return Ok(());
+    }
+    let commits = repo_state
+        .client
+        .get_pull_request_commits(pr.number())
+        .await?;
+    if commits.len() < 2 {
+        send_comment(":exclamation: The PR has only one commit.".to_string()).await?;
+        return Ok(());
+    }
+
+    // Extract the first and last commits
+    // We take the parents of the first commit, and the tree of the last commit, to create the
+    // squashed commit.
+    let first_commit = &commits[0];
+    let last_commit = commits.last().unwrap();
+    let author = last_commit.author.clone().unwrap_or_else(|| CommitAuthor {
+        name: pr.github.author.username.clone(),
+        email: pr
+            .github
+            .author
+            .email
+            .clone()
+            .unwrap_or_else(|| bors_commit_author().email),
+    });
+    let commit_msg = "Squashed commit";
+    let commit = match repo_state
+        .client
+        .create_commit(
+            &last_commit.tree,
+            &first_commit.parents,
+            commit_msg,
+            &author,
+        )
+        .await
+    {
+        Ok(commit) => commit,
+        Err(error) => {
+            send_comment(format!(
+                ":exclamation: Failed to create squashed commit: {error}"
+            ))
+            .await?;
+            return Ok(());
+        }
+    };
+
+    let fork_error =
+        || ":fork_and_knife: The squash command can only be used on PRs from a fork.".to_string();
+    let fork_repository = match pr.github.head_repository.as_ref() {
+        None => {
+            send_comment(fork_error()).await?;
+            return Ok(());
+        }
+        Some(repo) if repo == repo_state.repository() => {
+            send_comment(fork_error()).await?;
+            return Ok(());
+        }
+        Some(repo) => repo,
+    };
+    match repo_state
+        .client
+        .set_fork_branch_to_sha(
+            fork_repository,
+            &pr.github.head.name,
+            &commit,
+            ForcePush::YesIfBranchExists,
+        )
+        .await
+    {
+        Ok(_) => {}
+        Err(error) => {
+            send_comment(format!(
+                ":exclamation: Failed to push the squashed commit to `{fork_repository}`: {error}"
+            ))
+            .await?;
+        }
+    }
+
+    let unapproved = if pr_model.is_approved() {
+        unapprove_pr(&repo_state, &db, pr_model, pr.github).await?;
+        true
+    } else {
+        false
+    };
+
+    let mut msg = format!(
+        ":hammer: {} commits were squashed into {commit}.",
+        pr.github.commit_count,
+    );
+    if unapproved {
+        writeln!(msg, "\n\nThe pull request was unapproved.").unwrap();
+    }
+    send_comment(msg).await
+}

--- a/src/bors/mod.rs
+++ b/src/bors/mod.rs
@@ -78,6 +78,7 @@ pub fn format_help() -> &'static str {
         BorsCommand::TreeClosed(_) => {}
         BorsCommand::Retry => {}
         BorsCommand::Cancel => {}
+        BorsCommand::Squash => {}
     }
 
     r#"
@@ -106,6 +107,7 @@ You can use the following commands:
 - `try cancel`: Cancel a running try build on the current PR.
 - `retry`: Clear a failed auto build status from an approved PR. This will cause the merge queue to eventually attempt to merge the PR again.
 - `cancel` | `yield`: Cancel a running auto build on the current PR.
+- `squash`: Squash the commits of a PR into a single commit.
 - `info`: Get information about the current PR
 
 ## Repository management

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -697,6 +697,7 @@ pub fn pr_needs_update_in_db(db_pr: &PullRequestModel, gh_pr: &PullRequest) -> b
         number: _,
         head_label: _,
         head,
+        head_repository: _,
         base,
         title,
         // It seems that when we query PRs in bulk from GitHub, the mergeability status is
@@ -708,6 +709,7 @@ pub fn pr_needs_update_in_db(db_pr: &PullRequestModel, gh_pr: &PullRequest) -> b
         status,
         labels: _,
         html_url: _,
+        commit_count: _,
     } = gh_pr;
     if status != db_status {
         return true;

--- a/src/github/api/operations.rs
+++ b/src/github/api/operations.rs
@@ -1,6 +1,6 @@
 use crate::database::ExclusiveLockProof;
 use crate::github::api::client::{CheckRunOutput, CommitAuthor, GithubRepositoryClient};
-use crate::github::{CommitSha, TreeSha};
+use crate::github::{CommitSha, GithubRepoName, TreeSha};
 use http::StatusCode;
 use octocrab::models::CheckRunId;
 use octocrab::models::checks::CheckRun;
@@ -8,9 +8,14 @@ use octocrab::params::checks::{CheckRunConclusion, CheckRunStatus};
 use octocrab::params::repos::Reference;
 use thiserror::Error;
 
+/// How should we perform a push to a branch/git reference.
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub enum ForcePush {
+    /// Force push. If the branch doesn't exist, create it.
     Yes,
+    /// Force push, but only if the branch does exist. If it doesn't exist, exit with an error.
+    YesIfBranchExists,
+    /// Only try to push to the branch, without creating a branch and without force pushing.
     No,
 }
 
@@ -48,6 +53,7 @@ pub struct Commit {
     pub sha: CommitSha,
     pub parents: Vec<CommitSha>,
     pub tree: TreeSha,
+    pub author: Option<CommitAuthor>,
 }
 
 /// Creates a merge commit on the given repository.
@@ -100,7 +106,13 @@ pub async fn merge_branches(
                 .into_iter()
                 .map(|parent| CommitSha(parent.sha))
                 .collect();
-            Commit { sha, tree, parents }
+            // TODO
+            Commit {
+                sha,
+                tree,
+                parents,
+                author: None,
+            }
         }
     }
 
@@ -172,18 +184,19 @@ pub async fn merge_branches(
 /// Forcefully updates the branch to the given commit `sha`.
 /// If the branch does not exist yet, it instead attempts to create it.
 pub async fn set_branch_to_commit(
-    repo: &GithubRepositoryClient,
+    client: &GithubRepositoryClient,
+    repo: &GithubRepoName,
     branch_name: String,
     sha: &CommitSha,
     force: ForcePush,
 ) -> Result<(), BranchUpdateError> {
     // Fast-path: assume that the branch exists
-    match update_branch(repo, branch_name.clone(), sha, force).await {
+    match update_branch(client, repo, branch_name.clone(), sha, force).await {
         Ok(_) => Ok(()),
         // Branch does not exist yet or there was some other error.
         // Try to create it instead if we are force pushing.
         Err(BranchUpdateError::ValidationFailed(_)) if force == ForcePush::Yes => {
-            match create_branch(repo, branch_name.clone(), sha).await {
+            match create_branch(client, repo, branch_name.clone(), sha).await {
                 Ok(_) => Ok(()),
                 Err(error) => Err(BranchUpdateError::Custom(error)),
             }
@@ -193,12 +206,14 @@ pub async fn set_branch_to_commit(
 }
 
 pub async fn create_branch(
-    repo: &GithubRepositoryClient,
+    client: &GithubRepositoryClient,
+    repo: &GithubRepoName,
     name: String,
     sha: &CommitSha,
 ) -> Result<(), String> {
-    repo.client()
-        .repos(repo.repository().owner(), repo.repository().name())
+    client
+        .client()
+        .repos(repo.owner(), repo.name())
         .create_ref(&Reference::Branch(name), sha.as_ref())
         .await
         .map_err(|error| format!("Cannot create branch: {error}"))?;
@@ -221,14 +236,14 @@ pub enum BranchUpdateError {
 
 /// Force update the branch with the given `branch_name` to the given `sha`.
 async fn update_branch(
-    repo: &GithubRepositoryClient,
+    client: &GithubRepositoryClient,
+    repo: &GithubRepoName,
     branch_name: String,
     sha: &CommitSha,
     force: ForcePush,
 ) -> Result<(), BranchUpdateError> {
     let url = format!(
-        "/repos/{}/git/refs/{}",
-        repo.repository(),
+        "/repos/{repo}/git/refs/{}",
         Reference::Branch(branch_name.clone()).ref_url()
     );
 
@@ -240,13 +255,17 @@ async fn update_branch(
         force: bool,
     }
 
-    let res = repo
+    let force = match force {
+        ForcePush::Yes | ForcePush::YesIfBranchExists => true,
+        ForcePush::No => false,
+    };
+    let res = client
         .client()
         ._patch(
             url.as_str(),
             Some(&Request {
                 sha: sha.as_ref(),
-                force: matches!(force, ForcePush::Yes),
+                force,
             }),
         )
         .await?;
@@ -255,7 +274,7 @@ async fn update_branch(
     tracing::trace!(
         "Updating branch response: status={}, text={:?}",
         status,
-        repo.client().body_to_string(res).await
+        client.client().body_to_string(res).await
     );
 
     match status {

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -83,6 +83,7 @@ impl FromStr for GithubRepoName {
 pub struct GithubUser {
     pub id: UserId,
     pub username: String,
+    pub email: Option<String>,
     pub html_url: Url,
 }
 
@@ -91,6 +92,7 @@ impl From<octocrab::models::Author> for GithubUser {
         Self {
             id: value.id,
             username: value.login,
+            email: value.email,
             html_url: value.html_url,
         }
     }
@@ -146,6 +148,7 @@ pub struct PullRequest {
     // <author>:<branch>
     pub head_label: String,
     pub head: Branch,
+    pub head_repository: Option<GithubRepoName>,
     pub base: Branch,
     pub title: String,
     pub mergeable_state: MergeableState,
@@ -155,6 +158,7 @@ pub struct PullRequest {
     pub status: PullRequestStatus,
     pub labels: Vec<String>,
     pub html_url: Option<Url>,
+    pub commit_count: u64,
 }
 
 impl From<octocrab::models::pulls::PullRequest> for PullRequest {
@@ -166,6 +170,11 @@ impl From<octocrab::models::pulls::PullRequest> for PullRequest {
                 name: pr.head.ref_field,
                 sha: pr.head.sha.into(),
             },
+            head_repository: pr.head.repo.and_then(|repo| {
+                let author = repo.owner?;
+                let name = author.name?;
+                Some(GithubRepoName::new(&name, &repo.name))
+            }),
             base: Branch {
                 name: pr.base.ref_field,
                 sha: pr.base.sha.into(),
@@ -198,6 +207,7 @@ impl From<octocrab::models::pulls::PullRequest> for PullRequest {
                 .map(|l| l.name)
                 .collect(),
             html_url: pr.html_url,
+            commit_count: pr.commits.unwrap_or(0),
         }
     }
 }

--- a/src/server/webhook.rs
+++ b/src/server/webhook.rs
@@ -520,6 +520,7 @@ mod tests {
                                     4539057,
                                 ),
                                 username: "Kobzol",
+                                email: None,
                                 html_url: Url {
                                     scheme: "https",
                                     cannot_be_a_base: false,
@@ -572,6 +573,7 @@ mod tests {
                                         "bedf96270622ff19b4711dd7df3f19f4be1cba93",
                                     ),
                                 },
+                                head_repository: None,
                                 base: Branch {
                                     name: "testest",
                                     sha: CommitSha(
@@ -586,6 +588,7 @@ mod tests {
                                         78085736,
                                     ),
                                     username: "vohoanglong0107",
+                                    email: None,
                                     html_url: Url {
                                         scheme: "https",
                                         cannot_be_a_base: false,
@@ -626,6 +629,7 @@ mod tests {
                                         fragment: None,
                                     },
                                 ),
+                                commit_count: 2,
                             },
                             from_base_sha: Some(
                                 CommitSha(
@@ -663,6 +667,7 @@ mod tests {
                                         "bedf96270622ff19b4711dd7df3f19f4be1cba93",
                                     ),
                                 },
+                                head_repository: None,
                                 base: Branch {
                                     name: "main",
                                     sha: CommitSha(
@@ -677,6 +682,7 @@ mod tests {
                                         78085736,
                                     ),
                                     username: "vohoanglong0107",
+                                    email: None,
                                     html_url: Url {
                                         scheme: "https",
                                         cannot_be_a_base: false,
@@ -717,6 +723,7 @@ mod tests {
                                         fragment: None,
                                     },
                                 ),
+                                commit_count: 2,
                             },
                         },
                     ),
@@ -743,6 +750,7 @@ mod tests {
                                     4539057,
                                 ),
                                 username: "Kobzol",
+                                email: None,
                                 html_url: Url {
                                     scheme: "https",
                                     cannot_be_a_base: false,
@@ -795,6 +803,7 @@ mod tests {
                                         "5f935077074fb7e225332e672399306591db30dd",
                                     ),
                                 },
+                                head_repository: None,
                                 base: Branch {
                                     name: "main",
                                     sha: CommitSha(
@@ -809,6 +818,7 @@ mod tests {
                                         66968718,
                                     ),
                                     username: "Sakib25800",
+                                    email: None,
                                     html_url: Url {
                                         scheme: "https",
                                         cannot_be_a_base: false,
@@ -845,6 +855,7 @@ mod tests {
                                         fragment: None,
                                     },
                                 ),
+                                commit_count: 2,
                             },
                             draft: false,
                         },
@@ -878,6 +889,7 @@ mod tests {
                                         "cf36029b6811f9e73e0c2dd2d8e41e3168c0a21a",
                                     ),
                                 },
+                                head_repository: None,
                                 base: Branch {
                                     name: "main",
                                     sha: CommitSha(
@@ -892,6 +904,7 @@ mod tests {
                                         72911296,
                                     ),
                                     username: "geetanshjuneja",
+                                    email: None,
                                     html_url: Url {
                                         scheme: "https",
                                         cannot_be_a_base: false,
@@ -930,6 +943,7 @@ mod tests {
                                         fragment: None,
                                     },
                                 ),
+                                commit_count: 1,
                             },
                         },
                     ),
@@ -962,6 +976,7 @@ mod tests {
                                         "4964158cdea899629716b4f0c0e2f5ab72e3cb4a",
                                     ),
                                 },
+                                head_repository: None,
                                 base: Branch {
                                     name: "main",
                                     sha: CommitSha(
@@ -976,6 +991,7 @@ mod tests {
                                         72911296,
                                     ),
                                     username: "geetanshjuneja",
+                                    email: None,
                                     html_url: Url {
                                         scheme: "https",
                                         cannot_be_a_base: false,
@@ -1012,6 +1028,7 @@ mod tests {
                                         fragment: None,
                                     },
                                 ),
+                                commit_count: 1,
                             },
                         },
                     ),
@@ -1044,6 +1061,7 @@ mod tests {
                                         "cf36029b6811f9e73e0c2dd2d8e41e3168c0a21a",
                                     ),
                                 },
+                                head_repository: None,
                                 base: Branch {
                                     name: "main",
                                     sha: CommitSha(
@@ -1058,6 +1076,7 @@ mod tests {
                                         72911296,
                                     ),
                                     username: "geetanshjuneja",
+                                    email: None,
                                     html_url: Url {
                                         scheme: "https",
                                         cannot_be_a_base: false,
@@ -1096,6 +1115,7 @@ mod tests {
                                         fragment: None,
                                     },
                                 ),
+                                commit_count: 1,
                             },
                         },
                     ),
@@ -1128,6 +1148,7 @@ mod tests {
                                         "4964158cdea899629716b4f0c0e2f5ab72e3cb4a",
                                     ),
                                 },
+                                head_repository: None,
                                 base: Branch {
                                     name: "main",
                                     sha: CommitSha(
@@ -1142,6 +1163,7 @@ mod tests {
                                         72911296,
                                     ),
                                     username: "geetanshjuneja",
+                                    email: None,
                                     html_url: Url {
                                         scheme: "https",
                                         cannot_be_a_base: false,
@@ -1178,6 +1200,7 @@ mod tests {
                                         fragment: None,
                                     },
                                 ),
+                                commit_count: 1,
                             },
                             draft: true,
                         },
@@ -1211,6 +1234,7 @@ mod tests {
                                         "4964158cdea899629716b4f0c0e2f5ab72e3cb4a",
                                     ),
                                 },
+                                head_repository: None,
                                 base: Branch {
                                     name: "main",
                                     sha: CommitSha(
@@ -1225,6 +1249,7 @@ mod tests {
                                         72911296,
                                     ),
                                     username: "geetanshjuneja",
+                                    email: None,
                                     html_url: Url {
                                         scheme: "https",
                                         cannot_be_a_base: false,
@@ -1261,6 +1286,7 @@ mod tests {
                                         fragment: None,
                                     },
                                 ),
+                                commit_count: 1,
                             },
                         },
                     ),
@@ -1293,6 +1319,7 @@ mod tests {
                                         "4964158cdea899629716b4f0c0e2f5ab72e3cb4a",
                                     ),
                                 },
+                                head_repository: None,
                                 base: Branch {
                                     name: "main",
                                     sha: CommitSha(
@@ -1307,6 +1334,7 @@ mod tests {
                                         72911296,
                                     ),
                                     username: "geetanshjuneja",
+                                    email: None,
                                     html_url: Url {
                                         scheme: "https",
                                         cannot_be_a_base: false,
@@ -1343,6 +1371,7 @@ mod tests {
                                         fragment: None,
                                     },
                                 ),
+                                commit_count: 1,
                             },
                         },
                     ),
@@ -1369,6 +1398,7 @@ mod tests {
                                     4539057,
                                 ),
                                 username: "Kobzol",
+                                email: None,
                                 html_url: Url {
                                     scheme: "https",
                                     cannot_be_a_base: false,
@@ -1421,6 +1451,7 @@ mod tests {
                                         "3824fd9a567e3c27dff0cd51427e7562a0eda8da",
                                     ),
                                 },
+                                head_repository: None,
                                 base: Branch {
                                     name: "main",
                                     sha: CommitSha(
@@ -1435,6 +1466,7 @@ mod tests {
                                         66968718,
                                     ),
                                     username: "Sakib25800",
+                                    email: None,
                                     html_url: Url {
                                         scheme: "https",
                                         cannot_be_a_base: false,
@@ -1457,6 +1489,7 @@ mod tests {
                                             66968718,
                                         ),
                                         username: "Sakib25800",
+                                        email: None,
                                         html_url: Url {
                                             scheme: "https",
                                             cannot_be_a_base: false,
@@ -1493,6 +1526,7 @@ mod tests {
                                         fragment: None,
                                     },
                                 ),
+                                commit_count: 2,
                             },
                         },
                     ),
@@ -1525,6 +1559,7 @@ mod tests {
                                         "3824fd9a567e3c27dff0cd51427e7562a0eda8da",
                                     ),
                                 },
+                                head_repository: None,
                                 base: Branch {
                                     name: "main",
                                     sha: CommitSha(
@@ -1539,6 +1574,7 @@ mod tests {
                                         66968718,
                                     ),
                                     username: "Sakib25800",
+                                    email: None,
                                     html_url: Url {
                                         scheme: "https",
                                         cannot_be_a_base: false,
@@ -1575,6 +1611,7 @@ mod tests {
                                         fragment: None,
                                     },
                                 ),
+                                commit_count: 2,
                             },
                         },
                     ),


### PR DESCRIPTION
This is possible through the Create commit API that I recently discovered.

This PR lacks tests and some basic functionality (such as setting the commit message). I first implemented an MVP to test this on staging, so that I can test if it can actually be used to push to forks, which wasn't easy to simulate on my personal repository.
