### PR TITLE
Improve the squash command

### DIFF
--- a/src/bors/handlers/squash.rs
+++ b/src/bors/handlers/squash.rs
@@ -24,6 +24,17 @@ pub(super) async fn command_squash(
             .await?;
         anyhow::Ok(())
     };
+    #[cfg(not(test))]
+    {
+        if author.username.to_lowercase() != "kobzol" {
+            send_comment(
+                ":key: Squashing is currently experimental and cannot be used yet.".to_string(),
+            )
+            .await?;
+            return Ok(());
+        }
+    }
+
     let is_reviewer = repo_state
         .permissions
         .load()


### PR DESCRIPTION
Allow reviewers to squash, since they can do it anyway manually by pushing to the PR's branch. And use `--depth=1` when fetching the repository.

I want to see on production if doing the fetch operation in a stateless manner with `--depth=1` is good enough, performance-wise. In any case, we will have to implement some limits here to avoid too many (concurrent) squashes.

For now, I only enabled squashing for myself, to test on production.
