### PR TITLE
Enable `@bors squash` for everyone

### DIFF
--- a/src/bors/handlers/squash.rs
+++ b/src/bors/handlers/squash.rs
@@ -31,17 +31,6 @@ pub(super) async fn command_squash(
         anyhow::Ok(())
     };
 
-    #[cfg(not(test))]
-    {
-        if author.username.to_lowercase() != "kobzol" {
-            send_comment(
-                ":key: Squashing is currently experimental and cannot be used yet.".to_string(),
-            )
-            .await?;
-            return Ok(());
-        }
-    }
-
     let is_reviewer = repo_state
         .permissions
         .load()


### PR DESCRIPTION
It is now much faster than before, the git operations are properly queued to avoid overloading the server, and it is possible to specify the commit message. I think that this is ready for general usage!
