### PR TITLE
Embed bors git version into `@bors ping` response

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -40,6 +40,7 @@ jobs:
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: GIT_VERSION=${{ github.sha }}
 
       - name: Kick ECS to deploy new version
         run: |

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -42,6 +42,7 @@ jobs:
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: GIT_VERSION=${{ github.sha }}
 
       - name: Kick ECS to deploy new version
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,9 @@ COPY web web
 # Precompress static web assets with gzip to avoid paying for their compression cost at runtime
 RUN gzip --keep --best --force --recursive web/assets
 
+ARG GIT_VERSION=unknown
+ENV GIT_VERSION=${GIT_VERSION}
+
 RUN cargo build --release
 
 FROM ubuntu:24.04 AS runtime

--- a/src/bors/handlers/ping.rs
+++ b/src/bors/handlers/ping.rs
@@ -1,3 +1,4 @@
+use std::fmt::Write;
 use std::sync::Arc;
 
 use crate::PgDbClient;
@@ -10,8 +11,15 @@ pub(super) async fn command_ping(
     db: &PgDbClient,
     pr_number: PullRequestNumber,
 ) -> anyhow::Result<()> {
+    let mut msg = "Pong :ping_pong:!".to_string();
+
+    // We don't embed the git version automatically, e.g. through the
+    // `git-version` crate, because for production we build bors in Docker anyway, where there
+    // is no git repo.
+    let git_version = option_env!("GIT_VERSION").unwrap_or_else(|| "unknown");
+    writeln!(msg, "\n\nbors build: `{git_version}`").unwrap();
     repo.client
-        .post_comment(pr_number, Comment::new("Pong 🏓!".to_string()), db)
+        .post_comment(pr_number, Comment::new(msg), db)
         .await?;
     Ok(())
 }
@@ -24,7 +32,11 @@ mod tests {
     async fn ping_command(pool: sqlx::PgPool) {
         run_test(pool, async |ctx: &mut BorsTester| {
             ctx.post_comment("@bors ping").await?;
-            assert_eq!(ctx.get_next_comment_text(()).await?, "Pong 🏓!");
+            insta::assert_snapshot!(ctx.get_next_comment_text(()).await?, @"
+            Pong :ping_pong:!
+
+            bors build: `unknown`
+            ");
             Ok(())
         })
         .await;


### PR DESCRIPTION
When bors is being redeployed, it's not easy to see which version if currently active. This should help.
