### PR TITLE
Automatically mark rollups as rollup=never

### DIFF
--- a/.sqlx/query-d2ed8e6531641f0f5bda642822c51bbe14c9b336d2095b6724e597afd2bdbf48.json
+++ b/.sqlx/query-d2ed8e6531641f0f5bda642822c51bbe14c9b336d2095b6724e597afd2bdbf48.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT rollup\n        FROM rollup_member rm\n        WHERE rollup = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "rollup",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "d2ed8e6531641f0f5bda642822c51bbe14c9b336d2095b6724e597afd2bdbf48"
+}

--- a/src/database/operations.rs
+++ b/src/database/operations.rs
@@ -745,7 +745,7 @@ pub(crate) async fn set_pr_priority(
     .await
 }
 
-pub(crate) async fn set_pr_rollup(
+pub(crate) async fn set_pr_rollup_mode(
     executor: impl PgExecutor<'_>,
     pr_id: i32,
     rollup: RollupMode,
@@ -1141,6 +1141,26 @@ pub(crate) async fn get_nonclosed_rollups(
         }
 
         Ok(rollups_map)
+    })
+    .await
+}
+
+pub(crate) async fn is_rollup(
+    executor: impl PgExecutor<'_>,
+    id: PrimaryKey,
+) -> anyhow::Result<bool> {
+    measure_db_query("is_rollup", || async {
+        let row = sqlx::query!(
+            r#"
+        SELECT rollup
+        FROM rollup_member rm
+        WHERE rollup = $1
+            "#,
+            id
+        )
+        .fetch_optional(executor)
+        .await?;
+        Ok(row.is_some())
     })
     .await
 }


### PR DESCRIPTION
And do not allow them to be marked as anything else. This should avoid rolluping a rollup, whether intentionally or by accident :)