### PR TITLE
Ignore draft PRs in the merge queue and do not allow them to be rolled up

### DIFF
--- a/src/bors/merge_queue.rs
+++ b/src/bors/merge_queue.rs
@@ -208,7 +208,7 @@ async fn process_repository(
                 }
             }
             // We got to the end of the merge queue, stop going through the rest of the PRs
-            QueueStatus::NotApproved | QueueStatus::Failed(..) => break,
+            QueueStatus::NotApproved | QueueStatus::NotOpen | QueueStatus::Failed(..) => break,
         }
     }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -351,7 +351,7 @@ pub async fn queue_handler(
             QueueStatus::ReadyForMerge(..) => (1, 0),
             QueueStatus::Pending(..) => (1, 0),
             QueueStatus::Failed(..) => (0, 1),
-            QueueStatus::NotApproved => (0, 0),
+            QueueStatus::NotApproved | QueueStatus::NotOpen => (0, 0),
         };
 
         (in_queue + in_queue_inc, failed + failed_inc)

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -17,7 +17,7 @@ pub fn status_text(pr: &PullRequestModel) -> String {
         QueueStatus::ReadyForMerge(_, _) => "ready for merge".to_string(),
         QueueStatus::Pending(_, _) => "pending".to_string(),
         QueueStatus::Failed(_, _) => "failed".to_string(),
-        QueueStatus::NotApproved => String::new(),
+        QueueStatus::NotApproved | QueueStatus::NotOpen => String::new(),
     }
 }
 

--- a/src/utils/sort_queue.rs
+++ b/src/utils/sort_queue.rs
@@ -34,7 +34,7 @@ fn get_queue_status_priority(status: &QueueStatus) -> u32 {
         QueueStatus::Pending(_, _) => 1,
         QueueStatus::Approved(_) => 2,
         QueueStatus::Failed(_, _) => 3,
-        QueueStatus::NotApproved => 4,
+        QueueStatus::NotApproved | QueueStatus::NotOpen => 4,
     }
 }
 

--- a/web/templates/queue.html
+++ b/web/templates/queue.html
@@ -258,7 +258,7 @@
                         {%- endif -%}
                       {%- when QueueStatus::Failed(_, _) -%}
                         failed
-                      {%- when QueueStatus::NotApproved -%}
+                      {%- when QueueStatus::NotApproved | QueueStatus::NotOpen -%}
                     {%- endmatch -%}
                     <span class="elapsed-time-display"></span>
                 </td>


### PR DESCRIPTION
Marking a PR as draft does not unapprove it though, same as closing it.