### PR TITLE
Allow selecting rollup members in the queue page

### DIFF
--- a/web/templates/queue.html
+++ b/web/templates/queue.html
@@ -288,6 +288,9 @@
                     {%- endif -%}
                 </td>
                 <td>{{ pr.priority.unwrap_or(0) }}</td>
+                {%~ if rollups_info.rollups.get(pr.number).is_some() -%}
+                  <td>Rollup PR</td>
+                {%- else -%}
                 <td class="marker {%~ if let Some(rollup) = pr.rollup -%}
                       {%- match rollup -%}
                         {%- when Always -%}
@@ -312,6 +315,7 @@
                       {%- endmatch -%}
                     {%- endif -%}
                 </td>
+                {%- endif -%}
             </tr>
             {% endfor -%}
         </tbody>


### PR DESCRIPTION
To make it easier to create similar rollups and to see which PRs are already included in a rollup.

![rollup-select](https://github.com/user-attachments/assets/4e33a083-e219-443c-89cb-538206a9f46b)