### PR TITLE
Check existing reviewers in a case-insensitive manner

### DIFF
--- a/src/bors/handlers/review.rs
+++ b/src/bors/handlers/review.rs
@@ -675,6 +675,23 @@ approved = ["+approved"]
     }
 
     #[sqlx::test]
+    async fn approve_with_known_reviewer_different_case(pool: sqlx::PgPool) {
+        run_test(pool, async |ctx: &mut BorsTester| {
+            ctx.post_comment("@bors r=DEFAULT-USER").await?;
+            insta::assert_snapshot!(
+                ctx.get_next_comment_text(()).await?,
+                @"
+            :pushpin: Commit pr-1-sha has been approved by `DEFAULT-USER`
+
+            It is now in the [queue](https://bors-test.com/queue/borstest) for this repository.
+            "
+            );
+            Ok(())
+        })
+        .await;
+    }
+
+    #[sqlx::test]
     async fn insufficient_permission_approve(pool: sqlx::PgPool) {
         run_test(pool, async |ctx: &mut BorsTester| {
             ctx.post_comment(Comment::from("@bors try").with_author(User::unprivileged()))

--- a/src/permissions.rs
+++ b/src/permissions.rs
@@ -36,7 +36,10 @@ impl UserPermissions {
     ) -> Self {
         Self {
             review_users,
-            review_usernames,
+            review_usernames: review_usernames
+                .into_iter()
+                .map(|username| username.to_lowercase())
+                .collect(),
             try_users,
         }
     }
@@ -48,8 +51,10 @@ impl UserPermissions {
         }
     }
 
+    /// Checks if the given username is a valid reviewer.
+    /// The usernames are checked in a case-insensitive manner.
     pub fn has_reviewer(&self, username: &str) -> bool {
-        self.review_usernames.contains(username)
+        self.review_usernames.contains(&username.to_lowercase())
     }
 }
 


### PR DESCRIPTION
We forgot this in https://github.com/rust-lang/bors/pull/675.

Found [here](https://github.com/rust-lang/bors-kindergarten/pull/18#issuecomment-3810054086).
