### PR TITLE
Harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -12,11 +12,18 @@ on:
       - "**/Cargo.lock"
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   audit:
+    name: Security audit
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - uses: EmbarkStudios/cargo-deny-action@175dc7fd4fb85ec8f46948fb98f44db001149081 # v2.0.16
         continue-on-error: true

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -11,10 +11,11 @@ jobs:
     name: Deploy to production
     runs-on: ubuntu-latest
     environment: production
-    concurrency:
-      group: production
-      cancel-in-progress: true
+    concurrency: production
     if: github.repository_owner == 'rust-lang'
+    permissions:
+      id-token: write # required for OIDC authentication to AWS
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -13,11 +13,10 @@ jobs:
     name: Deploy to staging
     runs-on: ubuntu-latest
     environment: staging
-    concurrency:
-      group: staging
-      cancel-in-progress: true
+    concurrency: staging
     if: github.repository_owner == 'rust-lang'
     permissions:
+      id-token: write # required for OIDC authentication to AWS
       contents: read
     steps:
       - name: Checkout repository

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test
@@ -18,6 +21,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Start containers
         run: docker compose up -d --wait
@@ -55,6 +60,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       - name: Build the Docker image
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0


### PR DESCRIPTION
Improved security and reliability of Github Actions and workflow
Changes:
- Restricted permissions to minimum required
- Disabled credentials persistence

Before: 31 findings: 1 informational, 10 low, 8 medium, 12 high
After: some of them fixed,`info[anonymous-definition]` and `help[concurrency-limits]` are ignored.