### PR TITLE
Add Zizmor Security Audit workflow

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,24 @@
+name: Zizmor Security Audit
+
+on:
+  pull_request:
+  merge_group:
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          persona: pedantic

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,12 @@
+rules:
+  anonymous-definition:
+    ignore:
+      - audit.yml
+
+  concurrency-limits:
+    ignore:
+      - audit.yml
+      - deploy-production.yml
+      - deploy-staging.yml
+      - test.yml
+      - zizmor.yml


### PR DESCRIPTION
This PR adds a new GitHub Actions workflow for running the Zizmor security audit.
- Adds `.github/workflows/zizmor.yml`
- Adds `.github/zizmor.yml` to ignore `info[anonymous-definition]` and `help[concurrency-limits]`
purpose:
This workflow runs Zizmor to help detect potential security issues in the repository configuration and workflows.