### PR TITLE
Zizmor error fixes

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,5 +1,12 @@
 name: Security audit
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   schedule:
     # Runs at 00:00 UTC everyday
@@ -18,12 +25,12 @@ permissions:
 jobs:
   audit:
     name: Security audit
+    name: Security audit
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-
       - uses: EmbarkStudios/cargo-deny-action@175dc7fd4fb85ec8f46948fb98f44db001149081 # v2.0.16
         continue-on-error: true

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,5 +1,7 @@
 name: Deploy production
 
+permissions: {}
+
 on:
   workflow_dispatch:
 
@@ -11,14 +13,18 @@ jobs:
     name: Deploy to production
     runs-on: ubuntu-latest
     environment: production
-    concurrency: production
+    concurrency:
+      group: production
+      cancel-in-progress: true
     if: github.repository_owner == 'rust-lang'
     permissions:
-      id-token: write # required for OIDC authentication to AWS
+      id-token: write # Required for AWS OIDC authentication
       contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
         with:
           persist-credentials: false
       - name: Deploy to ECS

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,5 +1,7 @@
 name: Deploy staging
 
+permissions: {}
+
 on:
   push:
     branches:
@@ -13,14 +15,18 @@ jobs:
     name: Deploy to staging
     runs-on: ubuntu-latest
     environment: staging
-    concurrency: staging
+    concurrency:
+      group: staging
+      cancel-in-progress: true
     if: github.repository_owner == 'rust-lang'
     permissions:
-      id-token: write # required for OIDC authentication to AWS
+      id-token: write # Required for AWS OIDC authentication
       contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
         with:
           persist-credentials: false
       - name: Deploy to ECS

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,11 @@
 name: Test
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request: { }
   merge_group: { }
@@ -15,6 +21,8 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       # Matches docker-compose.yaml
       DATABASE_URL: postgres://bors:bors@localhost:5432/bors
@@ -57,6 +65,8 @@ jobs:
   docker:
     name: Test Docker
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,41 @@
+name: Zizmor Security Audit
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+
+jobs:
+  zizmor:
+    name: Run zizmor security audit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install zizmor
+        run: |
+          # Install zizmor from PyPI
+          pip install zizmor
+
+      - name: Run zizmor pedantic audit
+        run: |
+          zizmor --pedantic .github/workflows/ .github/actions/

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,6 @@ FROM base AS build
 WORKDIR /app
 COPY --from=planner /app/recipe.json recipe.json
 
-# Enable offline mode for sqlx (uses .sqlx/ directory)
-ENV SQLX_OFFLINE=1
-
 RUN cargo chef cook --release --recipe-path recipe.json
 
 COPY askama.toml .

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,9 @@ FROM base AS build
 WORKDIR /app
 COPY --from=planner /app/recipe.json recipe.json
 
+# Enable offline mode for sqlx (uses .sqlx/ directory)
+ENV SQLX_OFFLINE=1
+
 RUN cargo chef cook --release --recipe-path recipe.json
 
 COPY askama.toml .

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,17 +1,30 @@
-version: '3.7'
+version: '3.9'
+
 services:
   db:
     image: postgres:16.9
+    container_name: bors_db
     environment:
       POSTGRES_USER: bors
       POSTGRES_PASSWORD: bors
       POSTGRES_DB: bors
     ports:
       - "5432:5432"
-    # Optimize DB in tests
-    command: -c fsync=off
+
+    # Faster local dev (unsafe for prod — fine here)
+    command: ["postgres", "-c", "fsync=off"]
+
+    # Persist data locally (VERY important)
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready" ]
-      interval: 10s
+      test: ["CMD-SHELL", "pg_isready -U bors -d bors"]
+      interval: 5s
       timeout: 5s
       retries: 5
+
+    restart: unless-stopped
+
+volumes:
+  postgres_data:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,30 +1,17 @@
-version: '3.9'
-
+version: '3.7'
 services:
   db:
     image: postgres:16.9
-    container_name: bors_db
     environment:
       POSTGRES_USER: bors
       POSTGRES_PASSWORD: bors
       POSTGRES_DB: bors
     ports:
       - "5432:5432"
-
-    # Faster local dev (unsafe for prod — fine here)
-    command: ["postgres", "-c", "fsync=off"]
-
-    # Persist data locally (VERY important)
-    volumes:
-      - postgres_data:/var/lib/postgresql/data
-
+    # Optimize DB in tests
+    command: -c fsync=off
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U bors -d bors"]
-      interval: 5s
+      test: [ "CMD-SHELL", "pg_isready" ]
+      interval: 10s
       timeout: 5s
       retries: 5
-
-    restart: unless-stopped
-
-volumes:
-  postgres_data:


### PR DESCRIPTION
1. **AWS OIDC Workflows:** The id-token: write permission is still present but now explicitly documented inline. This is required for configure-aws-credentials to obtain an OIDC token from GitHub.

2. **Test Workflow Permissions:** The test jobs only need contents: read because:
   - They checkout code
   - They use docker/build-push-action with load: true (no push)
   - No GitHub API write operations are performed

3. **Empty Permissions Block:** permissions: {} at workflow level ensures no default permissions are granted. Each job must explicitly declare its needs.

4. **Concurrency Groups:** Using ${{ github.workflow }}-${{ github.ref }} ensures:
   - Different workflows don't cancel each other
   - Same workflow on different branches run independently
   - Pushes to the same branch/PR cancel previous runs