### PR TITLE
fix: tighten zizmor permissions and resolve SARIF upload warnings

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -12,6 +12,10 @@ jobs:
     name: Run zizmor
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      security-events: write # Required for SARIF upload to GithHub code Scanning
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
This PR fixes a Github actions permission issue in the zizmor workflow.

The zizmor scan was running correctly, but the SARIF upload step was failing in the merge queue due to missing `security-events: write` permission. 

changes:
- Add security-events: write permissions to job level

Result:
- Fixes SARIF upload failure
- Passes zizmor permission checks