### PR TITLE
Add comment text when a PR is unapproved

### DIFF
--- a/src/bors/handlers/mod.rs
+++ b/src/bors/handlers/mod.rs
@@ -1011,14 +1011,7 @@ pub fn invalidation_comment(
         .map(|b| b.status.is_failure_or_cancel())
         .unwrap_or(false);
 
-    // In this case we do not have to post a comment, to avoid needless spam
-    // It would be nicer to solve this in some more robust way..
-    let is_simple_unapproval = matches!(reason, InvalidationReason::Unapproval { .. })
-        && !outcome.closed
-        && build_cancelled_msg.is_none()
-        && invalidated_rollups.is_empty();
-
-    if outcome.unapproved && !is_simple_unapproval && (!had_failed_build || outcome.closed) {
+    if outcome.unapproved && (!had_failed_build || outcome.closed) {
         append(format!(
             "This {pr_label} was{} unapproved{}.",
             if is_rollup { " thus" } else { "" },

--- a/src/bors/handlers/review.rs
+++ b/src/bors/handlers/review.rs
@@ -860,7 +860,11 @@ approved = { modifications = ["+foo", "+baz"], unless = ["label1", "label2"] }
                 .await
                 .expect_approved_by(&User::default_pr_author().name);
             ctx.post_comment("@bors r-").await?;
-            insta::assert_snapshot!(ctx.get_next_comment_text(()).await?, @"[View changes since this unapproval](https://triagebot.infra.rust-lang.org/gh-changes-since/rust-lang/borstest/1/main-sha1..pr-1-sha)");
+            insta::assert_snapshot!(ctx.get_next_comment_text(()).await?, @"
+            This pull request was unapproved.
+
+            [View changes since this unapproval](https://triagebot.infra.rust-lang.org/gh-changes-since/rust-lang/borstest/1/main-sha1..pr-1-sha)
+            ");
             ctx.pr(()).await.expect_unapproved();
             Ok(())
         })
@@ -933,7 +937,11 @@ approved = { modifications = ["+foo", "+baz"], unless = ["label1", "label2"] }
                 It is now in the [queue](https://bors-test.com/queue/borstest) for this repository.
                 ");
                 ctx.post_comment("@bors r-").await?;
-                insta::assert_snapshot!(ctx.get_next_comment_text(()).await?, @"[View changes since this unapproval](https://triagebot.infra.rust-lang.org/gh-changes-since/rust-lang/borstest/1/main-sha1..pr-1-sha)");
+                insta::assert_snapshot!(ctx.get_next_comment_text(()).await?, @"
+                This pull request was unapproved.
+
+                [View changes since this unapproval](https://triagebot.infra.rust-lang.org/gh-changes-since/rust-lang/borstest/1/main-sha1..pr-1-sha)
+                ");
                 ctx.pr(()).await.expect_unapproved();
 
                 Ok(())
@@ -1238,7 +1246,11 @@ approved = { modifications = ["+foo", "+baz"], unless = ["label1", "label2"] }
                     .expect_approved_by(&User::default_pr_author().name);
 
                 ctx.post_comment(review_comment("@bors r-")).await?;
-                insta::assert_snapshot!(ctx.get_next_comment_text(()).await?, @"[View changes since this unapproval](https://triagebot.infra.rust-lang.org/gh-changes-since/rust-lang/borstest/1/main-sha1..pr-1-sha)");
+                insta::assert_snapshot!(ctx.get_next_comment_text(()).await?, @"
+                This pull request was unapproved.
+
+                [View changes since this unapproval](https://triagebot.infra.rust-lang.org/gh-changes-since/rust-lang/borstest/1/main-sha1..pr-1-sha)
+                ");
                 ctx.pr(()).await.expect_unapproved();
 
                 Ok(())

--- a/src/github/rollup.rs
+++ b/src/github/rollup.rs
@@ -1045,7 +1045,11 @@ also include this pls"
                 .await?
                 .assert_status(StatusCode::SEE_OTHER);
             ctx.post_comment(Comment::new(pr3.id(), "@bors r-")).await?;
-            insta::assert_snapshot!(ctx.get_next_comment_text(3).await?, @"[View changes since this unapproval](https://triagebot.infra.rust-lang.org/gh-changes-since/rust-lang/borstest/3/main-sha1..pr-3-sha)");
+            insta::assert_snapshot!(ctx.get_next_comment_text(3).await?, @"
+            This pull request was unapproved.
+
+            [View changes since this unapproval](https://triagebot.infra.rust-lang.org/gh-changes-since/rust-lang/borstest/3/main-sha1..pr-3-sha)
+            ");
             insta::assert_snapshot!(ctx.get_next_comment_text(4).await?, @"
             PR #3, which is a member of this rollup, was [unapproved](https://github.com/rust-lang/borstest/pull/3#issuecomment-3).
             ");


### PR DESCRIPTION
It was weird when it only included the "View changes since this unapproval" part.
