### PR TITLE
Make it clear that conflicts need to be rebased

### DIFF
--- a/src/bors/comment.rs
+++ b/src/bors/comment.rs
@@ -361,7 +361,7 @@ pub fn approve_blocking_labels_present(blocking_labels: &[&str]) -> Comment {
 
 pub fn approve_merge_conflict_comment() -> Comment {
     Comment::new(
-        ":clipboard: This PR cannot be approved because it has merge conflicts. Please resolve the conflicts and try again.".to_string()
+        ":clipboard: This PR cannot be approved because it has merge conflicts. Please [resolve the merge conflicts by rebasing](https://rustc-dev-guide.rust-lang.org/git.html#rebasing-and-conflicts), and try again.".to_string()
     )
 }
 
@@ -494,7 +494,7 @@ pub fn auto_build_push_failed_comment(error: &str) -> Comment {
 
 pub fn merge_conflict_comment(source: Option<PullRequestNumber>, was_unapproved: bool) -> Comment {
     Comment::new(format!(
-        r#":umbrella: The latest upstream changes{} made this pull request unmergeable. Please [resolve the merge conflicts](https://rustc-dev-guide.rust-lang.org/git.html#rebasing-and-conflicts).{}"#,
+        r#":umbrella: The latest upstream changes{} made this pull request unmergeable. Please [resolve the merge conflicts by rebasing](https://rustc-dev-guide.rust-lang.org/git.html#rebasing-and-conflicts).{}"#,
         source
             .map(|n| format!(" (presumably #{n})"))
             .unwrap_or_default(),

--- a/src/bors/handlers/pr_events.rs
+++ b/src/bors/handlers/pr_events.rs
@@ -771,7 +771,7 @@ report_merge_conflicts = false
 
             ctx.push_to_branch(default_branch_name(), Commit::new("sha", "push")).await?;
             ctx.run_mergeability_check().await?;
-            assert_snapshot!(ctx.get_next_comment_text(pr).await?, @":umbrella: The latest upstream changes made this pull request unmergeable. Please [resolve the merge conflicts](https://rustc-dev-guide.rust-lang.org/git.html#rebasing-and-conflicts).");
+            assert_snapshot!(ctx.get_next_comment_text(pr).await?, @":umbrella: The latest upstream changes made this pull request unmergeable. Please [resolve the merge conflicts by rebasing](https://rustc-dev-guide.rust-lang.org/git.html#rebasing-and-conflicts).");
 
             Ok(())
         })
@@ -794,7 +794,7 @@ report_merge_conflicts = false
             ctx.push_to_branch(default_branch_name(), Commit::new("sha", "push")).await?;
             ctx.run_mergeability_check().await?;
             assert_snapshot!(ctx.get_next_comment_text(pr.id()).await?, @"
-            :umbrella: The latest upstream changes made this pull request unmergeable. Please [resolve the merge conflicts](https://rustc-dev-guide.rust-lang.org/git.html#rebasing-and-conflicts).
+            :umbrella: The latest upstream changes made this pull request unmergeable. Please [resolve the merge conflicts by rebasing](https://rustc-dev-guide.rust-lang.org/git.html#rebasing-and-conflicts).
 
             This pull request was unapproved.
             ");
@@ -833,7 +833,7 @@ report_merge_conflicts = false
             // Ideally, the tests should do that automatically...
             ctx.push_to_branch(default_branch_name(), commit).await?;
             ctx.run_mergeability_check().await?;
-            assert_snapshot!(ctx.get_next_comment_text(pr2.id()).await?, @":umbrella: The latest upstream changes (presumably #3) made this pull request unmergeable. Please [resolve the merge conflicts](https://rustc-dev-guide.rust-lang.org/git.html#rebasing-and-conflicts).");
+            assert_snapshot!(ctx.get_next_comment_text(pr2.id()).await?, @":umbrella: The latest upstream changes (presumably #3) made this pull request unmergeable. Please [resolve the merge conflicts by rebasing](https://rustc-dev-guide.rust-lang.org/git.html#rebasing-and-conflicts).");
 
             Ok(())
         })
@@ -868,7 +868,7 @@ report_merge_conflicts = false
             // information.
             ctx.push_to_branch(default_branch_name(), commit).await?;
             ctx.run_mergeability_check().await?;
-            assert_snapshot!(ctx.get_next_comment_text(pr3.id()).await?, @":umbrella: The latest upstream changes made this pull request unmergeable. Please [resolve the merge conflicts](https://rustc-dev-guide.rust-lang.org/git.html#rebasing-and-conflicts).");
+            assert_snapshot!(ctx.get_next_comment_text(pr3.id()).await?, @":umbrella: The latest upstream changes made this pull request unmergeable. Please [resolve the merge conflicts by rebasing](https://rustc-dev-guide.rust-lang.org/git.html#rebasing-and-conflicts).");
 
             Ok(())
         })

--- a/src/bors/handlers/review.rs
+++ b/src/bors/handlers/review.rs
@@ -1786,7 +1786,7 @@ labels_blocking_approval = ["proposed-final-comment-period", "final-comment-peri
                 pr.mergeable_state = OctocrabMergeableState::Dirty;
             });
             ctx.post_comment("@bors r+").await?;
-            insta::assert_snapshot!(ctx.get_next_comment_text(()).await?, @":clipboard: This PR cannot be approved because it has merge conflicts. Please resolve the conflicts and try again.");
+            insta::assert_snapshot!(ctx.get_next_comment_text(()).await?, @":clipboard: This PR cannot be approved because it has merge conflicts. Please [resolve the merge conflicts by rebasing](https://rustc-dev-guide.rust-lang.org/git.html#rebasing-and-conflicts), and try again.");
             ctx.pr(()).await.expect_unapproved();
             Ok(())
         })

--- a/src/bors/merge_queue.rs
+++ b/src/bors/merge_queue.rs
@@ -1287,7 +1287,7 @@ merge_queue_enabled = false
             insta::assert_snapshot!(
                 ctx.get_next_comment_text(()).await?,
                 @"
-            :umbrella: The latest upstream changes made this pull request unmergeable. Please [resolve the merge conflicts](https://rustc-dev-guide.rust-lang.org/git.html#rebasing-and-conflicts).
+            :umbrella: The latest upstream changes made this pull request unmergeable. Please [resolve the merge conflicts by rebasing](https://rustc-dev-guide.rust-lang.org/git.html#rebasing-and-conflicts).
 
             This pull request was unapproved.
             "
@@ -1315,7 +1315,7 @@ merge_queue_enabled = false
                 .expect_no_auto_build()
                 .expect_unapproved();
             insta::assert_snapshot!(ctx.get_next_comment_text(pr.id()).await?, @"
-            :umbrella: The latest upstream changes made this pull request unmergeable. Please [resolve the merge conflicts](https://rustc-dev-guide.rust-lang.org/git.html#rebasing-and-conflicts).
+            :umbrella: The latest upstream changes made this pull request unmergeable. Please [resolve the merge conflicts by rebasing](https://rustc-dev-guide.rust-lang.org/git.html#rebasing-and-conflicts).
 
             This pull request was unapproved.
             ");
@@ -1351,7 +1351,7 @@ merge_queue_enabled = false
 
             // Ensure that the conflict source was taken from the mergeability queue
             insta::assert_snapshot!(ctx.get_next_comment_text(pr3.id()).await?, @"
-            :umbrella: The latest upstream changes (presumably #2) made this pull request unmergeable. Please [resolve the merge conflicts](https://rustc-dev-guide.rust-lang.org/git.html#rebasing-and-conflicts).
+            :umbrella: The latest upstream changes (presumably #2) made this pull request unmergeable. Please [resolve the merge conflicts by rebasing](https://rustc-dev-guide.rust-lang.org/git.html#rebasing-and-conflicts).
 
             This pull request was unapproved.
             ");

--- a/src/bors/mergeability_queue.rs
+++ b/src/bors/mergeability_queue.rs
@@ -45,7 +45,7 @@
 //! ### Mergeability queue
 //! To reload the mergeability of PRs, we use a mergeability queue, which is implemented in this
 //! module. Sadly, the mergeability status cannot be determined directly from GitHub, because it is
-//! computed by a background job (see https://docs.github.com/en/rest/guides/using-the-rest-api-to-interact-with-your-git-database).
+//! computed by a background job (see <https://docs.github.com/en/rest/guides/using-the-rest-api-to-interact-with-your-git-database>).
 //! Instead, we have to poll GitHub repeatedly, which is what the queue does.
 //!
 //! When you add a PR to the mergeability queue, it will then immediately contact the GH API

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,7 +24,7 @@ pub struct RepositoryConfig {
     /// Maps trigger events (approve, try, etc.) to label additions/removals.
     /// Format (one of):
     /// - `<trigger> = ["+label_to_add", "-label_to_remove"]`
-    /// - `<trigger> = { modifications = ["+add", "-remove"], unless = ["label1", "label"] }
+    /// - `<trigger> = { modifications = ["+add", "-remove"], unless = ["label1", "label"] }`
     #[serde(default, deserialize_with = "deserialize_labels")]
     pub labels: HashMap<LabelTrigger, LabelOperation>,
     /// Labels that will block a PR from being approved when present on the PR.


### PR DESCRIPTION
This PR adds "by rebasing" to bors merge conflict comments, and adds a missing link to the rebase instructions.

It also fixes some code comment formatting, happy to split or drop that commit.

Zulip conversation:
https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/Turn.20off.20merge.20resolution.20button.20on.20GitHub/with/594684684