### PR TITLE
build: Reduce test build times by tweaking build config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,3 +90,4 @@ opt-level = 3
 
 [profile.test]
 codegen-units = 32
+debug = "limited"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,3 +87,6 @@ debug = 1
 
 [profile.dev.package.sqlx-macros]
 opt-level = 3
+
+[profile.test]
+codegen-units = 32


### PR DESCRIPTION
It seems that with `cargo t --no-run` we're quite blocked on frontend producing CGUs. The following changes reduced incremental build time of `bors` in test scenarios by 40%.