### PR TITLE
fix: dont break startup for unconfigured repos

### DIFF
--- a/.github/workflows/deploy-ferrous.yml
+++ b/.github/workflows/deploy-ferrous.yml
@@ -1,0 +1,45 @@
+name: Build and Push to Harbor
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy-bors:
+    name: Deploy Bors to Ferrous Systems Harbor
+    runs-on: ubuntu-latest
+    environment: deployment
+    concurrency:
+      group: deployment
+      cancel-in-progress: true
+    if: github.repository_owner == 'ferrous-systems'
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Authenticate to Harbor
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ${{ vars.REGISTRY }}
+          username: ${{ vars.REGISTRY_USER }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Build and tag the container image
+        env:
+          REGISTRY: ${{ vars.REGISTRY }}
+          REPOSITORY: ops/bors
+          IMAGE_TAG: latest
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: .
+          tags: ${{ env.REGISTRY }}/ops/bors:${{ env.IMAGE_TAG }}
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: GIT_VERSION=ferrous-systems/bors@${{ github.sha }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,6 @@ target/
 .env
 .DS_Store
 __pycache__/
+data/*/
+!data/team/
 data/team/*.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common 0.1.7",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,6 +349,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum_session"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0deb5c3602db0d699dff8cca8ae2d3ff01320cccdebf5a4aeda4ad25008737c2"
+dependencies = [
+ "aes-gcm",
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes",
+ "chrono",
+ "cookie",
+ "dashmap",
+ "fastbloom-rs",
+ "forwarded-header-value",
+ "futures",
+ "hmac 0.13.0",
+ "http",
+ "http-body",
+ "rand 0.10.1",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -359,6 +426,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "bors"
 version = "0.1.0"
 dependencies = [
@@ -367,13 +443,14 @@ dependencies = [
  "askama",
  "axum",
  "axum-embed",
+ "axum_session",
  "base64",
  "chrono",
  "clap",
  "futures",
  "graphql-parser",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "http",
  "hyper",
  "insta",
@@ -390,7 +467,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlparser",
  "sqlx",
  "tempfile",
@@ -504,6 +581,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -515,6 +603,16 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.7",
+ "inout",
 ]
 
 [[package]]
@@ -556,6 +654,12 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "colorchoice"
@@ -618,6 +722,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "aes-gcm",
+ "base64",
+ "percent-encoding",
+ "rand 0.8.5",
+ "subtle",
+ "time",
+ "version_check",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -638,6 +763,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -700,7 +834,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
+name = "cuckoofilter"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b810a8449931679f64cd7eef1bbd0fa315801b6d5d9cdc1ace2804d6529eee18"
+dependencies = [
+ "byteorder",
+ "fnv",
+ "rand 0.7.3",
 ]
 
 [[package]]
@@ -710,9 +883,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -728,6 +901,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -754,7 +941,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -774,10 +961,22 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -804,7 +1003,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -830,7 +1029,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -852,7 +1051,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
@@ -908,6 +1107,24 @@ dependencies = [
  "parking",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "fastbloom-rs"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cedd8cf9a34b304cfa127370e66b51f85c412cf1a9cc15ec39fc1fe2912403a"
+dependencies = [
+ "cuckoofilter",
+ "fastmurmur3",
+ "xorfilter-rs",
+ "xxhash-rust",
+]
+
+[[package]]
+name = "fastmurmur3"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d7e9bc68be4cdabbb8938140b01a8b5bc1191937f2c7e7ecc2fcebbe2d749df"
 
 [[package]]
 name = "fastrand"
@@ -977,6 +1194,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "forwarded-header-value"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835f84f38484cc86f110a805655697908257fb9a7af005234060891557198e9"
+dependencies = [
+ "nonempty",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1100,6 +1327,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
@@ -1107,7 +1345,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -1134,8 +1372,19 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -1177,6 +1426,12 @@ dependencies = [
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -1228,7 +1483,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -1237,7 +1492,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1293,6 +1557,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1516,6 +1789,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "insta"
 version = "1.47.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1585,7 +1867,7 @@ dependencies = [
  "base64",
  "ed25519-dalek",
  "getrandom 0.2.17",
- "hmac",
+ "hmac 0.12.1",
  "js-sys",
  "p256",
  "p384",
@@ -1594,7 +1876,7 @@ dependencies = [
  "rsa",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "signature",
  "simple_asn1",
 ]
@@ -1703,7 +1985,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1745,9 +2027,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "nonempty"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e591e719385e6ebaeb5ce5d3887f7d5676fceca6411d1925ccc95745f3d6f7"
 
 [[package]]
 name = "nu-ansi-term"
@@ -1895,6 +2183,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1909,7 +2203,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1921,7 +2215,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2036,6 +2330,18 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "potential_utf"
@@ -2196,6 +2502,19 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
@@ -2213,6 +2532,27 @@ checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -2237,6 +2577,15 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
+]
+
+[[package]]
+name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
@@ -2251,6 +2600,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -2364,7 +2728,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -2388,8 +2752,8 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
@@ -2432,7 +2796,7 @@ version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
 dependencies = [
- "sha2",
+ "sha2 0.10.9",
  "walkdir",
 ]
 
@@ -2695,8 +3059,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2706,8 +3070,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2741,7 +3116,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -2896,7 +3271,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "thiserror 2.0.18",
  "tokio",
@@ -2934,7 +3309,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlx-core",
  "sqlx-mysql",
  "sqlx-postgres",
@@ -2957,7 +3332,7 @@ dependencies = [
  "bytes",
  "chrono",
  "crc",
- "digest",
+ "digest 0.10.7",
  "dotenvy",
  "either",
  "futures-channel",
@@ -2967,7 +3342,7 @@ dependencies = [
  "generic-array",
  "hex",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "itoa",
  "log",
  "md-5",
@@ -2978,7 +3353,7 @@ dependencies = [
  "rsa",
  "serde",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -3006,7 +3381,7 @@ dependencies = [
  "futures-util",
  "hex",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "home",
  "itoa",
  "log",
@@ -3016,7 +3391,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -3243,13 +3618,14 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -3485,9 +3861,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicase"
@@ -3535,6 +3911,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.7",
+ "subtle",
+]
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3572,6 +3958,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3607,6 +4005,12 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -4209,6 +4613,18 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xorfilter-rs"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47f9da296a88b6bc150b896d17770a62d4dc6f63ecf0ed10a9c08a1cb3d12f24"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,8 @@ which = "8"
 # Text processing
 pulldown-cmark = "0.13"
 regex = "1"
+axum_session = { version = "0.20.1", features = ["key-store"] }
+base64 = "0.22"
 
 [dev-dependencies]
 insta = "1.26"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,7 +11,7 @@ services:
     # Optimize DB in tests
     command: -c fsync=off
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready" ]
+      test: ["CMD-SHELL", "pg_isready --username=bors"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docs/development.md
+++ b/docs/development.md
@@ -166,5 +166,9 @@ $ python scripts/seed.py --repo owner/repo-name --token $GITHUB_TOKEN --count 5
 2. Opens pull requests for each branch
 3. Posts `@bors r+` comments to approve each PR
 
+The following options are also available:
+- `--prefix <CMD_PREFIX>` the command prefix for invoking bors, defaults to `@bors`
+- `--no-approve` disables posting `@bors r+` comments to approve each PR
+
 ## Updating commands
 When modifying commands, make sure to update the `@bors help` command in `src/bors/handlers/help.rs`.

--- a/docs/development.md
+++ b/docs/development.md
@@ -129,6 +129,7 @@ Nevertheless, sometimes it might be easier to test it on your own repository. Th
 - If you want to use custom permissions for PR approvals, create team data files for GitHub users in `data/team`. You can find examples in that directory, which you should copy and remove the `.example` suffix. 
   - Get your GitHub user `ID` `https://api.github.com/users/<your_github_user_name>`
   - Edit both `bors.review.json` and `bors.try.json` files to include your GitHub `ID`: `{ "github_ids": [123] }`
+- Add `<WEB_URL>/oauth/callback` as a callback URL (usually substituting `<WEB_URL>` below with `http://localhost:8080`)
 
 ### Everytime you run bors
 1. Start the Postgres [database](#Database)
@@ -139,6 +140,7 @@ Nevertheless, sometimes it might be easier to test it on your own repository. Th
    - (optional) Set `WEB_URL` to the public URL of the website of the app.
    - (optional) Set `CMD_PREFIX` to the command prefix used to control the bot (e.g. `@bors`).
    - (optional) Set `PERMISSIONS` `"data/permissions"` directory path to list users with permissions to perform try/review.
+   - (optional) Set `INSECURE_COOKIES` if you're accessing the web server UI via `http`. This allows github authentication to persist in browser sessions.
 3. Redirect webhooks from your test repository to bors. You can [gh webhook](https://docs.github.com/en/webhooks/testing-and-troubleshooting-webhooks/using-the-github-cli-to-forward-webhooks-for-testing) for that.
    - If you want to do it manually, you need to configure a globally reachable URL/IP address for your computer e.g. using [ngrok](https://ngrok.com/), and then configure the webhook URL of your GitHub app to point to `<your-pc-address>/github`.
 4. Try `@bors ping` on some PR on your test repository :)

--- a/scripts/seed.py
+++ b/scripts/seed.py
@@ -61,6 +61,8 @@ def main():
     parser.add_argument("--repo", required=True, help="Repository in format owner/repo-name")
     parser.add_argument("--token", required=True, help="GitHub personal access token")
     parser.add_argument("--count", type=int, default=3, help="Number of PRs to create (default: 3)")
+    parser.add_argument("--cmd-prefix", default="@bors", help="Bors command prefix")
+    parser.add_argument("--no-approve", default=False, help="Auto-approve using @bors r+", action='store_true')
 
     args = parser.parse_args()
 
@@ -90,16 +92,17 @@ def main():
         print("No PRs were created successfully.")
         sys.exit(1)
 
-    # Approve all PRs
-    print(f"\nApproving {len(pr_numbers)} PRs with `@bors r+`...")
-    for pr_number in pr_numbers:
-        try:
-            issue = repo.get_issue(pr_number)
-            issue.create_comment("@bors r+")
-
-            print(f"✓ Approved PR #{pr_number}")
-        except GithubException as e:
-            print(f"✗ Failed to approve PR #{pr_number}: {e}")
+    if not args.no_approve:
+        # Approve all PRs
+        print(f"\nApproving {len(pr_numbers)} PRs with `{args.cmd_prefix} r+`...")
+        for pr_number in pr_numbers:
+            try:
+                issue = repo.get_issue(pr_number)
+                issue.create_comment(f"{args.cmd_prefix} r+")
+    
+                print(f"✓ Approved PR #{pr_number}")
+            except GithubException as e:
+                print(f"✗ Failed to approve PR #{pr_number}: {e}")
 
     print(f"\n{len(pr_numbers)} PRs:")
 

--- a/src/bin/bors.rs
+++ b/src/bin/bors.rs
@@ -149,9 +149,8 @@ fn try_main(opts: Opts) -> anyhow::Result<()> {
                 repo
             }
             Err(error) => {
-                return Err(anyhow::anyhow!(
-                    "Failed to load repository {name}: {error:?}"
-                ));
+                tracing::error!("Failed to load repository {name}: {error:?}");
+                continue;
             }
         };
 

--- a/src/bin/bors.rs
+++ b/src/bin/bors.rs
@@ -81,12 +81,16 @@ struct Opts {
         default_value = "https://team-api.infra.rust-lang.org"
     )]
     permissions: String,
+
+    /// Disable the use of `Secure` cookies for session management. Only recommended in local dev.
+    #[arg(long, env = "INSECURE_COOKIES")]
+    insecure_cookies: bool,
 }
 
 /// Starts a server that receives GitHub webhooks and generates events into a queue
 /// that is then handled by the Bors process.
-async fn webhook_server(state: ServerState) -> anyhow::Result<()> {
-    let app = create_app(state);
+async fn webhook_server(state: ServerState, insecure_cookies: bool) -> anyhow::Result<()> {
+    let app = create_app(state, insecure_cookies).await?;
 
     let addr = SocketAddr::from(([0, 0, 0, 0], 8080));
     let listener = tokio::net::TcpListener::bind(addr)
@@ -275,7 +279,7 @@ fn try_main(opts: Opts) -> anyhow::Result<()> {
         oauth_client,
         ctx,
     );
-    let server_process = webhook_server(state);
+    let server_process = webhook_server(state, opts.insecure_cookies);
 
     let fut = async move {
         tokio::select! {

--- a/src/bors/mod.rs
+++ b/src/bors/mod.rs
@@ -215,6 +215,7 @@ pub struct RepositoryState {
     pub client: GithubRepositoryClient,
     pub permissions: ArcSwap<UserPermissions>,
     pub config: ArcSwap<RepositoryConfig>,
+    pub private: bool,
 }
 
 impl RepositoryState {

--- a/src/github/api/mod.rs
+++ b/src/github/api/mod.rs
@@ -155,11 +155,13 @@ async fn create_repo_state(
         .with_context(|| format!("Could not load permissions for repository {name}"))?;
 
     let config = load_config(&client).await?;
+    let repo = client.get_repo().await?;
 
     Ok(RepositoryState {
         client,
         config: ArcSwap::new(Arc::new(config)),
         permissions: ArcSwap::new(Arc::new(permissions)),
+        private: repo.private.unwrap_or(true),
     })
 }
 

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -17,7 +17,7 @@ mod labels;
 mod oauth;
 pub mod rollup;
 
-pub use oauth::{OAuthClient, OAuthConfig};
+pub use oauth::{ExchangeCode as OAuthExchangeCode, GitHubSession, OAuthClient, OAuthConfig};
 
 pub use crate::server::webhook::WebhookSecret;
 pub use api::operations::{MergeResult, attempt_merge};
@@ -47,6 +47,17 @@ impl GithubRepoName {
 
     pub fn name(&self) -> &str {
         &self.name
+    }
+
+    pub async fn is_visible_to_client(&self, client: &Octocrab) -> anyhow::Result<bool> {
+        let repo = client.repos(&self.owner, &self.name);
+        match repo.get().await {
+            Ok(_) => Ok(true),
+            Err(octocrab::Error::GitHub { .. }) => Ok(false),
+            Err(error) => {
+                Err(anyhow::anyhow!(error).context("Failed to test repository access for user"))
+            }
+        }
     }
 }
 
@@ -214,7 +225,8 @@ impl From<octocrab::models::pulls::PullRequest> for PullRequest {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Serialize)]
+#[serde(transparent)]
 pub struct PullRequestNumber(pub u64);
 
 impl From<u64> for PullRequestNumber {

--- a/src/github/oauth.rs
+++ b/src/github/oauth.rs
@@ -1,8 +1,21 @@
 use crate::github::api::client::GithubRepositoryClient;
 use crate::github::{GithubRepoName, GithubUser, prepare_octocrab_client};
 use anyhow::Context;
+use axum_session::SessionNullSession;
+use base64::Engine;
+use base64::prelude::BASE64_URL_SAFE;
+use octocrab::Octocrab;
 use secrecy::{ExposeSecret, SecretString};
 use std::collections::HashMap;
+use std::fmt::Write;
+
+#[derive(serde::Deserialize)]
+#[serde(transparent)]
+pub struct ExchangeCode(String);
+
+#[derive(serde::Deserialize, serde::Serialize)]
+#[serde(transparent)]
+pub struct AccessToken(String);
 
 /// Client that handles OAuth authentication used for rollups.
 /// It is able to provide a GitHub client authenticated as a given GitHub user.
@@ -26,12 +39,11 @@ impl OAuthClient {
         &self.config
     }
 
-    /// Create a GitHub client authenticated as a user with the given OAuth exchange code.
-    pub async fn get_authenticated_client(
+    /// Upgrades a OAuth exchange code from the callback into a GitHub access token.
+    pub async fn get_access_token(
         &self,
-        repo: GithubRepoName,
-        code: &str,
-    ) -> anyhow::Result<UserGitHubClient> {
+        ExchangeCode(code): ExchangeCode,
+    ) -> anyhow::Result<AccessToken> {
         tracing::info!("Exchanging OAuth code for access token");
         let client = reqwest::Client::new();
         let token_response = client
@@ -39,7 +51,7 @@ impl OAuthClient {
             .form(&[
                 ("client_id", self.config.client_id()),
                 ("client_secret", self.config.client_secret()),
-                ("code", code),
+                ("code", &code),
             ])
             .send()
             .await
@@ -57,22 +69,54 @@ impl OAuthClient {
             .ok_or_else(|| anyhow::anyhow!("No OAuth access token in response"))?;
 
         tracing::info!("Retrieved OAuth access token");
+        Ok(AccessToken(access_token.to_owned()))
+    }
 
-        let user_client = prepare_octocrab_client(&self.github_api_base_url)?
-            .user_access_token(access_token.clone())
-            .build()?;
-        let user = user_client
+    /// Create an authenticated Octocrab client with the given OAuth access token.
+    pub fn get_authenticated_client(
+        &self,
+        AccessToken(access_token): &AccessToken,
+    ) -> anyhow::Result<Octocrab> {
+        prepare_octocrab_client(&self.github_api_base_url)?
+            .user_access_token(access_token.as_str())
+            .build()
+            .context("Unable to build GitHub client")
+    }
+
+    /// Wrap an authenticated Octocrab client for accessing the given repo.
+    pub async fn get_user_client(
+        &self,
+        authenticated_client: Octocrab,
+        repo: GithubRepoName,
+    ) -> anyhow::Result<UserGitHubClient> {
+        let user = authenticated_client
             .current()
             .user()
             .await
             .context("Cannot get user authenticated with OAuth")?;
 
         let client_repo = GithubRepoName::new(&user.login, repo.name());
-        let client = GithubRepositoryClient::new(user.html_url.clone(), user_client, client_repo);
+        let client =
+            GithubRepositoryClient::new(user.html_url.clone(), authenticated_client, client_repo);
         Ok(UserGitHubClient {
             user: user.into(),
             client,
         })
+    }
+
+    /// Return a constructed GitHub OAuth URL for navigation
+    pub fn authorization_url(&self, redirect_uri: Option<String>) -> String {
+        let mut url = format!(
+            "{base_url}/login/oauth/authorize?client_id={client_id}&scope={scope}",
+            base_url = self.github_base_url,
+            client_id = self.config.client_id(),
+            scope = "public_repo,workflow",
+        );
+        if let Some(redirect_uri) = redirect_uri {
+            let state = BASE64_URL_SAFE.encode(redirect_uri);
+            write!(&mut url, "&state={state}").unwrap();
+        }
+        url
     }
 }
 
@@ -102,5 +146,22 @@ impl OAuthConfig {
 
     pub fn client_secret(&self) -> &str {
         self.client_secret.expose_secret()
+    }
+}
+
+#[derive(serde::Deserialize, serde::Serialize)]
+pub struct GitHubSession {
+    pub access_token: AccessToken,
+}
+
+impl GitHubSession {
+    const SESSION_KEY: &str = "github-session";
+
+    pub fn save(session: &SessionNullSession, access_token: AccessToken) {
+        session.set(Self::SESSION_KEY, GitHubSession { access_token });
+    }
+
+    pub fn restore(session: &SessionNullSession) -> Option<GitHubSession> {
+        session.get(Self::SESSION_KEY)
     }
 }

--- a/src/github/oauth.rs
+++ b/src/github/oauth.rs
@@ -3,7 +3,7 @@ use crate::github::{GithubRepoName, GithubUser, prepare_octocrab_client};
 use anyhow::Context;
 use axum_session::SessionNullSession;
 use base64::Engine;
-use base64::prelude::BASE64_URL_SAFE;
+use base64::prelude::BASE64_URL_SAFE_NO_PAD;
 use octocrab::Octocrab;
 use secrecy::{ExposeSecret, SecretString};
 use std::collections::HashMap;
@@ -113,7 +113,7 @@ impl OAuthClient {
             scope = "public_repo,workflow",
         );
         if let Some(redirect_uri) = redirect_uri {
-            let state = BASE64_URL_SAFE.encode(redirect_uri);
+            let state = BASE64_URL_SAFE_NO_PAD.encode(redirect_uri);
             write!(&mut url, "&state={state}").unwrap();
         }
         url
@@ -152,13 +152,33 @@ impl OAuthConfig {
 #[derive(serde::Deserialize, serde::Serialize)]
 pub struct GitHubSession {
     pub access_token: AccessToken,
+    pub username: String,
+    pub html_url: String,
 }
 
 impl GitHubSession {
     const SESSION_KEY: &str = "github-session";
 
-    pub fn save(session: &SessionNullSession, access_token: AccessToken) {
-        session.set(Self::SESSION_KEY, GitHubSession { access_token });
+    pub async fn save(
+        session: &SessionNullSession,
+        oauth_client: &OAuthClient,
+        access_token: AccessToken,
+    ) -> anyhow::Result<()> {
+        let authenticated_client = oauth_client.get_authenticated_client(&access_token)?;
+        let user = authenticated_client
+            .current()
+            .user()
+            .await
+            .context("Unable to fetch current GitHub user")?;
+        session.set(
+            Self::SESSION_KEY,
+            GitHubSession {
+                access_token,
+                username: user.login,
+                html_url: user.html_url.to_string(),
+            },
+        );
+        Ok(())
     }
 
     pub fn restore(session: &SessionNullSession) -> Option<GitHubSession> {

--- a/src/github/rollup.rs
+++ b/src/github/rollup.rs
@@ -2,6 +2,7 @@ use super::{GithubRepoName, PullRequest, PullRequestNumber};
 use crate::PgDbClient;
 use crate::bors::{RollupMode, make_text_ignored_by_bors, normalize_merge_message};
 use crate::database::RegisterRollupMemberParams;
+use crate::github::GitHubSession;
 use crate::github::api::client::GithubRepositoryClient;
 use crate::github::api::operations::MergeError;
 use crate::github::oauth::{OAuthClient, UserGitHubClient};
@@ -9,9 +10,10 @@ use crate::permissions::PermissionType;
 use crate::server::ServerStateRef;
 use crate::utils::sort_queue::sort_queue_prs;
 use anyhow::Context;
-use axum::extract::{Query, State};
+use axum::extract::{OriginalUri, Query, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Redirect, Response};
+use axum_session::SessionNullSession;
 use futures::StreamExt;
 use itertools::Itertools;
 use rand::{Rng, distr::Alphanumeric};
@@ -23,20 +25,9 @@ use tracing::Instrument;
 /// Maximum number of PRs that can be rolled up at once.
 const ROLLUP_PR_LIMIT: u64 = 50;
 
-/// Query parameters received from GitHub's OAuth callback.
-///
-/// Documentation: https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#2-users-are-redirected-back-to-your-site-by-github
-#[derive(serde::Deserialize)]
-pub struct OAuthCallbackQuery {
-    /// Temporary code from GitHub to exchange for an access token (expires in 10m).
-    code: String,
-    /// State passed in the initial OAuth request - contains rollup info created from the queue page.
-    state: String,
-}
-
 #[derive(serde::Serialize, serde::Deserialize)]
-struct OAuthRollupState {
-    pr_nums: Vec<u32>,
+pub struct SubmitRollupQuery {
+    pr_nums: String,
     repo_name: String,
     repo_owner: String,
 }
@@ -102,30 +93,53 @@ where
     }
 }
 
-pub async fn oauth_callback_handler(
+pub async fn submit(
+    session: SessionNullSession,
     State(db): State<Arc<PgDbClient>>,
     State(oauth): State<Option<OAuthClient>>,
     State(ServerStateRef(state)): State<ServerStateRef>,
-    Query(callback): Query<OAuthCallbackQuery>,
+    Query(rollup): Query<SubmitRollupQuery>,
+    uri: OriginalUri,
 ) -> Result<impl IntoResponse, RollupError> {
     let Some(oauth_client) = oauth else {
-        let error =
-            anyhow::anyhow!("OAuth not configured. Please set CLIENT_ID and CLIENT_SECRET.");
+        let error = anyhow::anyhow!(
+            "OAuth not configured. Please set OAUTH_CLIENT_ID and OAUTH_CLIENT_SECRET."
+        );
         tracing::error!("{error}");
         return Err(error.into());
     };
 
-    let oauth_state: OAuthRollupState = serde_json::from_str(&callback.state)
-        .map_err(|_| anyhow::anyhow!("Invalid state parameter"))?;
+    let Some(github_session) = GitHubSession::restore(&session) else {
+        tracing::info!(
+            session_id = session.get_session_id(),
+            "Missing GitHub access token, requesting authentication"
+        );
+        let redirect =
+            oauth_client.authorization_url(Some(uri.path_and_query().unwrap().to_string()));
+        return Ok(Redirect::to(&redirect));
+    };
 
-    let repo_name = GithubRepoName::new(&oauth_state.repo_owner, &oauth_state.repo_name);
+    let authenticated_client =
+        oauth_client.get_authenticated_client(&github_session.access_token)?;
+    let repo_name = GithubRepoName::new(&rollup.repo_owner, &rollup.repo_name);
+
+    // don't 404 until after checking for the repo state to prevent timing-based detection
+    let is_visible = repo_name
+        .is_visible_to_client(&authenticated_client)
+        .await?;
     let Some(repo_state) = state.get_repo(&repo_name) else {
         return Err(RollupError::BaseRepoNotFound { repo_name });
     };
+    if !is_visible {
+        return Err(RollupError::BaseRepoNotFound { repo_name });
+    }
 
     let user_client = oauth_client
-        .get_authenticated_client(repo_name.clone(), &callback.code)
+        .get_user_client(authenticated_client, repo_name.clone())
         .await?;
+
+    let pr_nums: Vec<u32> =
+        serde_json::from_str(&rollup.pr_nums).context("Unable to deserialize pr_nums")?;
 
     // The rollup author is expected to r+ the rollup, so they must have review permissions to
     // create it in the first place.
@@ -140,12 +154,13 @@ pub async fn oauth_callback_handler(
     let span = tracing::info_span!(
         "create_rollup",
         repo = %repo_name,
-        pr_nums = ?oauth_state.pr_nums
+        pr_nums = ?pr_nums
     );
 
     let pr = match create_rollup(
         db,
-        oauth_state,
+        repo_name,
+        pr_nums,
         state.get_web_url(),
         &repo_state.client,
         user_client,
@@ -168,26 +183,21 @@ pub async fn oauth_callback_handler(
         .to_string();
 
     tracing::info!("Rollup created successfully, redirecting to: {pr_url}");
-    Ok(Redirect::to(&pr_url).into_response())
+    Ok(Redirect::to(&pr_url))
 }
 
 /// Creates a rollup PR by merging multiple approved PRs into a single branch
 /// in the user's fork, then opens a PR to the upstream repository.
 async fn create_rollup(
     db: Arc<PgDbClient>,
-    rollup_state: OAuthRollupState,
+    // Repository where we will create the PR
+    base_repo: GithubRepoName,
+    mut pr_nums: Vec<u32>,
     web_url: &str,
     gh_client: &GithubRepositoryClient,
     user_client: UserGitHubClient,
 ) -> Result<PullRequest, RollupError> {
-    let OAuthRollupState {
-        repo_name,
-        repo_owner,
-        mut pr_nums,
-    } = rollup_state;
-    // Repository where we will create the PR
-    let base_repo = GithubRepoName::new(&repo_owner, &repo_name);
-
+    let repo_name = base_repo.name();
     let username = user_client.user.username;
 
     tracing::info!("User {username} is creating a rollup with PRs: {pr_nums:?}");
@@ -434,7 +444,6 @@ async fn create_rollup(
 #[cfg(test)]
 mod tests {
     use crate::bors::{PullRequestStatus, RollupMode};
-    use crate::github::rollup::OAuthRollupState;
     use crate::github::{GithubRepoName, PullRequestNumber};
     use crate::permissions::PermissionType;
     use crate::tests::{
@@ -491,14 +500,11 @@ mod tests {
     #[sqlx::test]
     async fn rollup_nonexistent_pr(pool: sqlx::PgPool) {
         run_test((pool, rollup_state()), async |ctx: &mut BorsTester| {
-            ctx.api_request(rollup_request(
-                &rollup_user().name,
-                default_repo_name(),
-                &[50u64.into()],
-            ))
-            .await?
-            .assert_status(StatusCode::BAD_REQUEST)
-            .assert_body("Pull request #50 was not found");
+            ctx.authenticate(&rollup_user().name).await?;
+            ctx.api_request(rollup_request(default_repo_name(), &[50u64.into()]))
+                .await?
+                .assert_status(StatusCode::BAD_REQUEST)
+                .assert_body("Pull request #50 was not found");
             Ok(())
         })
         .await;
@@ -507,15 +513,12 @@ mod tests {
     #[sqlx::test]
     async fn rollup_too_many_prs(pool: sqlx::PgPool) {
         run_test((pool, rollup_state()), async |ctx: &mut BorsTester| {
+            ctx.authenticate(&rollup_user().name).await?;
             let prs = (1..60).map(PullRequestNumber).collect::<Vec<_>>();
-            ctx.api_request(rollup_request(
-                &rollup_user().name,
-                default_repo_name(),
-                &prs,
-            ))
-            .await?
-            .assert_status(StatusCode::BAD_REQUEST)
-            .assert_body("Rolling up too many pull requests, at most 50 is allowed");
+            ctx.api_request(rollup_request(default_repo_name(), &prs))
+                .await?
+                .assert_status(StatusCode::BAD_REQUEST)
+                .assert_body("Rolling up too many pull requests, at most 50 is allowed");
             Ok(())
         })
         .await;
@@ -1208,12 +1211,9 @@ also include this pls"
         prs: &[&PullRequest],
     ) -> anyhow::Result<ApiResponse> {
         let prs = prs.iter().map(|pr| pr.number()).collect::<Vec<_>>();
-        ctx.api_request(rollup_request(
-            &rollup_user().name,
-            default_repo_name(),
-            &prs,
-        ))
-        .await
+        ctx.authenticate(&rollup_user().name).await?;
+        ctx.api_request(rollup_request(default_repo_name(), &prs))
+            .await
     }
 
     fn rollup_state() -> GitHub {
@@ -1240,14 +1240,10 @@ also include this pls"
         GithubRepoName::new(&rollup_user().name, default_repo_name().name())
     }
 
-    fn rollup_request(code: &str, repo: GithubRepoName, prs: &[PullRequestNumber]) -> ApiRequest {
-        let state = OAuthRollupState {
-            pr_nums: prs.iter().map(|v| v.0 as u32).collect(),
-            repo_name: repo.name,
-            repo_owner: repo.owner,
-        };
-        ApiRequest::get("/oauth/callback")
-            .query("code", code)
-            .query("state", &serde_json::to_string(&state).unwrap())
+    fn rollup_request(repo: GithubRepoName, prs: &[PullRequestNumber]) -> ApiRequest {
+        ApiRequest::get("/rollup/submit")
+            .query("pr_nums", &serde_json::to_string(prs).unwrap())
+            .query("repo_name", repo.name())
+            .query("repo_owner", repo.owner())
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -18,7 +18,7 @@ use axum::{Json, Router};
 use axum_embed::ServeEmbed;
 use axum_session::{SessionConfig, SessionLayer, SessionNullSession, SessionNullSessionStore};
 use base64::Engine;
-use base64::prelude::BASE64_URL_SAFE;
+use base64::prelude::BASE64_URL_SAFE_NO_PAD;
 use chrono::Utc;
 use http::{Request, StatusCode};
 use pulldown_cmark::Parser;
@@ -153,6 +153,7 @@ pub async fn create_app(state: ServerState, insecure_cookies: bool) -> anyhow::R
         .route("/health", get(health_handler))
         .route("/oauth/callback", get(oauth_callback_handler))
         .route("/rollup/submit", get(rollup::submit))
+        .route("/logout", get(logout_handler))
         .nest("/api", api)
         .nest_service("/assets", serve_assets)
         .layer(SessionLayer::new(session_store))
@@ -260,7 +261,13 @@ fn handle_panic(_err: Box<dyn Any + Send + 'static>) -> Response {
 }
 
 async fn not_found_handler() -> impl IntoResponse {
-    (StatusCode::NOT_FOUND, HtmlTemplate(NotFoundTemplate {}))
+    (
+        StatusCode::NOT_FOUND,
+        HtmlTemplate(NotFoundTemplate {
+            login_url: None,
+            github_user: None,
+        }),
+    )
 }
 
 async fn health_handler() -> impl IntoResponse {
@@ -306,10 +313,11 @@ async fn help_handler(
     State(ServerStateRef(state)): State<ServerStateRef>,
     State(oauth): State<Option<OAuthClient>>,
 ) -> impl IntoResponse {
-    let authenticated_client = match GitHubSession::restore(&session) {
+    let github_session = GitHubSession::restore(&session);
+    let authenticated_client = match github_session.as_ref() {
         None => None,
         Some(gh_session) => {
-            let oauth_client = oauth.unwrap();
+            let oauth_client = oauth.as_ref().unwrap();
             match oauth_client.get_authenticated_client(&gh_session.access_token) {
                 Ok(client) => Some(client),
                 Err(error) => {
@@ -357,6 +365,10 @@ async fn help_handler(
     pulldown_cmark::html::push_html(&mut help_html, markdown);
 
     HtmlTemplate(HelpTemplate {
+        login_url: oauth
+            .as_ref()
+            .map(|oauth_client| oauth_client.authorization_url(None)),
+        github_user: github_session.as_ref().map(Into::into),
         repos,
         help: help_html,
         cmd_prefix: state.get_cmd_prefix().as_ref().to_string(),
@@ -397,8 +409,9 @@ pub async fn queue_handler(
     Query(params): Query<QueueParams>,
 ) -> Result<impl IntoResponse, AppError> {
     let repo_name = GithubRepoName::new(&repo_owner, &repo_name);
+    let gh_session = GitHubSession::restore(&session);
     let mut is_visible = false;
-    if let Some(gh_session) = GitHubSession::restore(&session) {
+    if let Some(gh_session) = gh_session.as_ref() {
         let oauth_client = oauth.as_ref().unwrap();
         let authenticated_client =
             oauth_client.get_authenticated_client(&gh_session.access_token)?;
@@ -520,9 +533,10 @@ pub async fn queue_handler(
     }
 
     Ok(HtmlTemplate(QueueTemplate {
-        oauth_client_id: oauth
+        login_url: oauth
             .as_ref()
-            .map(|client| client.config().client_id().to_string()),
+            .map(|client| client.authorization_url(Some(format!("/queue/{}", repo.name)))),
+        github_user: gh_session.as_ref().map(Into::into),
         repo_name: repo.name.name().to_string(),
         repo_owner: repo.name.owner().to_string(),
         repo_url: format!("https://github.com/{}", repo.name),
@@ -594,7 +608,11 @@ async fn oauth_callback_handler(
 
     let prev = GitHubSession::restore(&session);
     match oauth_client.get_access_token(query.code).await {
-        Ok(access_token) => GitHubSession::save(&session, access_token),
+        Ok(access_token) => {
+            if let Err(error) = GitHubSession::save(&session, &oauth_client, access_token).await {
+                tracing::warn!("Unable to save GitHub session: {error}");
+            }
+        }
         Err(error) if prev.is_some() => {
             tracing::warn!("Ignoring invalid GitHub access code: {error}")
         }
@@ -607,16 +625,25 @@ async fn oauth_callback_handler(
     let mut endpoint = None;
     if let Some(query_state) = query.state {
         // don't fail if the endpoint can't be decoded
-        if let Ok(bytes) = BASE64_URL_SAFE.decode(query_state) {
-            if let Ok(bytes_str) = std::str::from_utf8(&bytes) {
-                endpoint = Some(bytes_str.to_string());
-            }
+        match BASE64_URL_SAFE_NO_PAD.decode(&query_state) {
+            Ok(bytes) => match std::str::from_utf8(&bytes) {
+                Ok(decoded) => endpoint = Some(decoded.to_string()),
+                Err(error) => {
+                    tracing::warn!(state = query_state, %error, "invalid utf-8 from endpoint")
+                }
+            },
+            Err(error) => tracing::warn!(state = query_state, %error, "invalid base64 encoding"),
         }
     }
 
     let target = endpoint.as_deref().unwrap_or("/");
     tracing::debug!("Redirecting after oauth to: {target}");
     Redirect::to(target).into_response()
+}
+
+async fn logout_handler(session: SessionNullSession) -> Redirect {
+    session.destroy();
+    Redirect::to("/")
 }
 
 #[cfg(test)]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -146,7 +146,7 @@ pub async fn create_app(state: ServerState, insecure_cookies: bool) -> anyhow::R
         .route("/", get(index_handler))
         .route("/help", get(help_handler))
         .route(
-            "/queue/{repo_name}",
+            "/queue/{repo_owner}/{repo_name}",
             get(queue_handler).layer(compression_layer),
         )
         .route("/github", post(github_webhook_handler))
@@ -272,7 +272,7 @@ async fn index_handler(State(ServerStateRef(state)): State<ServerStateRef>) -> i
     if let Some(repo_name) = state.ctx.repositories.repository_names().pop()
         && state.ctx.repositories.repo_count() == 1
     {
-        return Redirect::temporary(&format!("/queue/{}", repo_name.name())).into_response();
+        return Redirect::temporary(&format!("/queue/{}", repo_name)).into_response();
     };
     help_handler(State(ServerStateRef(state)))
         .await
@@ -291,7 +291,7 @@ async fn help_handler(State(ServerStateRef(state)): State<ServerStateRef>) -> im
             .flatten()
             .is_some_and(|repo| repo.tree_state.is_closed());
         repos.push(RepositoryView {
-            name: repo.name().to_string(),
+            name: repo.to_string(),
             treeclosed,
         });
     }
@@ -335,14 +335,29 @@ impl<'de> Deserialize<'de> for PullRequestList {
 }
 
 pub async fn queue_handler(
-    Path(repo_name): Path<String>,
+    session: SessionNullSession,
+    Path((repo_owner, repo_name)): Path<(String, String)>,
     State(db): State<Arc<PgDbClient>>,
     State(oauth): State<Option<OAuthClient>>,
+    State(ServerStateRef(state)): State<ServerStateRef>,
     Query(params): Query<QueueParams>,
 ) -> Result<impl IntoResponse, AppError> {
-    let repo = match db.repo_by_name(&repo_name).await? {
-        Some(repo) => repo,
-        None => {
+    let repo_name = GithubRepoName::new(&repo_owner, &repo_name);
+    let mut is_visible = false;
+    if let Some(gh_session) = GitHubSession::restore(&session) {
+        let oauth_client = oauth.as_ref().unwrap();
+        let authenticated_client =
+            oauth_client.get_authenticated_client(&gh_session.access_token)?;
+        is_visible = repo_name
+            .is_visible_to_client(&authenticated_client)
+            .await?;
+    } else if let Some(repo) = state.get_repo(&repo_name) {
+        is_visible = !repo.private;
+    }
+
+    let repo = match db.repo_db(&repo_name).await? {
+        Some(repo) if is_visible => repo,
+        _ => {
             return Ok((
                 StatusCode::NOT_FOUND,
                 format!("Repository {repo_name} not found"),

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -286,7 +286,9 @@ async fn index_handler(
         let repo_name = repo.repository();
         let mut is_visible = !repo.private;
         if !is_visible && let Some(gh_session) = GitHubSession::restore(&session) {
-            let oauth_client = oauth.as_ref().unwrap();
+            let oauth_client = oauth
+                .as_ref()
+                .expect("github session without oauth configurations");
             // if there's an error with determining if the repo is visible, then fall back to not redirecting
             match oauth_client.get_authenticated_client(&gh_session.access_token) {
                 Ok(authenticated_client) => {
@@ -317,7 +319,9 @@ async fn help_handler(
     let authenticated_client = match github_session.as_ref() {
         None => None,
         Some(gh_session) => {
-            let oauth_client = oauth.as_ref().unwrap();
+            let oauth_client = oauth
+                .as_ref()
+                .expect("github session without oauth configurations");
             match oauth_client.get_authenticated_client(&gh_session.access_token) {
                 Ok(client) => Some(client),
                 Err(error) => {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,7 +1,7 @@
 use crate::bors::event::BorsEvent;
 use crate::bors::{CommandPrefix, RepositoryState, format_help};
 use crate::database::{ApprovalStatus, QueueStatus};
-use crate::github::{GithubRepoName, PullRequestNumber, rollup};
+use crate::github::{GitHubSession, GithubRepoName, OAuthExchangeCode, PullRequestNumber, rollup};
 use crate::templates::{
     HelpTemplate, HtmlTemplate, NotFoundTemplate, PullRequestStats, QueueTemplate, RepositoryView,
     RollupsInfo,
@@ -16,6 +16,9 @@ use axum::response::{IntoResponse, Redirect, Response};
 use axum::routing::{get, post};
 use axum::{Json, Router};
 use axum_embed::ServeEmbed;
+use axum_session::{SessionConfig, SessionLayer, SessionNullSession, SessionNullSessionStore};
+use base64::Engine;
+use base64::prelude::BASE64_URL_SAFE;
 use chrono::Utc;
 use http::{Request, StatusCode};
 use pulldown_cmark::Parser;
@@ -95,7 +98,7 @@ impl FromRef<ServerStateRef> for Arc<PgDbClient> {
 #[derive(Clone)]
 pub struct ServerStateRef(pub Arc<ServerState>);
 
-pub fn create_app(state: ServerState) -> Router {
+pub async fn create_app(state: ServerState, insecure_cookies: bool) -> anyhow::Result<Router> {
     let compression_layer = CompressionLayer::new()
         .br(true)
         .gzip(true)
@@ -120,6 +123,18 @@ pub fn create_app(state: ServerState) -> Router {
             },
         );
 
+    if insecure_cookies {
+        tracing::warn!("Secure cookies are disabled. This is only recommended in local dev");
+    }
+
+    let session_config = SessionConfig::default()
+        .with_http_only(true)
+        .with_key(axum_session::Key::generate())
+        .with_memory_lifetime(chrono::Duration::hours(2))
+        .with_secure(!insecure_cookies)
+        .with_table_name("web_sessions");
+    let session_store = SessionNullSessionStore::new(None, session_config).await?;
+
     #[derive(Embed, Clone)]
     #[folder = "web/assets/"]
     struct Assets;
@@ -127,7 +142,7 @@ pub fn create_app(state: ServerState) -> Router {
     let serve_assets = ServeEmbed::<Assets>::new();
 
     let api = create_api_router();
-    Router::new()
+    Ok(Router::new()
         .route("/", get(index_handler))
         .route("/help", get(help_handler))
         .route(
@@ -136,14 +151,16 @@ pub fn create_app(state: ServerState) -> Router {
         )
         .route("/github", post(github_webhook_handler))
         .route("/health", get(health_handler))
-        .route("/oauth/callback", get(rollup::oauth_callback_handler))
+        .route("/oauth/callback", get(oauth_callback_handler))
+        .route("/rollup/submit", get(rollup::submit))
         .nest("/api", api)
         .nest_service("/assets", serve_assets)
+        .layer(SessionLayer::new(session_store))
         .layer(ConcurrencyLimitLayer::new(100))
         .layer(CatchPanicLayer::custom(handle_panic))
         .layer(trace_layer)
         .with_state(ServerStateRef(Arc::new(state)))
-        .fallback(not_found_handler)
+        .fallback(not_found_handler))
 }
 
 fn create_api_router() -> Router<ServerStateRef> {
@@ -477,6 +494,60 @@ pub async fn github_webhook_handler(
             }
         },
     }
+}
+
+/// Query parameters received from GitHub's OAuth callback.
+///
+/// Documentation: https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#2-users-are-redirected-back-to-your-site-by-github
+#[derive(serde::Deserialize)]
+struct OAuthCallbackQuery {
+    code: OAuthExchangeCode,
+    /// Contains the endpoint to redirect to
+    state: Option<String>,
+}
+
+async fn oauth_callback_handler(
+    session: SessionNullSession,
+    State(oauth): State<Option<OAuthClient>>,
+    Query(query): Query<OAuthCallbackQuery>,
+) -> Response {
+    tracing::debug!(
+        session_id = session.get_session_id(),
+        "oauth callback for session"
+    );
+    let Some(oauth_client) = oauth else {
+        let error = anyhow::anyhow!(
+            "OAuth not configured. Please set OAUTH_CLIENT_ID and OAUTH_CLIENT_SECRET."
+        );
+        tracing::error!("{error}");
+        return (StatusCode::INTERNAL_SERVER_ERROR, format!("{error:?}")).into_response();
+    };
+
+    let prev = GitHubSession::restore(&session);
+    match oauth_client.get_access_token(query.code).await {
+        Ok(access_token) => GitHubSession::save(&session, access_token),
+        Err(error) if prev.is_some() => {
+            tracing::warn!("Ignoring invalid GitHub access code: {error}")
+        }
+        Err(error) => {
+            tracing::error!("{error}");
+            return (StatusCode::INTERNAL_SERVER_ERROR, format!("{error:?}")).into_response();
+        }
+    }
+
+    let mut endpoint = None;
+    if let Some(query_state) = query.state {
+        // don't fail if the endpoint can't be decoded
+        if let Ok(bytes) = BASE64_URL_SAFE.decode(query_state) {
+            if let Ok(bytes_str) = std::str::from_utf8(&bytes) {
+                endpoint = Some(bytes_str.to_string());
+            }
+        }
+    }
+
+    let target = endpoint.as_deref().unwrap_or("/");
+    tracing::debug!("Redirecting after oauth to: {target}");
+    Redirect::to(target).into_response()
 }
 
 #[cfg(test)]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -267,31 +267,85 @@ async fn health_handler() -> impl IntoResponse {
     (StatusCode::OK, "")
 }
 
-async fn index_handler(State(ServerStateRef(state)): State<ServerStateRef>) -> impl IntoResponse {
+async fn index_handler(
+    session: SessionNullSession,
+    State(ServerStateRef(state)): State<ServerStateRef>,
+    State(oauth): State<Option<OAuthClient>>,
+) -> impl IntoResponse {
     // If we manage exactly one repo, redirect to its queue page directly
-    if let Some(repo_name) = state.ctx.repositories.repository_names().pop()
+    if let Some(repo) = state.ctx.repositories.repositories().pop()
         && state.ctx.repositories.repo_count() == 1
     {
-        return Redirect::temporary(&format!("/queue/{}", repo_name)).into_response();
-    };
-    help_handler(State(ServerStateRef(state)))
+        let repo_name = repo.repository();
+        let mut is_visible = !repo.private;
+        if !is_visible && let Some(gh_session) = GitHubSession::restore(&session) {
+            let oauth_client = oauth.as_ref().unwrap();
+            // if there's an error with determining if the repo is visible, then fall back to not redirecting
+            match oauth_client.get_authenticated_client(&gh_session.access_token) {
+                Ok(authenticated_client) => {
+                    match repo_name.is_visible_to_client(&authenticated_client).await {
+                        Ok(visibility) => is_visible = visibility,
+                        Err(error) => tracing::warn!("{error}"),
+                    }
+                }
+                Err(error) => tracing::warn!("{error}"),
+            }
+        }
+
+        if is_visible {
+            return Redirect::temporary(&format!("/queue/{repo_name}")).into_response();
+        }
+    }
+    help_handler(session, State(ServerStateRef(state)), State(oauth))
         .await
         .into_response()
 }
 
-async fn help_handler(State(ServerStateRef(state)): State<ServerStateRef>) -> impl IntoResponse {
+async fn help_handler(
+    session: SessionNullSession,
+    State(ServerStateRef(state)): State<ServerStateRef>,
+    State(oauth): State<Option<OAuthClient>>,
+) -> impl IntoResponse {
+    let authenticated_client = match GitHubSession::restore(&session) {
+        None => None,
+        Some(gh_session) => {
+            let oauth_client = oauth.unwrap();
+            match oauth_client.get_authenticated_client(&gh_session.access_token) {
+                Ok(client) => Some(client),
+                Err(error) => {
+                    tracing::warn!("{error}");
+                    None
+                }
+            }
+        }
+    };
+
     let mut repos = Vec::with_capacity(state.ctx.repositories.repo_count());
-    for repo in state.ctx.repositories.repository_names() {
+    for repo in state.ctx.repositories.repositories() {
+        let repo_name = repo.repository();
+        if repo.private {
+            let Some(authenticated_client) = authenticated_client.as_ref() else {
+                continue;
+            };
+            if !repo_name
+                .is_visible_to_client(authenticated_client)
+                .await
+                .unwrap_or(false)
+            {
+                continue;
+            }
+        }
+
         let treeclosed = state
             .ctx
             .db
-            .repo_db(&repo)
+            .repo_db(repo_name)
             .await
             .ok()
             .flatten()
             .is_some_and(|repo| repo.tree_state.is_closed());
         repos.push(RepositoryView {
-            name: repo.to_string(),
+            name: repo_name.to_string(),
             treeclosed,
         });
     }

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -3,7 +3,7 @@ use crate::database::{
     BuildModel, BuildStatus, MergeableState::*, PullRequestModel, QueueStatus, TreeState,
     WorkflowModel,
 };
-use crate::github::PullRequestNumber;
+use crate::github::{GitHubSession, PullRequestNumber};
 use askama::Template;
 use axum::response::{Html, IntoResponse, Response};
 use chrono::Utc;
@@ -42,9 +42,26 @@ where
     }
 }
 
+pub struct GitHubUser {
+    pub username: String,
+    pub html_url: String,
+}
+
+impl From<&GitHubSession> for GitHubUser {
+    fn from(value: &GitHubSession) -> Self {
+        GitHubUser {
+            username: value.username.clone(),
+            html_url: value.html_url.clone(),
+        }
+    }
+}
+
 #[derive(Template)]
 #[template(path = "help.html")]
 pub struct HelpTemplate {
+    pub login_url: Option<String>,
+    /// Can only be Some if login_url is as well
+    pub github_user: Option<GitHubUser>,
     pub repos: Vec<RepositoryView>,
     pub cmd_prefix: String,
     pub help: String,
@@ -82,7 +99,9 @@ pub struct QueueTemplate {
     pub prs: Vec<PullRequestModel>,
     pub rollups_info: RollupsInfo,
     pub tree_state: TreeState,
-    pub oauth_client_id: Option<String>,
+    pub login_url: Option<String>,
+    /// Can only be Some if login_url is as well
+    pub github_user: Option<GitHubUser>,
     // PRs that should be pre-selected for being included in a rollup
     pub selected_rollup_prs: Vec<u32>,
     // Active workflow for an active pending auto build
@@ -153,4 +172,7 @@ impl QueueTemplate {
 
 #[derive(Template)]
 #[template(path = "not_found.html")]
-pub struct NotFoundTemplate {}
+pub struct NotFoundTemplate {
+    pub login_url: Option<String>,
+    pub github_user: Option<GitHubUser>,
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1051,8 +1051,11 @@ impl BorsTester {
                 .to_vec(),
         );
         for set_cookie in headers.get_all(SET_COOKIE) {
-            let set_cookie = set_cookie.to_str().unwrap();
-            let Some(session_cookie) = set_cookie.strip_prefix("session=") else {
+            let Some(session_cookie) = set_cookie
+                .to_str()
+                .ok()
+                .and_then(|cookie| cookie.strip_prefix("session="))
+            else {
                 continue;
             };
             let session_id = session_cookie.split(";").next().unwrap_or(session_cookie);

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -14,6 +14,7 @@ use crate::{
 };
 use anyhow::Context;
 use axum::Router;
+use http::header::{COOKIE, SET_COOKIE};
 use http::{HeaderMap, Method, Request, StatusCode};
 use octocrab::models::RunId;
 use octocrab::models::workflows::Conclusion;
@@ -194,6 +195,7 @@ pub struct BorsTester {
     mergeability_queue_rx: MergeabilityQueueReceiver,
     gitops_queue_rx: GitOpsQueueReceiver,
     ctx: Arc<BorsContext>,
+    current_session: Option<String>,
 }
 
 impl BorsTester {
@@ -251,7 +253,7 @@ impl BorsTester {
             Some(oauth_client),
             ctx.clone(),
         );
-        let app = create_app(state);
+        let app = create_app(state, true).await.unwrap();
         let bors = tokio::spawn(bors_process);
         (
             Self {
@@ -264,6 +266,7 @@ impl BorsTester {
                 mergeability_queue_rx,
                 gitops_queue_rx,
                 ctx,
+                current_session: None,
             },
             bors,
         )
@@ -1030,15 +1033,14 @@ impl BorsTester {
             write!(path, "{c}{key}={}", urlencoding::encode(value))?;
         }
 
+        let mut req = Request::builder().uri(&path).method(request.method);
+        if let Some(session_id) = self.current_session.as_ref() {
+            req = req.header(COOKIE, format!("session={session_id}"));
+        }
+
         let response = self
             .app
-            .call(
-                Request::builder()
-                    .uri(&path)
-                    .method(request.method)
-                    .body(String::new())
-                    .unwrap(),
-            )
+            .call(req.body(String::new()).unwrap())
             .await
             .context("Cannot send REST API request")?;
         let headers = response.headers().clone();
@@ -1048,6 +1050,14 @@ impl BorsTester {
                 .await?
                 .to_vec(),
         );
+        for set_cookie in headers.get_all(SET_COOKIE) {
+            let set_cookie = set_cookie.to_str().unwrap();
+            let Some(session_cookie) = set_cookie.strip_prefix("session=") else {
+                continue;
+            };
+            let session_id = session_cookie.split(";").next().unwrap_or(session_cookie);
+            self.current_session = Some(session_id.to_string());
+        }
         Ok(ApiResponse {
             status,
             headers,
@@ -1177,6 +1187,13 @@ impl BorsTester {
         self.db()
             .get_pull_request(&id.repo, PullRequestNumber(id.number))
             .await
+    }
+
+    pub async fn authenticate(&mut self, code: &str) -> anyhow::Result<()> {
+        self.api_request(ApiRequest::get("/oauth/callback").query("code", code))
+            .await?
+            .assert_status(StatusCode::from_u16(303).unwrap());
+        Ok(())
     }
 
     async fn finish(self, bors: JoinHandle<()>) -> anyhow::Result<GitHub> {

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -174,10 +174,36 @@
           content: "-";
           color: var(--color-text-muted);
       }
+
+      .navbar {
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          border-bottom-width: 2px;
+          border-bottom-color: black;
+      }
+
+      .container {
+          display: flex;
+          flex-direction: column;
+      }
   </style>
   {% block head %}{% endblock %}
 </head>
 <body>
+    <div class="container">
+        <div class="navbar">
+            <h1>{% block heading %}{% endblock %}</h1>
+            {%- if let Some(github_user) = github_user -%}
+            <div>
+                Signed in to GitHub as <a href="{{ github_user.html_url }}">{{ github_user.username }}</a>
+            </div>
+            <button><a href="/logout">Log out</a></button>
+            {%- else if let Some(login_url) = login_url -%}
+            <button><a href='{{ "{}" | format(login_url | safe) }}'>Sign in with GitHub</a></button>
+            {%- endif -%}
+        </div>
 {% block body %}{% endblock %}
+    </div>
 </body>
 </html>

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -187,6 +187,20 @@
           display: flex;
           flex-direction: column;
       }
+
+      a.btn {
+          font-size: small;
+          display: inline-block;
+          background-color: var(--color-bg-higlight);
+          border: 1px solid var(--color-border-muted);
+          border-radius: 5%;
+          padding: 0.25rem 0.5rem;
+          margin: auto unset;
+      }
+
+      a.btn:hover {
+          filter: brightness(95%);
+      }
   </style>
   {% block head %}{% endblock %}
 </head>
@@ -198,9 +212,9 @@
             <div>
                 Signed in to GitHub as <a href="{{ github_user.html_url }}">{{ github_user.username }}</a>
             </div>
-            <button><a href="/logout">Log out</a></button>
+            <a class="btn" href="/logout">Log out</a>
             {%- else if let Some(login_url) = login_url -%}
-            <button><a href='{{ "{}" | format(login_url | safe) }}'>Sign in with GitHub</a></button>
+            <a class="btn" href='{{ "{}" | format(login_url | safe) }}'>Sign in with GitHub</a>
             {%- endif -%}
         </div>
 {% block body %}{% endblock %}

--- a/web/templates/help.html
+++ b/web/templates/help.html
@@ -43,10 +43,12 @@
 </style>
 {% endblock %}
 
+{% block heading %}
+Bors
+{% endblock %}
+
 {% block body %}
 <main>
-  <h1>Bors</h1>
-
   <h2>Repositories</h2>
   <ul class="repos">
     {% for repo in repos %}

--- a/web/templates/not_found.html
+++ b/web/templates/not_found.html
@@ -14,9 +14,12 @@
 </style>
 {% endblock %}
 
+{% block heading %}
+Page not found
+{% endblock %}
+
 {% block body %}
 <main>
-    <h1>Page not found</h1>
     <p><a href="/">Go back to the index</a></p>
 </main>
 {% endblock %}

--- a/web/templates/queue.html
+++ b/web/templates/queue.html
@@ -680,9 +680,7 @@ Average duration of recent auto builds: {{ format_duration(*average_build_durati
     });
 
     {% if let Some(client_id) = oauth_client_id %}
-    rollupContinueButton.addEventListener("click", () => {
-        const scopes = ["public_repo", "workflow"];
-
+    rollupContinueButton.addEventListener("click", async () => {
         // Gather PR numbers
         let selectedRows = table.rows({ selected: true }).nodes().toArray();
         let nums = selectedRows
@@ -692,18 +690,11 @@ Average duration of recent auto builds: {{ format_duration(*average_build_durati
             })
             .filter(num => num !== null);
 
-        let state = JSON.stringify({
-            pr_nums: nums,
-            repo_name: "{{ repo_name }}",
-            repo_owner: "{{ repo_owner }}"
-        });
-
-        const oauthUrl = new URL("https://github.com/login/oauth/authorize");
-        oauthUrl.searchParams.set("client_id", "{{ client_id }}");
-        oauthUrl.searchParams.set("scope", scopes.join(","));
-        oauthUrl.searchParams.set("state", state);
-
-        window.location.href = oauthUrl.toString();
+        const submitUrl = new URL("/rollup/submit", window.location.href);
+        submitUrl.searchParams.set("pr_nums", JSON.stringify(nums));
+        submitUrl.searchParams.set("repo_owner", "{{ repo_owner }}");
+        submitUrl.searchParams.set("repo_name", "{{ repo_name }}");
+        window.location.href = submitUrl.toString();
     });
     {% endif %}
 

--- a/web/templates/queue.html
+++ b/web/templates/queue.html
@@ -213,19 +213,19 @@
 </style>
 {% endblock %}
 
+{% block heading %}
+<a href="/help">Bors</a> queue - <a href="{{ repo_url }}" target="_blank">{{ repo_name }}</a>
+{% if tree_state.is_closed() %}
+{% if let Some(comment_source) = tree_state.comment_source() %}
+{% if let Some(priority) = tree_state.priority() %}
+[<a href="{{ comment_source }}">TREECLOSED</a> below priority {{ priority }}]
+{% endif %}
+{% endif %}
+{% endif %}
+{% endblock %}
+
 {% block body %}
 <main>
-  <h1>
-    <a href="/help">Bors</a> queue - <a href="{{ repo_url }}" target="_blank">{{ repo_name }}</a>
-    {% if tree_state.is_closed() %}
-    {% if let Some(comment_source) = tree_state.comment_source() %}
-    {% if let Some(priority) = tree_state.priority() %}
-    [<a href="{{ comment_source }}">TREECLOSED</a> below priority {{ priority }}]
-    {% endif %}
-    {% endif %}
-    {% endif %}
-  </h1>
-
   <div style="margin-bottom: 1rem; display: flex; align-items: center;">
     <button id="showRollupSelection">Create rollup</button>
     <p style="margin-left: 10px; margin-bottom: 0;">
@@ -657,7 +657,7 @@ Average duration of recent auto builds: {{ format_duration(*average_build_durati
     });
 
     createRollupButton.addEventListener("click", () => {
-        {% if oauth_client_id.is_none() %}
+        {% if login_url.is_none() %}
         alert("Both CLIENT_ID and CLIENT_SECRET must be set to enabled OAuth.");
         return;
         {% endif %}
@@ -679,7 +679,7 @@ Average duration of recent auto builds: {{ format_duration(*average_build_durati
         modal.style.display = "block";
     });
 
-    {% if let Some(client_id) = oauth_client_id %}
+    {% if let Some(login_url) = login_url %}
     rollupContinueButton.addEventListener("click", async () => {
         // Gather PR numbers
         let selectedRows = table.rows({ selected: true }).nodes().toArray();
@@ -694,7 +694,18 @@ Average duration of recent auto builds: {{ format_duration(*average_build_durati
         submitUrl.searchParams.set("pr_nums", JSON.stringify(nums));
         submitUrl.searchParams.set("repo_owner", "{{ repo_owner }}");
         submitUrl.searchParams.set("repo_name", "{{ repo_name }}");
-        window.location.href = submitUrl.toString();
+
+        {% if github_user.is_some() %}
+        const dest = submitUrl;
+        {% else %}
+        const dest = new URL('{{ "{}" | format(login_url | safe) }}');
+        const finalDestination = btoa(`${submitUrl.pathname}${submitUrl.search}`)
+            .replace(/=*$/, '') // remove padding
+            .replace(/\+/g, '-').replace(/\//g, '_'); // url-safe alphabet
+        dest.searchParams.set('state', finalDestination);
+        {% endif %}
+
+        window.location.href = dest.toString();
     });
     {% endif %}
 

--- a/web/templates/queue.html
+++ b/web/templates/queue.html
@@ -29,7 +29,7 @@
     }
     main {
         max-width: 1920px;
-        width: 100%;
+        width: 95vw;
         margin: 0 auto;
     }
 


### PR DESCRIPTION
if bors is installed on the whole organization, then a repo without `rust-bors.toml` will result in bors not starting up.

this changes `fn main` to match the behavior of `src/bors/handlers/mod.rs#reload_repos`, which simply prints the error for the repo and exits.