### PR TITLE
Teach bors to post to Zulip and notify about tree closed/open events

### DIFF
--- a/src/bin/bors.rs
+++ b/src/bin/bors.rs
@@ -7,10 +7,11 @@ use anyhow::Context;
 use bors::server::{ServerState, create_app};
 use bors::{
     BorsContext, BorsGlobalEvent, BorsProcess, CommandParser, Git, OAuthClient, OAuthConfig,
-    PgDbClient, RepositoryStore, TeamApiClient, TreeState, WebhookSecret, create_bors_process,
-    create_github_client, load_repositories,
+    PgDbClient, RepositoryStore, TeamApiClient, TreeState, WebhookSecret, ZulipClient,
+    create_bors_process, create_github_client, load_repositories,
 };
 use clap::Parser;
+use secrecy::{ExposeSecret, SecretString};
 use sqlx::postgres::PgConnectOptions;
 use sqlx::{ConnectOptions, PgPool};
 use tokio::time::{Interval, MissedTickBehavior};
@@ -48,7 +49,7 @@ struct Opts {
 
     /// Private key used to authenticate as a Github App.
     #[arg(long, env = "PRIVATE_KEY", allow_hyphen_values = true)]
-    private_key: String,
+    private_key: SecretString,
 
     /// GitHub OAuth client ID for rollups.
     #[arg(long, env = "OAUTH_CLIENT_ID")]
@@ -56,15 +57,27 @@ struct Opts {
 
     /// GitHub OAuth client secret for rollups.
     #[arg(long, env = "OAUTH_CLIENT_SECRET")]
-    client_secret: Option<String>,
+    client_secret: Option<SecretString>,
+
+    /// Zulip account username for sending messages to Zulip.
+    #[arg(long, env = "ZULIP_USERNAME")]
+    zulip_username: Option<String>,
+
+    /// Zulip account token for sending messages to Zulip.
+    #[arg(long, env = "ZULIP_TOKEN")]
+    zulip_token: Option<SecretString>,
+
+    /// Zulip server for sending messages.
+    #[arg(long, env = "ZULIP_SERVER")]
+    zulip_server: Option<String>,
 
     /// Secret used to authenticate webhooks.
     #[arg(long, env = "WEBHOOK_SECRET")]
-    webhook_secret: String,
+    webhook_secret: SecretString,
 
     /// Database connection string.
     #[arg(long, env = "DATABASE_URL")]
-    db: String,
+    db: SecretString,
 
     /// Prefix used for bot commands in PR comments.
     #[arg(long, env = "CMD_PREFIX", default_value = "@bors")]
@@ -124,10 +137,10 @@ fn try_main(opts: Opts) -> anyhow::Result<()> {
         .context("Cannot build tokio runtime")?;
 
     let db = runtime
-        .block_on(initialize_db(&opts.db))
+        .block_on(initialize_db(opts.db.expose_secret()))
         .context("Cannot initialize database")?;
     let team_api = TeamApiClient::new(opts.permissions);
-    let (client, loaded_repos) = runtime.block_on(async {
+    let (gh_client, loaded_repos) = runtime.block_on(async {
         let client = create_github_client(
             opts.app_id.into(),
             "https://api.github.com".to_string(),
@@ -136,6 +149,17 @@ fn try_main(opts: Opts) -> anyhow::Result<()> {
         let repos = load_repositories(&client, &team_api).await?;
         Ok::<_, anyhow::Error>((client, repos))
     })?;
+    let zulip_client = match (opts.zulip_server, opts.zulip_username, opts.zulip_token) {
+        (Some(url), Some(username), Some(token)) => {
+            Some(ZulipClient::new(url, username, token).context("Cannot create Zulip client")?)
+        }
+        (None, None, None) => None,
+        _ => {
+            return Err(anyhow::anyhow!(
+                "You have to provide the Zulip URL, username and token when providing at least one of them"
+            ));
+        }
+    };
 
     let repos = Arc::new(RepositoryStore::default());
     for (name, repo) in loaded_repos {
@@ -177,6 +201,7 @@ fn try_main(opts: Opts) -> anyhow::Result<()> {
         repos.clone(),
         git,
         &opts.web_url,
+        zulip_client,
     ));
     let BorsProcess {
         repository_tx,
@@ -185,7 +210,7 @@ fn try_main(opts: Opts) -> anyhow::Result<()> {
         ..
     } = create_bors_process(
         ctx.clone(),
-        client,
+        gh_client,
         team_api,
         chrono::Duration::from_std(MERGE_QUEUE_MAX_INTERVAL).unwrap(),
     );

--- a/src/bin/bors.rs
+++ b/src/bin/bors.rs
@@ -144,7 +144,7 @@ fn try_main(opts: Opts) -> anyhow::Result<()> {
         let client = create_github_client(
             opts.app_id.into(),
             "https://api.github.com".to_string(),
-            opts.private_key.into(),
+            opts.private_key,
         )?;
         let repos = load_repositories(&client, &team_api).await?;
         Ok::<_, anyhow::Error>((client, repos))

--- a/src/bors/context.rs
+++ b/src/bors/context.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use super::{RepositoryState, RepositoryStore};
 use crate::bors::gitops::Git;
-use crate::{PgDbClient, bors::command::CommandParser, github::GithubRepoName};
+use crate::{PgDbClient, ZulipClient, bors::command::CommandParser, github::GithubRepoName};
 
 pub struct BorsContext {
     pub parser: CommandParser,
@@ -10,6 +10,7 @@ pub struct BorsContext {
     pub repositories: Arc<RepositoryStore>,
     git: Option<Git>,
     web_url: String,
+    zulip_client: Option<ZulipClient>,
 }
 
 impl BorsContext {
@@ -19,6 +20,7 @@ impl BorsContext {
         repositories: Arc<RepositoryStore>,
         git: Option<Git>,
         web_url: &str,
+        zulip_client: Option<ZulipClient>,
     ) -> Self {
         Self {
             parser,
@@ -26,6 +28,7 @@ impl BorsContext {
             repositories,
             git,
             web_url: web_url.trim_end_matches('/').to_string(),
+            zulip_client,
         }
     }
 
@@ -50,5 +53,9 @@ impl BorsContext {
             }
         };
         Ok(repo_state)
+    }
+
+    pub fn get_zulip_api(&self) -> Option<&ZulipClient> {
+        self.zulip_client.as_ref()
     }
 }

--- a/src/bors/handlers/mod.rs
+++ b/src/bors/handlers/mod.rs
@@ -423,7 +423,9 @@ async fn handle_comment(
                             database,
                             pr,
                             &comment.author,
+                            &comment.html_url,
                             senders.merge_queue(),
+                            ctx.get_zulip_api(),
                         )
                         .instrument(span)
                         .await
@@ -441,6 +443,7 @@ async fn handle_comment(
                                 comment_url: &comment.html_url,
                             },
                             senders.merge_queue(),
+                            ctx.get_zulip_api(),
                         )
                         .instrument(span)
                         .await

--- a/src/bors/handlers/review.rs
+++ b/src/bors/handlers/review.rs
@@ -17,7 +17,7 @@ use crate::database::{MergeableState, TreeState};
 use crate::github::{CommitSha, LabelTrigger, PullRequest};
 use crate::github::{GithubUser, PullRequestNumber};
 use crate::permissions::PermissionType;
-use crate::{BorsContext, PgDbClient};
+use crate::{BorsContext, PgDbClient, ZulipClient};
 use std::sync::Arc;
 use tracing::log;
 
@@ -427,7 +427,10 @@ pub(super) async fn command_close_tree(
     author: &GithubUser,
     args: TreeCloseArguments<'_>,
     merge_queue_tx: &MergeQueueSender,
+    zulip_api: Option<&ZulipClient>,
 ) -> anyhow::Result<()> {
+    use std::fmt::Write;
+
     let TreeCloseArguments {
         priority,
         reason,
@@ -449,11 +452,33 @@ pub(super) async fn command_close_tree(
         repo_state.repository(),
         TreeState::Closed {
             priority,
-            reason,
+            reason: reason.clone(),
             source: comment_url.to_string(),
         },
     )
     .await?;
+
+    if let Some(zulip_api) = zulip_api {
+        let mut message = format!(
+            r#"The tree of `{}` was [closed]({}) for PRs with priority below `{priority}` by `{}`."#,
+            repo_state.repository(),
+            comment_url,
+            author.username
+        );
+        if let Some(reason) = reason {
+            // Just as a pre-caution, to avoid pinging anyone.
+            let reason = reason.replace("@", "");
+            writeln!(message, "\n\nReason: {reason}").unwrap();
+        }
+
+        // This should not break the command execution
+        if let Err(error) = zulip_api
+            .send_message(zulip_api.tree_ops_topic(), &message)
+            .await
+        {
+            tracing::error!("Could not send Zulip message when closing a tree: {error:?}");
+        }
+    }
 
     merge_queue_tx.notify().await?;
     notify_of_tree_closed(&repo_state, &db, pr.number(), priority).await
@@ -464,7 +489,9 @@ pub(super) async fn command_open_tree(
     db: Arc<PgDbClient>,
     pr: PullRequestData<'_>,
     author: &GithubUser,
+    comment_url: &str,
     merge_queue_tx: &MergeQueueSender,
+    zulip_api: Option<&ZulipClient>,
 ) -> anyhow::Result<()> {
     if !sufficient_delegate_permission(repo_state.clone(), author) {
         deny_request(
@@ -480,6 +507,20 @@ pub(super) async fn command_open_tree(
 
     db.upsert_repository(repo_state.repository(), TreeState::Open)
         .await?;
+
+    if let Some(zulip_api) = zulip_api {
+        let message = format!(
+            "The tree of `{}` was [reopened]({comment_url}) by `{}`.",
+            repo_state.repository(),
+            author.username
+        );
+        if let Err(error) = zulip_api
+            .send_message(zulip_api.tree_ops_topic(), &message)
+            .await
+        {
+            tracing::error!("Could not send Zulip message when opening a tree: {error:?}");
+        }
+    }
 
     merge_queue_tx.notify().await?;
     notify_of_tree_open(&repo_state, &db, pr.number()).await

--- a/src/github/oauth.rs
+++ b/src/github/oauth.rs
@@ -89,10 +89,10 @@ pub struct OAuthConfig {
 }
 
 impl OAuthConfig {
-    pub fn new(client_id: String, client_secret: String) -> Self {
+    pub fn new(client_id: String, client_secret: SecretString) -> Self {
         Self {
             client_id,
-            client_secret: client_secret.into(),
+            client_secret,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub use github::{
 pub use permissions::TeamApiClient;
 pub use server::ServerState;
 pub use server::create_app;
+pub use zulip::ZulipClient;
 
 /// This migrator serves for including a single place in the test code that stores all migrations
 /// loaded from disk. All sqlx tests should then reference it using
@@ -36,3 +37,4 @@ static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!();
 
 #[cfg(test)]
 mod tests;
+mod zulip;

--- a/src/server/webhook.rs
+++ b/src/server/webhook.rs
@@ -32,8 +32,8 @@ use crate::server::ServerStateRef;
 pub struct WebhookSecret(SecretString);
 
 impl WebhookSecret {
-    pub fn new(secret: String) -> Self {
-        Self(secret.into())
+    pub fn new(secret: SecretString) -> Self {
+        Self(secret)
     }
 
     pub fn expose(&self) -> &str {
@@ -1750,7 +1750,7 @@ mod tests {
         let server_ref = ServerStateRef(Arc::new(ServerState::new(
             repository_tx,
             global_tx,
-            WebhookSecret::new(TEST_WEBHOOK_SECRET.to_string()),
+            WebhookSecret::new(TEST_WEBHOOK_SECRET.into()),
             None,
             Arc::new(BorsContext::new(
                 CommandParser::new(default_cmd_prefix()),
@@ -1758,6 +1758,7 @@ mod tests {
                 Arc::new(RepositoryStore::default()),
                 None,
                 "",
+                None,
             )),
         )));
         GitHubWebhook::from_request(request, &server_ref).await

--- a/src/tests/github.rs
+++ b/src/tests/github.rs
@@ -544,7 +544,7 @@ pub fn default_repo_name() -> GithubRepoName {
 }
 
 pub fn default_oauth_config() -> OAuthConfig {
-    OAuthConfig::new(test_oauth_client_id(), test_oauth_client_secret())
+    OAuthConfig::new(test_oauth_client_id(), test_oauth_client_secret().into())
 }
 
 fn test_oauth_client_id() -> String {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -226,6 +226,7 @@ impl BorsTester {
             // local git ops, but we do not currently mock git in tests.
             Some(Git::from_path(PathBuf::from("/tmp/git"))),
             "https://bors-test.com",
+            None,
         ));
 
         let BorsProcess {
@@ -248,7 +249,7 @@ impl BorsTester {
         let state = ServerState::new(
             repository_tx,
             global_tx.clone(),
-            WebhookSecret::new(TEST_WEBHOOK_SECRET.to_string()),
+            WebhookSecret::new(TEST_WEBHOOK_SECRET.into()),
             Some(oauth_client),
             ctx.clone(),
         );

--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -1,0 +1,93 @@
+use crate::utils::timing::{RetryMethod, perform_retryable};
+use anyhow::Context;
+use http::Method;
+use secrecy::{ExposeSecret, SecretString};
+
+pub struct ZulipClient {
+    client: reqwest::Client,
+    url: String,
+    username: String,
+    token: SecretString,
+}
+
+impl ZulipClient {
+    pub fn new(url: String, username: String, token: SecretString) -> anyhow::Result<Self> {
+        let client = reqwest::ClientBuilder::new()
+            .user_agent("bors-rust-lang")
+            .build()?;
+        Ok(Self {
+            client,
+            url,
+            username,
+            token,
+        })
+    }
+
+    /// Sends a message to a Zulip topic.
+    pub async fn send_message<'a>(
+        &self,
+        recipient: Recipient<'a>,
+        message: &'a str,
+    ) -> anyhow::Result<()> {
+        #[derive(serde::Serialize)]
+        struct SerializedApi<'a> {
+            #[serde(rename = "type")]
+            type_: &'static str,
+            to: String,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            topic: Option<&'a str>,
+            content: &'a str,
+        }
+
+        #[derive(Debug, serde::Deserialize)]
+        struct MessageApiResponse {
+            #[serde(rename = "id")]
+            _message_id: u64,
+        }
+
+        perform_retryable("send-zulip-message", RetryMethod::default(), || async {
+            let response = self
+                .make_request(Method::POST, "messages")
+                .form(&SerializedApi {
+                    type_: match recipient {
+                        Recipient::Stream { .. } => "stream",
+                    },
+                    to: match recipient {
+                        Recipient::Stream { id, .. } => id.to_string(),
+                    },
+                    topic: match recipient {
+                        Recipient::Stream { topic, .. } => Some(topic),
+                    },
+                    content: message,
+                })
+                .send()
+                .await
+                .context("fail sending Zulip message")?;
+
+            response
+                .error_for_status()?
+                .json::<MessageApiResponse>()
+                .await?;
+            anyhow::Ok(())
+        })
+        .await?;
+        Ok(())
+    }
+
+    fn make_request(&self, method: Method, url: &str) -> reqwest::RequestBuilder {
+        self.client
+            .request(method, format!("{}/api/v1/{url}", self.url))
+            .basic_auth(&self.username, Some(self.token.expose_secret()))
+    }
+}
+
+#[derive(Copy, Clone, serde::Serialize)]
+#[serde(tag = "type")]
+#[serde(rename_all = "snake_case")]
+pub enum Recipient<'a> {
+    Stream {
+        #[serde(rename = "to")]
+        id: u64,
+        topic: &'a str,
+    },
+}

--- a/src/zulip.rs
+++ b/src/zulip.rs
@@ -17,10 +17,18 @@ impl ZulipClient {
             .build()?;
         Ok(Self {
             client,
-            url,
+            url: url.trim_end_matches('/').to_string(),
             username,
             token,
         })
+    }
+
+    // The channel is hardcoded for now
+    pub fn tree_ops_topic(&self) -> Recipient<'_> {
+        Recipient::Stream {
+            id: 242791,
+            topic: "Tree ops",
+        }
     }
 
     /// Sends a message to a Zulip topic.


### PR DESCRIPTION
This PR adds support for using a Zulip client to bors. Initially, it will post about tree closed/open events to the Rust Zulip's https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/Tree.20ops/with/611420348 topic.

This needs the new environment variables configured in simpleinfra.
