### PR TITLE
Add web page with EC2 instance list

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,6 @@ insta = "1.26"
 wiremock = "0.6"
 base64 = "0.22"
 tracing-test = "0.2"
-regex = "1"
 parking_lot = "0.12"
 thread_local = "1"
 sqlparser = { version = "0.62", features = ["visitor"] }

--- a/src/bors/handlers/mod.rs
+++ b/src/bors/handlers/mod.rs
@@ -138,7 +138,7 @@ pub async fn handle_bors_repository_event(
                 run_id = payload.run_id.into_inner(),
                 job_id = payload.job_id.into_inner(),
             );
-            handle_workflow_job_started(&ctx, repo, payload)
+            handle_workflow_job_started(&ctx, db, repo, payload)
                 .instrument(span)
                 .await?;
         }

--- a/src/bors/handlers/mod.rs
+++ b/src/bors/handlers/mod.rs
@@ -24,8 +24,8 @@ use crate::bors::labels::handle_label_trigger;
 use crate::bors::mergeability_queue::set_pr_mergeability_based_on_user_action;
 use crate::bors::process::QueueSenders;
 use crate::bors::{
-    AUTO_BRANCH_NAME, BorsContext, CommandPrefix, Comment, PullRequestStatus, RepositoryState,
-    TRY_BRANCH_NAME,
+    AUTO_BRANCH_NAME, BorsContext, BuildKind, CommandPrefix, Comment, PullRequestStatus,
+    RepositoryState, TRY_BRANCH_NAME,
 };
 use crate::database::{DelegatedPermission, DelegationStatus, PullRequestModel};
 use crate::ec2::terminate_old_ec2_instances;
@@ -1130,6 +1130,14 @@ pub fn invalidation_comment(
 /// Is this branch interesting for the bot?
 fn is_bors_observed_branch(branch: &str) -> bool {
     branch == TRY_BRANCH_NAME || branch == AUTO_BRANCH_NAME
+}
+
+fn get_build_kind_from_branch(branch: &str) -> Option<BuildKind> {
+    match branch {
+        b if b == TRY_BRANCH_NAME => Some(BuildKind::Try),
+        b if b == AUTO_BRANCH_NAME => Some(BuildKind::Auto),
+        _ => None,
+    }
 }
 
 #[cfg(test)]

--- a/src/bors/handlers/workflow.rs
+++ b/src/bors/handlers/workflow.rs
@@ -3,7 +3,7 @@ use crate::bors::build::{CancelBuildConclusion, CancelBuildError};
 use crate::bors::build_queue::BuildQueueSender;
 use crate::bors::comment::{CommentTag, append_workflow_links_to_comment};
 use crate::bors::event::{WorkflowJobStarted, WorkflowRunCompleted, WorkflowRunStarted};
-use crate::bors::handlers::is_bors_observed_branch;
+use crate::bors::handlers::{get_build_kind_from_branch, is_bors_observed_branch};
 use crate::bors::{BuildKind, build};
 use crate::database::{BuildModel, BuildStatus, PullRequestModel, WorkflowStatus};
 use crate::ec2::{ParsedLabel, start_ec2_github_runner};
@@ -153,9 +153,9 @@ pub(super) async fn handle_workflow_job_started(
     repo: Arc<RepositoryState>,
     payload: WorkflowJobStarted,
 ) -> anyhow::Result<()> {
-    if !is_bors_observed_branch(&payload.branch) {
+    let Some(build_kind) = get_build_kind_from_branch(&payload.branch) else {
         return Ok(());
-    }
+    };
 
     let Some(ec2_ctx) = ctx.get_ec2_ctx() else {
         return Ok(());
@@ -201,7 +201,10 @@ pub(super) async fn handle_workflow_job_started(
         }
     };
 
-    start_ec2_github_runner(ec2_ctx, ec2_config, &repo, label, &payload, pr_number).await?;
+    start_ec2_github_runner(
+        ec2_ctx, ec2_config, &repo, label, &payload, pr_number, build_kind,
+    )
+    .await?;
 
     Ok(())
 }

--- a/src/bors/handlers/workflow.rs
+++ b/src/bors/handlers/workflow.rs
@@ -173,8 +173,8 @@ pub(super) async fn handle_workflow_job_started(
         return Ok(());
     };
 
-    // Try to find a PR attached to the job. This is best effort (though normally it should
-    // suceced).
+    // Try to find a PR attached to the job. This is best-effort (though normally it should
+    // succeed).
     let pr_number = async {
         let Some(build) = db
             .find_build(

--- a/src/bors/handlers/workflow.rs
+++ b/src/bors/handlers/workflow.rs
@@ -149,6 +149,7 @@ pub(super) async fn handle_workflow_completed(
 
 pub(super) async fn handle_workflow_job_started(
     ctx: &BorsContext,
+    db: Arc<PgDbClient>,
     repo: Arc<RepositoryState>,
     payload: WorkflowJobStarted,
 ) -> anyhow::Result<()> {
@@ -172,7 +173,35 @@ pub(super) async fn handle_workflow_job_started(
         return Ok(());
     };
 
-    start_ec2_github_runner(ec2_ctx, ec2_config, &repo, label, &payload).await?;
+    // Try to find a PR attached to the job. This is best effort (though normally it should
+    // suceced).
+    let pr_number = async {
+        let Some(build) = db
+            .find_build(
+                repo.repository(),
+                &payload.branch,
+                payload.commit_sha.clone(),
+            )
+            .await?
+        else {
+            return Ok(None);
+        };
+
+        let Some(pr) = db.find_pr_by_build(&build).await? else {
+            return Ok(None);
+        };
+        anyhow::Ok(Some(pr.number))
+    }
+    .await;
+    let pr_number = match pr_number {
+        Ok(Some(pr_number)) => Some(pr_number),
+        res => {
+            tracing::warn!("Cannot find PR for workflow job {}: {res:?}", payload.name);
+            None
+        }
+    };
+
+    start_ec2_github_runner(ec2_ctx, ec2_config, &repo, label, &payload, pr_number).await?;
 
     Ok(())
 }

--- a/src/ec2/mod.rs
+++ b/src/ec2/mod.rs
@@ -1,11 +1,15 @@
 use crate::bors::RepositoryState;
 use crate::bors::event::WorkflowJobStarted;
 use crate::config::{Ec2RunnersConfig, JitRunnerKind};
-use crate::github::PullRequestNumber;
+use crate::database::RunId;
+use crate::github::{GithubRepoName, PullRequestNumber};
 use anyhow::Context;
-use chrono::Utc;
+use chrono::{DateTime, NaiveDateTime, Utc};
+use octocrab::models::JobId;
+use regex::Regex;
 use serde::Deserialize;
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, LazyLock};
 use std::time::Duration;
 
 /// Script that will be executed on the launched EC2 instance.
@@ -220,69 +224,10 @@ pub async fn terminate_old_ec2_instances(
 
     let timeout = repo_config.timeout;
 
-    #[derive(serde::Deserialize, Debug)]
-    #[serde(rename_all = "PascalCase")]
-    struct InstanceState {
-        name: String,
-    }
-
-    #[derive(serde::Deserialize, Debug)]
-    #[serde(rename_all = "PascalCase")]
-    struct Tag {
-        key: String,
-        value: String,
-    }
-
-    #[derive(serde::Deserialize, Debug)]
-    #[serde(rename_all = "PascalCase")]
-    struct Instance {
-        #[serde(rename = "InstanceId")]
-        id: String,
-        launch_time: chrono::DateTime<Utc>,
-        state: InstanceState,
-        #[serde(default)]
-        tags: Vec<Tag>,
-    }
-
-    #[derive(serde::Deserialize, Debug)]
-    #[serde(rename_all = "PascalCase")]
-    struct Reservation {
-        instances: Vec<Instance>,
-    }
-
-    #[derive(serde::Deserialize, Debug)]
-    #[serde(rename_all = "PascalCase")]
-    struct Instances {
-        reservations: Vec<Reservation>,
-    }
-
-    #[derive(Debug)]
-    struct BorsInstance {
-        instance: Instance,
-    }
-
     let creds = get_aws_credentials(&ec2_ctx.role_arn).await?;
-    let instances = run_command(
-        prepare_aws_cli(Some(&creds), Some(&ec2_config.region))
-            .arg("ec2")
-            .arg("describe-instances"),
-    )
-    .await
-    .context("Cannot list running EC2 instances")?;
-
-    let instances: Vec<BorsInstance> = serde_json::from_str::<Instances>(&instances)?
-        .reservations
-        .into_iter()
-        .flat_map(|r| r.instances)
-        .filter_map(|instance| {
-            let terminate = instance.tags.iter().find(|t| t.key == TAG_BORS_TERMINATE)?;
-            if terminate.value != "true" {
-                return None;
-            }
-
-            Some(BorsInstance { instance })
-        })
-        .collect();
+    let instances = get_ec2_instances(repo.repository(), &creds, ec2_config)
+        .await
+        .context("Cannot load EC2 instances")?;
     if instances.is_empty() {
         tracing::info!("Did not find any bors EC2 instances");
         return Ok(());
@@ -296,9 +241,9 @@ pub async fn terminate_old_ec2_instances(
     let deadline = Utc::now() - timeout;
     let too_old_ids = instances
         .into_iter()
-        .filter(|instance| instance.instance.state.name != "terminated")
-        .filter(|instance| instance.instance.launch_time < deadline)
-        .map(|instance| instance.instance.id)
+        .filter(|instance| !matches!(instance.status, Ec2InstanceStatus::Terminated))
+        .filter(|instance| instance.started_at < deadline)
+        .map(|instance| instance.id)
         .collect::<Vec<String>>();
 
     if !too_old_ids.is_empty() {
@@ -325,33 +270,142 @@ pub async fn terminate_old_ec2_instances(
     Ok(())
 }
 
-fn prepare_aws_cli(
-    creds: Option<&RoleCredentials>,
-    region: Option<&str>,
-) -> tokio::process::Command {
-    let mut cmd = tokio::process::Command::new("aws");
-    if let Some(creds) = creds {
-        cmd.env("AWS_ACCESS_KEY_ID", &creds.access_key_id);
-        cmd.env("AWS_SECRET_ACCESS_KEY", &creds.secret_access_key);
-        cmd.env("AWS_SESSION_TOKEN", &creds.session_token);
+/// Return EC2 instances for the given repo and region that are managed by bors.
+pub async fn get_ec2_instances(
+    repo: &GithubRepoName,
+    creds: &RoleCredentials,
+    ec2_config: &Ec2RunnersConfig,
+) -> anyhow::Result<Vec<Ec2Instance>> {
+    #[derive(serde::Deserialize, Debug)]
+    #[serde(rename_all = "PascalCase")]
+    struct InstanceState {
+        name: String,
     }
-    if let Some(region) = region {
-        cmd.arg("--region").arg(region);
+
+    #[derive(serde::Deserialize, Debug)]
+    #[serde(rename_all = "PascalCase")]
+    struct Tag {
+        key: String,
+        value: String,
     }
-    cmd.kill_on_drop(true);
-    cmd
+
+    #[derive(serde::Deserialize, Debug)]
+    #[serde(rename_all = "PascalCase")]
+    struct Instance {
+        #[serde(rename = "InstanceId")]
+        id: String,
+        launch_time: chrono::DateTime<Utc>,
+        state: InstanceState,
+        #[serde(default)]
+        tags: Vec<Tag>,
+        #[serde(default, rename = "StateTransitionReason")]
+        reason: Option<String>,
+    }
+
+    #[derive(serde::Deserialize, Debug)]
+    #[serde(rename_all = "PascalCase")]
+    struct Reservation {
+        instances: Vec<Instance>,
+    }
+
+    #[derive(serde::Deserialize, Debug)]
+    #[serde(rename_all = "PascalCase")]
+    struct Instances {
+        reservations: Vec<Reservation>,
+    }
+
+    let mut cli = prepare_aws_cli(Some(creds), Some(&ec2_config.region));
+    cli.arg("ec2").arg("describe-instances").arg("--filters");
+
+    // Filter by bors terminate marker and repository
+    cli.arg(format!("Name=tag:{TAG_BORS_TERMINATE},Values=true"));
+    cli.arg(format!("Name=tag:{TAG_REPO},Values={repo}"));
+
+    let instances = run_command(&mut cli)
+        .await
+        .context("Cannot list running EC2 instances")?;
+
+    let instances = serde_json::from_str::<Instances>(&instances)?
+        .reservations
+        .into_iter()
+        .flat_map(|r| r.instances)
+        .filter_map(|instance| {
+            let tags: HashMap<String, String> = instance
+                .tags
+                .into_iter()
+                .map(|t| (t.key, t.value))
+                .collect();
+            let job_id = tags
+                .get(TAG_JOB_ID)
+                .and_then(|id| id.parse::<u64>().map(JobId).ok())?;
+            let job_name = tags.get(TAG_JOB_ID).cloned()?;
+            let run_id = tags
+                .get(TAG_RUN_ID)
+                .and_then(|id| id.parse::<u64>().map(RunId).ok())?;
+            let pr_number = tags
+                .get(TAG_PR_NUMBER)
+                .and_then(|pr| pr.parse::<u64>().map(PullRequestNumber).ok());
+
+            let status = match instance.state.name.as_str() {
+                "pending" => Ec2InstanceStatus::Pending,
+                "running" => Ec2InstanceStatus::Running,
+                "shutting-down" => Ec2InstanceStatus::ShuttingDown,
+                "terminated" => Ec2InstanceStatus::Terminated,
+                "stopping" => Ec2InstanceStatus::Stopping,
+                "stopped" => Ec2InstanceStatus::Stopped,
+                _ => Ec2InstanceStatus::Unknown(instance.state.name),
+            };
+
+            let ended_at = instance.reason.and_then(|r| parse_state_transition(&r));
+
+            Some(Ec2Instance {
+                id: instance.id,
+                job_id,
+                job_name,
+                run_id,
+                started_at: instance.launch_time,
+                ended_at,
+                pr_number,
+                status,
+            })
+        })
+        .collect();
+    Ok(instances)
+}
+
+#[derive(Debug)]
+pub enum Ec2InstanceStatus {
+    Pending,
+    Running,
+    ShuttingDown,
+    Terminated,
+    Stopping,
+    Stopped,
+    Unknown(String),
+}
+
+#[derive(Debug)]
+pub struct Ec2Instance {
+    pub id: String,
+    pub job_id: JobId,
+    pub job_name: String,
+    pub run_id: RunId,
+    pub started_at: DateTime<Utc>,
+    pub ended_at: Option<DateTime<Utc>>,
+    pub pr_number: Option<PullRequestNumber>,
+    pub status: Ec2InstanceStatus,
 }
 
 #[derive(Deserialize)]
 #[serde(rename_all = "PascalCase")]
-struct RoleCredentials {
+pub struct RoleCredentials {
     access_key_id: String,
     secret_access_key: String,
     session_token: String,
 }
 
 /// Assume the given role with the current AWS credentials, to create credentials for the role.
-async fn get_aws_credentials(role_arn: &str) -> anyhow::Result<RoleCredentials> {
+pub async fn get_aws_credentials(role_arn: &str) -> anyhow::Result<RoleCredentials> {
     #[derive(Deserialize)]
     #[serde(rename_all = "PascalCase")]
     struct Root {
@@ -371,6 +425,23 @@ async fn get_aws_credentials(role_arn: &str) -> anyhow::Result<RoleCredentials> 
     let creds: Root =
         serde_json::from_str(&output).context("Cannot deserialize aws sts assume-role output")?;
     Ok(creds.credentials)
+}
+
+fn prepare_aws_cli(
+    creds: Option<&RoleCredentials>,
+    region: Option<&str>,
+) -> tokio::process::Command {
+    let mut cmd = tokio::process::Command::new("aws");
+    if let Some(creds) = creds {
+        cmd.env("AWS_ACCESS_KEY_ID", &creds.access_key_id);
+        cmd.env("AWS_SECRET_ACCESS_KEY", &creds.secret_access_key);
+        cmd.env("AWS_SESSION_TOKEN", &creds.session_token);
+    }
+    if let Some(region) = region {
+        cmd.arg("--region").arg(region);
+    }
+    cmd.kill_on_drop(true);
+    cmd
 }
 
 async fn run_command(cmd: &mut tokio::process::Command) -> anyhow::Result<String> {
@@ -394,9 +465,21 @@ async fn run_command(cmd: &mut tokio::process::Command) -> anyhow::Result<String
     }
 }
 
+/// Parse State transition reason of EC2 instances, for example:
+/// `User initiated (2026-08-01 18:44:49 GMT)`
+fn parse_state_transition(text: &str) -> Option<DateTime<Utc>> {
+    static TRANSITION_REGEX: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r#"^.*\((.*?)\).*$"#).unwrap());
+
+    let re = TRANSITION_REGEX.captures(text)?;
+    let group = re.get(1)?;
+    let date = NaiveDateTime::parse_from_str(group.as_str(), "%Y-%m-%d %H:%M:%S %Z").ok()?;
+    Some(DateTime::from_naive_utc_and_offset(date, Utc))
+}
+
 #[cfg(test)]
 mod tests {
-    use super::ParsedLabel;
+    use super::{ParsedLabel, parse_state_transition};
 
     #[test]
     fn parse_label() {
@@ -413,5 +496,12 @@ mod tests {
     #[test]
     fn parse_label_different_prefix() {
         assert!(ParsedLabel::parse("x64-linux", "ec2").is_none());
+    }
+
+    #[test]
+    fn parse_state_transition_reason() {
+        let reason = "User initiated (2026-08-01 18:44:49 GMT)";
+        let date = parse_state_transition(reason).unwrap();
+        insta::assert_debug_snapshot!(date, @"2026-08-01T18:44:49Z");
     }
 }

--- a/src/ec2/mod.rs
+++ b/src/ec2/mod.rs
@@ -1,6 +1,7 @@
 use crate::bors::RepositoryState;
 use crate::bors::event::WorkflowJobStarted;
 use crate::config::{Ec2RunnersConfig, JitRunnerKind};
+use crate::github::PullRequestNumber;
 use anyhow::Context;
 use chrono::Utc;
 use serde::Deserialize;
@@ -20,6 +21,8 @@ const TAG_JOB_ID: &str = "bors-job-id";
 const TAG_JOB_NAME: &str = "bors-job-name";
 /// Tag with the workflow run ID for which the instance was started.
 const TAG_RUN_ID: &str = "bors-run-id";
+/// Tag with the pull request number for which the instance was started.
+const TAG_PR_NUMBER: &str = "bors-pr-number";
 
 /// How much time to wait before timeouting each aws command execution.
 const AWS_COMMAND_TIMEOUT: Duration = Duration::from_secs(30);
@@ -73,6 +76,7 @@ pub async fn start_ec2_github_runner(
     repo: &RepositoryState,
     label: ParsedLabel<'_>,
     payload: &WorkflowJobStarted,
+    pr_number: Option<PullRequestNumber>,
 ) -> anyhow::Result<()> {
     tracing::info!("Trying to start EC2 runner for label {}", label.label);
     let Some(image_name) = ec2.images.get(label.image_name) else {
@@ -136,14 +140,18 @@ pub async fn start_ec2_github_runner(
         payload.commit_sha,
     );
 
-    let tags = [
-        ("Name", instance_name.as_str()),
-        (TAG_BORS_TERMINATE, "true"),
-        (TAG_REPO, &repo.repository().to_string()),
-        (TAG_JOB_ID, &payload.job_id.to_string()),
-        (TAG_JOB_NAME, &payload.name),
-        (TAG_RUN_ID, &payload.run_id.to_string()),
+    let mut tags = vec![
+        ("Name", instance_name.clone()),
+        (TAG_BORS_TERMINATE, "true".to_string()),
+        (TAG_REPO, repo.repository().to_string()),
+        (TAG_JOB_ID, payload.job_id.to_string()),
+        (TAG_JOB_NAME, payload.name.clone()),
+        (TAG_RUN_ID, payload.run_id.to_string()),
     ];
+    if let Some(pr_number) = pr_number {
+        tags.push((TAG_PR_NUMBER, pr_number.to_string()));
+    }
+
     let tags = tags
         .into_iter()
         .map(|(k, v)| {

--- a/src/ec2/mod.rs
+++ b/src/ec2/mod.rs
@@ -12,8 +12,14 @@ const LAUNCH_SCRIPT: &str = include_str!("ec2-runner-script.sh");
 
 /// Instance tag that specifies that the given instance should be garbage collected by bors.
 const TAG_BORS_TERMINATE: &str = "bors-terminate";
-/// Tag with the job ID for which the instance was started.
+/// Tag with the repository for which the instance was started.
+const TAG_REPO: &str = "bors-repo";
+/// Tag with the workflow job ID for which the instance was started.
 const TAG_JOB_ID: &str = "bors-job-id";
+/// Tag with the workflow job name for which the instance was started.
+const TAG_JOB_NAME: &str = "bors-job-name";
+/// Tag with the workflow run ID for which the instance was started.
+const TAG_RUN_ID: &str = "bors-run-id";
 
 /// How much time to wait before timeouting each aws command execution.
 const AWS_COMMAND_TIMEOUT: Duration = Duration::from_secs(30);
@@ -130,15 +136,23 @@ pub async fn start_ec2_github_runner(
         payload.commit_sha,
     );
 
-    let job_id = payload.job_id.to_string();
     let tags = [
         ("Name", instance_name.as_str()),
         (TAG_BORS_TERMINATE, "true"),
-        (TAG_JOB_ID, job_id.as_str()),
+        (TAG_REPO, &repo.repository().to_string()),
+        (TAG_JOB_ID, &payload.job_id.to_string()),
+        (TAG_JOB_NAME, &payload.name),
+        (TAG_RUN_ID, &payload.run_id.to_string()),
     ];
     let tags = tags
         .into_iter()
-        .map(|(k, v)| format!("{{Key={k},Value={v}}}"))
+        .map(|(k, v)| {
+            format!(
+                "{{Key=\"{}\",Value=\"{}\"}}",
+                k.replace("\"", ""),
+                v.replace("\"", "")
+            )
+        })
         .collect::<Vec<_>>()
         .join(",");
 

--- a/src/ec2/mod.rs
+++ b/src/ec2/mod.rs
@@ -131,7 +131,7 @@ pub async fn start_ec2_github_runner(
 
     let script = LAUNCH_SCRIPT.replace("$JITCONFIG", &jit_config.encoded_jit_config);
 
-    let creds = get_aws_credentials(&ec2_ctx.role_arn).await?;
+    let creds = get_aws_credentials(ec2_ctx).await?;
 
     // Hopefully a unique key that identifies this specific instance
     let instance_name = format!(
@@ -224,7 +224,7 @@ pub async fn terminate_old_ec2_instances(
 
     let timeout = repo_config.timeout;
 
-    let creds = get_aws_credentials(&ec2_ctx.role_arn).await?;
+    let creds = get_aws_credentials(ec2_ctx).await?;
     let instances = get_ec2_instances(repo.repository(), &creds, ec2_config)
         .await
         .context("Cannot load EC2 instances")?;
@@ -405,7 +405,7 @@ pub struct RoleCredentials {
 }
 
 /// Assume the given role with the current AWS credentials, to create credentials for the role.
-pub async fn get_aws_credentials(role_arn: &str) -> anyhow::Result<RoleCredentials> {
+pub async fn get_aws_credentials(ctx: &Ec2Context) -> anyhow::Result<RoleCredentials> {
     #[derive(Deserialize)]
     #[serde(rename_all = "PascalCase")]
     struct Root {
@@ -416,7 +416,7 @@ pub async fn get_aws_credentials(role_arn: &str) -> anyhow::Result<RoleCredentia
     cli.arg("sts")
         .arg("assume-role")
         .arg("--role-arn")
-        .arg(role_arn)
+        .arg(&ctx.role_arn)
         .arg("--role-session-name")
         .arg("bors");
     let output = run_command(&mut cli)

--- a/src/ec2/mod.rs
+++ b/src/ec2/mod.rs
@@ -373,7 +373,7 @@ pub async fn get_ec2_instances(
     Ok(instances)
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum Ec2InstanceStatus {
     Pending,
     Running,
@@ -384,7 +384,7 @@ pub enum Ec2InstanceStatus {
     Unknown(String),
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Ec2Instance {
     pub id: String,
     pub job_id: JobId,

--- a/src/ec2/mod.rs
+++ b/src/ec2/mod.rs
@@ -377,10 +377,10 @@ pub async fn get_ec2_instances(
 pub enum Ec2InstanceStatus {
     Pending,
     Running,
-    ShuttingDown,
-    Terminated,
     Stopping,
     Stopped,
+    ShuttingDown,
+    Terminated,
     Unknown(String),
 }
 

--- a/src/ec2/mod.rs
+++ b/src/ec2/mod.rs
@@ -1,5 +1,5 @@
-use crate::bors::RepositoryState;
 use crate::bors::event::WorkflowJobStarted;
+use crate::bors::{BuildKind, RepositoryState};
 use crate::config::{Ec2RunnersConfig, JitRunnerKind};
 use crate::database::RunId;
 use crate::github::{GithubRepoName, PullRequestNumber};
@@ -27,6 +27,8 @@ const TAG_JOB_NAME: &str = "bors-job-name";
 const TAG_RUN_ID: &str = "bors-run-id";
 /// Tag with the pull request number for which the instance was started.
 const TAG_PR_NUMBER: &str = "bors-pr-number";
+/// Tag with the build kind (auto/try) for which the instance was started.
+const TAG_BUILD_KIND: &str = "bors-build-kind";
 
 /// How much time to wait before timeouting each aws command execution.
 const AWS_COMMAND_TIMEOUT: Duration = Duration::from_secs(30);
@@ -81,6 +83,7 @@ pub async fn start_ec2_github_runner(
     label: ParsedLabel<'_>,
     payload: &WorkflowJobStarted,
     pr_number: Option<PullRequestNumber>,
+    build_kind: BuildKind,
 ) -> anyhow::Result<()> {
     tracing::info!("Trying to start EC2 runner for label {}", label.label);
     let Some(image_name) = ec2.images.get(label.image_name) else {
@@ -151,6 +154,14 @@ pub async fn start_ec2_github_runner(
         (TAG_JOB_ID, payload.job_id.to_string()),
         (TAG_JOB_NAME, payload.name.clone()),
         (TAG_RUN_ID, payload.run_id.to_string()),
+        (
+            TAG_BUILD_KIND,
+            match build_kind {
+                BuildKind::Try => "try",
+                BuildKind::Auto => "auto",
+            }
+            .to_string(),
+        ),
     ];
     if let Some(pr_number) = pr_number {
         tags.push((TAG_PR_NUMBER, pr_number.to_string()));
@@ -345,6 +356,13 @@ pub async fn get_ec2_instances(
             let pr_number = tags
                 .get(TAG_PR_NUMBER)
                 .and_then(|pr| pr.parse::<u64>().map(PullRequestNumber).ok());
+            let build_kind =
+                tags.get(TAG_BUILD_KIND)
+                    .and_then(|build_kind| match build_kind.as_str() {
+                        "try" => Some(BuildKind::Try),
+                        "auto" => Some(BuildKind::Auto),
+                        _ => None,
+                    })?;
 
             let status = match instance.state.name.as_str() {
                 "pending" => Ec2InstanceStatus::Pending,
@@ -360,13 +378,14 @@ pub async fn get_ec2_instances(
 
             Some(Ec2Instance {
                 id: instance.id,
+                status,
                 job_id,
                 job_name,
                 run_id,
                 started_at: instance.launch_time,
                 ended_at,
                 pr_number,
-                status,
+                build_kind,
             })
         })
         .collect();
@@ -387,13 +406,14 @@ pub enum Ec2InstanceStatus {
 #[derive(Clone, Debug)]
 pub struct Ec2Instance {
     pub id: String,
+    pub status: Ec2InstanceStatus,
     pub job_id: JobId,
     pub job_name: String,
     pub run_id: RunId,
     pub started_at: DateTime<Utc>,
     pub ended_at: Option<DateTime<Utc>>,
     pub pr_number: Option<PullRequestNumber>,
-    pub status: Ec2InstanceStatus,
+    pub build_kind: BuildKind,
 }
 
 #[derive(Deserialize)]

--- a/src/server/cached.rs
+++ b/src/server/cached.rs
@@ -1,0 +1,51 @@
+use chrono::{DateTime, Utc};
+use std::sync::RwLock;
+use std::time::Duration;
+
+/// Cached value with some maximum staleness
+pub struct Cached<T> {
+    value: RwLock<Option<CachedValue<T>>>,
+    max_stale_duration: chrono::Duration,
+}
+
+impl<T: Clone> Cached<T> {
+    pub fn new(max_stale_duration: Duration) -> Self {
+        Self {
+            value: RwLock::new(None),
+            max_stale_duration: chrono::Duration::from_std(max_stale_duration).unwrap(),
+        }
+    }
+
+    pub async fn load<F>(&self, func: F) -> anyhow::Result<CachedValue<T>>
+    where
+        F: AsyncFnOnce() -> anyhow::Result<T>,
+    {
+        {
+            let lock = self.value.read().unwrap();
+            if let Some(value) = lock.as_ref()
+                && Utc::now().signed_duration_since(value.loaded_at) < self.max_stale_duration
+            {
+                // Cache hit
+                return Ok(value.clone());
+            }
+        }
+
+        // Try to load a new value
+        let value = func().await?;
+
+        let cached_value = CachedValue {
+            value,
+            loaded_at: Utc::now(),
+        };
+        let mut lock = self.value.write().unwrap();
+        *lock = Some(cached_value.clone());
+
+        Ok(cached_value)
+    }
+}
+
+#[derive(Clone)]
+pub struct CachedValue<T> {
+    pub value: T,
+    pub loaded_at: DateTime<Utc>,
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,7 +1,7 @@
 use crate::bors::event::BorsEvent;
-use crate::bors::{CommandPrefix, RepositoryState, format_help};
+use crate::bors::{BuildKind, CommandPrefix, RepositoryState, format_help};
 use crate::database::{ApprovalStatus, QueueStatus};
-use crate::ec2::{Ec2Instance, get_aws_credentials, get_ec2_instances};
+use crate::ec2::{Ec2Instance, Ec2InstanceStatus, get_aws_credentials, get_ec2_instances};
 use crate::github::{GithubRepoName, PullRequestNumber, rollup};
 use crate::server::cached::Cached;
 use crate::templates::{
@@ -517,12 +517,34 @@ pub async fn ec2_handler(
         anyhow::Ok(instances)
     };
     let cached = state.cache.ec2_instances.load(load_instances).await?;
+    let mut instances = cached.value;
+    instances.sort_by(|a, b| {
+        // Sort by status first, then build kind, then started date
+        let status = |instance: &Ec2Instance| match instance.status {
+            Ec2InstanceStatus::Pending => 0,
+            Ec2InstanceStatus::Running => 1,
+            Ec2InstanceStatus::Stopping => 2,
+            Ec2InstanceStatus::Stopped => 3,
+            Ec2InstanceStatus::ShuttingDown => 4,
+            Ec2InstanceStatus::Terminated => 5,
+            _ => 6,
+        };
+        let build_kind = |instance: &Ec2Instance| match instance.build_kind {
+            BuildKind::Auto => 0,
+            BuildKind::Try => 1,
+        };
+
+        status(a)
+            .cmp(&status(b))
+            .then_with(|| build_kind(a).cmp(&build_kind(b)))
+            .then_with(|| a.started_at.cmp(&b.started_at))
+    });
 
     Ok(HtmlTemplate(EC2Template {
         repo_name,
         repo_owner,
         repo_url: format!("https://github.com/{gh_repo_name}"),
-        instances: cached.value,
+        instances,
         loaded_at: cached.loaded_at,
     })
     .into_response())

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,8 +1,9 @@
 use crate::bors::event::BorsEvent;
 use crate::bors::{CommandPrefix, RepositoryState, format_help};
 use crate::database::{ApprovalStatus, QueueStatus};
-use crate::ec2::{get_aws_credentials, get_ec2_instances};
+use crate::ec2::{Ec2Instance, get_aws_credentials, get_ec2_instances};
 use crate::github::{GithubRepoName, PullRequestNumber, rollup};
+use crate::server::cached::Cached;
 use crate::templates::{
     EC2Template, HelpTemplate, HtmlTemplate, NotFoundTemplate, PullRequestStats, QueueTemplate,
     RepositoryView, RollupsInfo,
@@ -36,7 +37,11 @@ use tower_http::trace::TraceLayer;
 use tracing::Span;
 use webhook::GitHubWebhook;
 
+mod cached;
 pub mod webhook;
+
+/// How often to reload EC2 instance list from AWS.
+const EC2_INSTANCE_RELOAD_DURATION: Duration = Duration::from_secs(60 * 2);
 
 /// Shared server state for all axum handlers.
 pub struct ServerState {
@@ -45,6 +50,7 @@ pub struct ServerState {
     webhook_secret: WebhookSecret,
     oauth: Option<OAuthClient>,
     ctx: Arc<BorsContext>,
+    cache: ServerCache,
 }
 
 impl ServerState {
@@ -61,6 +67,7 @@ impl ServerState {
             webhook_secret,
             oauth,
             ctx,
+            cache: ServerCache::default(),
         }
     }
 
@@ -95,6 +102,18 @@ impl FromRef<ServerStateRef> for Arc<PgDbClient> {
 
 #[derive(Clone)]
 pub struct ServerStateRef(pub Arc<ServerState>);
+
+struct ServerCache {
+    ec2_instances: Cached<Vec<Ec2Instance>>,
+}
+
+impl Default for ServerCache {
+    fn default() -> Self {
+        Self {
+            ec2_instances: Cached::new(EC2_INSTANCE_RELOAD_DURATION),
+        }
+    }
+}
 
 pub fn create_app(state: ServerState) -> Router {
     let compression_layer = CompressionLayer::new()
@@ -492,14 +511,19 @@ pub async fn ec2_handler(
             .into_response());
     };
 
-    let creds = get_aws_credentials(ec2_context).await?;
-    let instances = get_ec2_instances(&gh_repo_name, &creds, ec2_config).await?;
+    let load_instances = async || {
+        let creds = get_aws_credentials(ec2_context).await?;
+        let instances = get_ec2_instances(&gh_repo_name, &creds, ec2_config).await?;
+        anyhow::Ok(instances)
+    };
+    let cached = state.cache.ec2_instances.load(load_instances).await?;
 
     Ok(HtmlTemplate(EC2Template {
         repo_name,
         repo_owner,
         repo_url: format!("https://github.com/{gh_repo_name}"),
-        instances,
+        instances: cached.value,
+        loaded_at: cached.loaded_at,
     })
     .into_response())
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,10 +1,11 @@
 use crate::bors::event::BorsEvent;
 use crate::bors::{CommandPrefix, RepositoryState, format_help};
 use crate::database::{ApprovalStatus, QueueStatus};
+use crate::ec2::{get_aws_credentials, get_ec2_instances};
 use crate::github::{GithubRepoName, PullRequestNumber, rollup};
 use crate::templates::{
-    HelpTemplate, HtmlTemplate, NotFoundTemplate, PullRequestStats, QueueTemplate, RepositoryView,
-    RollupsInfo,
+    EC2Template, HelpTemplate, HtmlTemplate, NotFoundTemplate, PullRequestStats, QueueTemplate,
+    RepositoryView, RollupsInfo,
 };
 use crate::utils::sort_queue::sort_queue_prs;
 use crate::{
@@ -132,7 +133,11 @@ pub fn create_app(state: ServerState) -> Router {
         .route("/help", get(help_handler))
         .route(
             "/queue/{repo_name}",
-            get(queue_handler).layer(compression_layer),
+            get(queue_handler).layer(compression_layer.clone()),
+        )
+        .route(
+            "/ec2/{repo_owner}/{repo_name}",
+            get(ec2_handler).layer(compression_layer),
         )
         .route("/github", post(github_webhook_handler))
         .route("/health", get(health_handler))
@@ -456,6 +461,49 @@ pub async fn queue_handler(
     .into_response())
 }
 
+pub async fn ec2_handler(
+    Path((repo_owner, repo_name)): Path<(String, String)>,
+    State(ServerStateRef(state)): State<ServerStateRef>,
+) -> Result<impl IntoResponse, AppError> {
+    let Some(ec2_context) = state.ctx.get_ec2_ctx() else {
+        return Ok((
+            StatusCode::SERVICE_UNAVAILABLE,
+            "EC2 context is not configured for this bors instance".to_string(),
+        )
+            .into_response());
+    };
+
+    let gh_repo_name = GithubRepoName::new(&repo_owner, &repo_name);
+    let repo = match state.get_repo(&gh_repo_name) {
+        Some(repo) => repo,
+        None => {
+            return Ok((
+                StatusCode::UNPROCESSABLE_ENTITY,
+                format!("Repository {gh_repo_name} not found"),
+            )
+                .into_response());
+        }
+    };
+    let Some(ec2_config) = &repo.config.load().ec2_runners else {
+        return Ok((
+            StatusCode::UNPROCESSABLE_ENTITY,
+            format!("Repository {gh_repo_name} does not have EC2 configured"),
+        )
+            .into_response());
+    };
+
+    let creds = get_aws_credentials(ec2_context).await?;
+    let instances = get_ec2_instances(&gh_repo_name, &creds, ec2_config).await?;
+
+    Ok(HtmlTemplate(EC2Template {
+        repo_name,
+        repo_owner,
+        repo_url: format!("https://github.com/{gh_repo_name}"),
+        instances,
+    })
+    .into_response())
+}
+
 /// Axum handler that receives a webhook and sends it to a webhook channel.
 pub async fn github_webhook_handler(
     State(ServerStateRef(state)): State<ServerStateRef>,
@@ -496,6 +544,6 @@ mod tests {
             insta::assert_snapshot!(response, @r#"[{"number":1,"title":"Title of PR 1","author":"default-user","status":"open","head_branch":"pr/1","base_branch":"main","priority":null,"approver":"default-user","try_build":null,"auto_build":null}]"#);
             Ok(())
         })
-        .await;
+            .await;
     }
 }

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -1,3 +1,4 @@
+use crate::bors::BuildKind;
 use crate::bors::RollupMode::*;
 use crate::database::{
     BuildModel, BuildStatus, MergeableState::*, PullRequestModel, QueueStatus, TreeState,
@@ -171,7 +172,7 @@ impl EC2Template {
     }
 
     fn get_lifetime(&self, instance: &Ec2Instance) -> String {
-        let end = instance.ended_at.unwrap_or_else(|| Utc::now());
+        let end = instance.ended_at.unwrap_or_else(Utc::now);
         let duration = end
             .signed_duration_since(instance.started_at)
             .to_std()

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -154,6 +154,7 @@ pub struct EC2Template {
     pub repo_owner: String,
     pub repo_url: String,
     pub instances: Vec<Ec2Instance>,
+    pub loaded_at: chrono::DateTime<Utc>,
 }
 
 impl EC2Template {

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -3,6 +3,7 @@ use crate::database::{
     BuildModel, BuildStatus, MergeableState::*, PullRequestModel, QueueStatus, TreeState,
     WorkflowModel,
 };
+use crate::ec2::{Ec2Instance, Ec2InstanceStatus};
 use crate::github::PullRequestNumber;
 use askama::Template;
 use axum::response::{Html, IntoResponse, Response};
@@ -95,35 +96,7 @@ pub struct QueueTemplate {
 
 impl QueueTemplate {
     fn format_duration(&self, duration: Duration) -> String {
-        let total_seconds = duration.as_secs();
-        let days = total_seconds / 86400;
-        let hours = (total_seconds % 86400) / 3600;
-        let minutes = (total_seconds % 3600) / 60;
-
-        let mut output = String::new();
-        if days > 0 {
-            write!(output, "{days}d").unwrap();
-        }
-
-        if hours > 0 {
-            if !output.is_empty() {
-                output.push(' ');
-            }
-            write!(output, "{hours}h").unwrap();
-        }
-
-        if days == 0 && minutes > 0 {
-            if !output.is_empty() {
-                output.push(' ');
-            }
-            write!(output, "{minutes}m").unwrap();
-        }
-
-        if output.is_empty() {
-            output.push_str("<1m");
-        }
-
-        output
+        format_duration(duration)
     }
 
     fn pending_build_elapsed(&self, build: &BuildModel) -> Duration {
@@ -172,6 +145,70 @@ impl QueueTemplate {
         // and the result is significant
         pr.note() == Some("rustc-perf")
     }
+}
+
+#[derive(Template)]
+#[template(path = "ec2.html", whitespace = "minimize")]
+pub struct EC2Template {
+    pub repo_name: String,
+    pub repo_owner: String,
+    pub repo_url: String,
+    pub instances: Vec<Ec2Instance>,
+}
+
+impl EC2Template {
+    fn format_status<'a>(&self, status: &'a Ec2InstanceStatus) -> &'a str {
+        match status {
+            Ec2InstanceStatus::Pending => "Starting",
+            Ec2InstanceStatus::Running => "Running",
+            Ec2InstanceStatus::ShuttingDown => "Shutting down",
+            Ec2InstanceStatus::Terminated => "Terminated",
+            Ec2InstanceStatus::Stopping => "Stopping",
+            Ec2InstanceStatus::Stopped => "Stopped",
+            Ec2InstanceStatus::Unknown(reason) => reason.as_str(),
+        }
+    }
+
+    fn get_lifetime(&self, instance: &Ec2Instance) -> String {
+        let end = instance.ended_at.unwrap_or_else(|| Utc::now());
+        let duration = end
+            .signed_duration_since(instance.started_at)
+            .to_std()
+            .unwrap_or(Duration::ZERO);
+        format_duration(duration)
+    }
+}
+
+fn format_duration(duration: Duration) -> String {
+    let total_seconds = duration.as_secs();
+    let days = total_seconds / 86400;
+    let hours = (total_seconds % 86400) / 3600;
+    let minutes = (total_seconds % 3600) / 60;
+
+    let mut output = String::new();
+    if days > 0 {
+        write!(output, "{days}d").unwrap();
+    }
+
+    if hours > 0 {
+        if !output.is_empty() {
+            output.push(' ');
+        }
+        write!(output, "{hours}h").unwrap();
+    }
+
+    if days == 0 && minutes > 0 {
+        if !output.is_empty() {
+            output.push(' ');
+        }
+        write!(output, "{minutes}m").unwrap();
+    }
+
+    if output.is_empty() {
+        output.push_str("<1m");
+    }
+
+    output
 }
 
 #[derive(Template)]

--- a/web/templates/ec2.html
+++ b/web/templates/ec2.html
@@ -1,0 +1,77 @@
+{% extends "base.html" %}
+
+{% block title %}EC2 instances of {{ repo_owner }}/{{ repo_name }}{% endblock %}
+
+{% block head %}
+<style>
+    main {
+        max-width: 65rem;
+        width: 100%;
+    }
+
+    table {
+        margin-block: var(--space-s);
+    }
+
+    tbody tr:last-child td {
+        border-bottom: none;
+    }
+
+    th,
+    td {
+        padding: var(--space-xs) var(--space-s);
+        border-bottom: 1px solid var(--color-border-muted);
+        white-space: nowrap;
+    }
+
+    th {
+        background-color: var(--color-bg-higlight);
+    }
+</style>
+{% endblock %}
+
+{% block body %}
+<main>
+  <h1>EC2 instances of <b>{{ repo_owner }}/{{ repo_name }}</b></h1>
+
+  <table>
+    <thead>
+    <tr>
+      <th>ID</th>
+      <th>PR</th>
+      <th>Job</th>
+      <th>State</th>
+      <th>Started at</th>
+      <th>Ended at</th>
+      <th>Lifetime</th>
+    </tr>
+    </thead>
+    {% for instance in instances %}
+    <tr>
+      <td>{{ instance.id }}</td>
+      <td>
+        {% if let Some(pr_number) = instance.pr_number %}
+        <a href="{{ repo_url }}/pull/{{ pr_number }}">{{ pr_number }}</a></td>
+      {% else %}
+      Unknown
+      {% endif %}
+      <td><a href="{{ repo_url }}/actions/runs/{{ instance.run_id }}/job/{{ instance.job_id }}">{{
+        instance.job_name }}</a></td>
+      <td>{{ format_status(&instance.status) }}</td>
+      <td>{{ instance.started_at.to_string() }}</td>
+      <td>
+        {% if let Some(ended_at) = instance.ended_at %}
+        {{ ended_at.to_string() }}
+        {% endif %}
+      </td>
+      <td>
+        {{ get_lifetime(&instance) }}
+      </td>
+    </tr>
+    {% endfor %}
+  </table>
+  <div style="text-align: center; margin-top: 1em;">
+    <a href="https://github.com/rust-lang/bors">Contribute on GitHub</a>
+  </div>
+</main>
+{% endblock %}

--- a/web/templates/ec2.html
+++ b/web/templates/ec2.html
@@ -39,6 +39,7 @@
     <tr>
       <th>ID</th>
       <th>PR</th>
+      <th>Build kind</th>
       <th>Job</th>
       <th>State</th>
       <th>Started at</th>
@@ -55,6 +56,14 @@
       {% else %}
       Unknown
       {% endif %}
+      <td>
+        {% match instance.build_kind %}
+        {% when BuildKind::Try %}
+        try
+        {% when BuildKind::Auto %}
+        auto
+        {% endmatch %}
+      </td>
       <td><a href="{{ repo_url }}/actions/runs/{{ instance.run_id }}/job/{{ instance.job_id }}">{{
         instance.job_name }}</a></td>
       <td>{{ format_status(&instance.status) }}</td>

--- a/web/templates/ec2.html
+++ b/web/templates/ec2.html
@@ -70,6 +70,7 @@
     </tr>
     {% endfor %}
   </table>
+  <div>Instance list loaded at {{ loaded_at }}</div>
   <div style="text-align: center; margin-top: 1em;">
     <a href="https://github.com/rust-lang/bors">Contribute on GitHub</a>
   </div>


### PR DESCRIPTION
This PR adds additional tags/metadata to the started EC2 instances, and adds a new page that lists all EC2 instances started by bors for a given repository (reloaded on-demand, cached for 2 minutes). This should help with debugging the EC2 instances without having to go to AWS.

<img width="1161" height="335" alt="image" src="https://github.com/user-attachments/assets/142936bb-fe3f-4a12-ba61-a06d5811d6df" />