### PR TITLE
Add links to the queue page

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -486,6 +486,13 @@ pub async fn queue_handler(
             Some(expected_remaining_duration.unwrap_or_default() + remaining_duration);
     }
 
+    let ec2_configured = state.ctx.get_ec2_ctx().is_some()
+        && state
+            .ctx
+            .get_repo(&repo.name)
+            .map(|r| r.config.load().ec2_runners.is_some())
+            .unwrap_or(false);
+
     Ok(HtmlTemplate(QueueTemplate {
         oauth_client_id: oauth
             .as_ref()
@@ -505,6 +512,7 @@ pub async fn queue_handler(
         rollups_info: RollupsInfo::from(rollups),
         expected_remaining_duration,
         average_build_duration,
+        ec2_configured,
     })
     .into_response())
 }

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -103,6 +103,7 @@ pub struct QueueTemplate {
     pub expected_remaining_duration: Option<Duration>,
     // Average build duration over the past few successful auto builds
     pub average_build_duration: Duration,
+    pub ec2_configured: bool,
 }
 
 impl QueueTemplate {

--- a/web/templates/queue.html
+++ b/web/templates/queue.html
@@ -248,7 +248,12 @@
       {% endif %}
       {% endif %}
     </h1>
-    <a href="/help">Help</a>
+    <div>
+      {% if ec2_configured %}
+      <a href="/ec2/{{ repo_owner }}/{{ repo_name }}">EC2 instances</a> |
+      {% endif %}
+      <a href="/help">Help</a>
+    </div>
   </nav>
 
   <div style="margin-bottom: 1rem; display: flex; align-items: center;">

--- a/web/templates/queue.html
+++ b/web/templates/queue.html
@@ -225,21 +225,31 @@
         display: flex;
         margin-left: 5px;
     }
+    nav {
+        margin-bottom: 10px;
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+        align-items: center;
+    }
 </style>
 {% endblock %}
 
 {% block body %}
 <main>
-  <h1>
-    <a href="/help">Bors</a> queue - <a href="{{ repo_url }}" target="_blank">{{ repo_name }}</a>
-    {% if tree_state.is_closed() %}
-    {% if let Some(comment_source) = tree_state.comment_source() %}
-    {% if let Some(priority) = tree_state.priority() %}
-    [<a href="{{ comment_source }}">TREECLOSED</a> below priority {{ priority }}{% if let Some(reason) = tree_state.reason() %} ({{ reason }}){% endif %}]
-    {% endif %}
-    {% endif %}
-    {% endif %}
-  </h1>
+  <nav>
+    <h1 style="margin-bottom: 0;">
+      Bors queue - <a href="{{ repo_url }}" target="_blank">{{ repo_name }}</a>
+      {% if tree_state.is_closed() %}
+      {% if let Some(comment_source) = tree_state.comment_source() %}
+      {% if let Some(priority) = tree_state.priority() %}
+      [<a href="{{ comment_source }}">TREECLOSED</a> below priority {{ priority }}{% if let Some(reason) = tree_state.reason() %} ({{ reason }}){% endif %}]
+      {% endif %}
+      {% endif %}
+      {% endif %}
+    </h1>
+    <a href="/help">Help</a>
+  </nav>
 
   <div style="margin-bottom: 1rem; display: flex; align-items: center;">
     <button id="showRollupSelection">Create rollup</button>


### PR DESCRIPTION
Before I wasn't sure how to fit the available space, but the solution was kinda obvious in retrospect.

<img width="2543" height="144" alt="image" src="https://github.com/user-attachments/assets/9ab91323-e383-4085-b47b-59f2f49c18b0" />

Fixes: https://github.com/rust-lang/bors/issues/604