### PR TITLE
add `.idea` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target/
 .DS_Store
 __pycache__/
 data/team/*.json
+.idea/


### PR DESCRIPTION
Hi!

This is just a very small PR (as we discussed via Discord) to add the entire .idea folder to `.gitignore`. 

This makes it much easier to switch and especially rebase branches, while preserving the `.idea` config without the worry of dropping it or having to stash it constantly.