### PR TITLE
Simplify startup script

### DIFF
--- a/src/ec2/ec2-runner-script.sh
+++ b/src/ec2/ec2-runner-script.sh
@@ -1,41 +1,9 @@
 #!/bin/bash
 
-export DEBIAN_FRONTEND=noninteractive
+# $JITCONFIG is replaced by bors with the actual JIT token.
+echo '$JITCONFIG' | sudo -u ubuntu tee /home/ubuntu/jit-token > /dev/null
 
-apt update && apt install -y build-essential unzip
-
-# Without this we end up hitting the tiny default pids limit on larger hosts.
-mkdir -p /etc/containers
-touch /etc/containers/nodocker
-cat > /etc/containers/containers.conf <<EOF
-[containers]
-pids_limit=1000000
-default_ulimits=["nofile=100000:100000"]
-EOF
-
-ARCH="$(uname -m)"
-curl "https://awscli.amazonaws.com/awscli-exe-linux-${ARCH}.zip" -o "/tmp/awscliv2.zip"
-mkdir -p /var/tmp/aws-cli
-cd /var/tmp/aws-cli
-unzip /tmp/awscliv2.zip
-sudo ./aws/install
-cd -
-
-sudo --login -u ubuntu bash -c 'curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal'
-
-ulimit -n $(ulimit -n -H)
-
-# Provision github actions runner
-# https://github.com/actions/runner/blob/main/docs/start/envlinux.md
-apt install -y liblttng-ust1t64 libkrb5-3 zlib1g libssl3 libicu78
-apt install -y docker.io docker-buildx jq python3-pip
-usermod -a -G docker ubuntu
-systemctl start docker
-sudo --login -u ubuntu bash -c 'mkdir actions-runner'
-
-# Note: the runner should self-update
-sudo --login -u ubuntu bash -c 'cd actions-runner && curl -o runner.tar.gz -L https://github.com/actions/runner/releases/download/v2.335.1/actions-runner-linux-x64-2.335.1.tar.gz'
-sudo --login -u ubuntu bash -c 'cd actions-runner && tar xzf runner.tar.gz'
-sudo --login -u ubuntu bash -c 'cd actions-runner && ./run.sh --jitconfig "$JITCONFIG"'
-sleep 30
-shutdown now
+# Will terminate instance once it exits (either successfully or with failure).
+# The unit itself is defined as part of the pre-built AMI, see
+# https://github.com/rust-lang/simpleinfra/blob/master/terragrunt/modules/ci-runners/lambda/ubuntu.pkr.hcl
+systemctl start gha-runner


### PR DESCRIPTION
Now that we are baking AMIs, we can remove most of the complexity from bors related to starting instances.

This should also speed up time waiting for the instance to come up, though it already wasn't particularly long.

I think this should work but we should obviously verify on staging.