### PR TITLE
Add a hint to `@bors try cancel`

### DIFF
--- a/src/bors/comment.rs
+++ b/src/bors/comment.rs
@@ -140,12 +140,13 @@ pub fn try_build_cancelled_with_failed_workflow_cancel_comment() -> Comment {
 }
 
 pub fn try_build_cancelled_comment(workflow_urls: impl Iterator<Item = String>) -> Comment {
-    let mut try_build_cancelled_comment =
-        r#"Try build cancelled. Cancelled workflows:"#.to_string();
+    let mut comment = r#"Try build cancelled. Cancelled workflows:"#.to_string();
     for url in workflow_urls {
-        try_build_cancelled_comment += format!("\n- {url}").as_str();
+        comment += format!("\n- {url}").as_str();
     }
-    Comment::new(try_build_cancelled_comment)
+    writeln!(comment, "\n\n**Hint**: if you want to run another try build, you do not need to manually cancel the previous one. Just run `@bors try` and bors will cancel the previous build automatically.").unwrap();
+
+    Comment::new(comment)
 }
 
 pub fn build_failed_comment(

--- a/src/bors/handlers/trybuild.rs
+++ b/src/bors/handlers/trybuild.rs
@@ -776,7 +776,11 @@ try-job: Bar
 
             To cancel the try build, run the command `@bors try cancel`.
             ");
-            insta::assert_snapshot!(ctx.get_next_comment_text(()).await?, @"Try build cancelled. Cancelled workflows:");
+            insta::assert_snapshot!(ctx.get_next_comment_text(()).await?, @"
+            Try build cancelled. Cancelled workflows:
+
+            **Hint**: if you want to run another try build, you do not need to manually cancel the previous one. Just run `@bors try` and bors will cancel the previous build automatically.
+            ");
             Ok(())
         })
         .await;
@@ -861,6 +865,8 @@ try-job: Bar
             Try build cancelled. Cancelled workflows:
             - https://github.com/rust-lang/borstest/actions/runs/1
             - https://github.com/rust-lang/borstest/actions/runs/2
+
+            **Hint**: if you want to run another try build, you do not need to manually cancel the previous one. Just run `@bors try` and bors will cancel the previous build automatically.
             ");
             ctx.expect_cancelled_workflows((), &[w1, w2]);
 
@@ -919,6 +925,8 @@ try-job: Bar
             insta::assert_snapshot!(ctx.get_next_comment_text(()).await?, @"
             Try build cancelled. Cancelled workflows:
             - https://github.com/rust-lang/borstest/actions/runs/3
+
+            **Hint**: if you want to run another try build, you do not need to manually cancel the previous one. Just run `@bors try` and bors will cancel the previous build automatically.
             ");
             ctx.expect_cancelled_workflows((), &[w3]);
             Ok(())


### PR DESCRIPTION
I sometimes see people cancelling a running try build unnecessarily. This hint might help.
