### PR TITLE
Trigger the merge queue when the priority of a PR changes

### DIFF
--- a/src/bors/handlers/mod.rs
+++ b/src/bors/handlers/mod.rs
@@ -531,9 +531,17 @@ async fn handle_comment(
                     }
                     BorsCommand::SetPriority { priority, note } => {
                         let span = tracing::info_span!("Priority");
-                        command_set_priority(repo, database, pr, &comment.author, priority, note)
-                            .instrument(span)
-                            .await
+                        command_set_priority(
+                            repo,
+                            database,
+                            pr,
+                            &comment.author,
+                            priority,
+                            note,
+                            senders.merge_queue(),
+                        )
+                        .instrument(span)
+                        .await
                     }
                     BorsCommand::Delegate(cmd) => {
                         let span = tracing::info_span!("Delegate");

--- a/src/bors/handlers/review.rs
+++ b/src/bors/handlers/review.rs
@@ -279,6 +279,7 @@ pub(super) async fn command_set_priority(
     author: &GithubUser,
     priority: u32,
     note: Option<String>,
+    merge_queue_tx: &MergeQueueSender,
 ) -> anyhow::Result<()> {
     if !has_permission(&repo_state, author, pr, PermissionType::Review).await? {
         deny_request(
@@ -291,7 +292,12 @@ pub(super) async fn command_set_priority(
         .await?;
         return Ok(());
     };
-    db.set_priority(pr.db, priority, note).await
+    db.set_priority(pr.db, priority, note).await?;
+
+    // Changing the priority can be interesting for the merge queue
+    merge_queue_tx.notify().await?;
+
+    Ok(())
 }
 
 /// Delegate permissions of a pull request to its author.


### PR DESCRIPTION
This is not really a concern on `rust-lang/rust`, but when testing on smaller repositories, it is nicer if the merge queue is triggered when priority changes, to avoid waiting for its normal background tick unnecessarily.
