### PR TITLE
Correctly parse unrolled member build kind from EC2 instance tags

### DIFF
--- a/src/ec2/mod.rs
+++ b/src/ec2/mod.rs
@@ -469,6 +469,7 @@ pub async fn get_ec2_instances(
                     .and_then(|build_kind| match build_kind.as_str() {
                         "try" => Some(BuildKind::Try),
                         "auto" => Some(BuildKind::Auto),
+                        "try-perf" => Some(BuildKind::UnrolledMember),
                         _ => None,
                     })?;
 

--- a/src/ec2/mod.rs
+++ b/src/ec2/mod.rs
@@ -5,6 +5,7 @@ use crate::database::{RunId, WorkflowStatus};
 use crate::github::{CommitSha, GithubRepoName, PullRequestNumber};
 use anyhow::Context;
 use chrono::{DateTime, NaiveDateTime, Utc};
+use itertools::Itertools;
 use octocrab::models::JobId;
 use octocrab::models::workflows::Status;
 use regex::Regex;
@@ -572,17 +573,36 @@ fn prepare_aws_cli(
 }
 
 async fn run_command(cmd: &mut tokio::process::Command) -> anyhow::Result<String> {
+    fn format_command(cmd: &tokio::process::Command) {
+        // The command probably has secrets in ENV, so only print the command-line arguments
+        let program = cmd
+            .as_std()
+            .get_program()
+            .to_str()
+            .unwrap_or_default()
+            .to_string();
+        let args = cmd
+            .as_std()
+            .get_args()
+            .into_iter()
+            .filter_map(|arg| arg.to_str())
+            .join(" ");
+        format!("{program} {args}")
+    }
+
     let output = match tokio::time::timeout(AWS_COMMAND_TIMEOUT, cmd.output()).await {
         Ok(output) => output?,
         Err(_) => {
             return Err(anyhow::anyhow!(
-                "Command {cmd:?} has timeouted after one minute"
+                "Command {} has timeouted after one minute",
+                format_command(cmd)
             ));
         }
     };
     if !output.status.success() {
         Err(anyhow::anyhow!(
-            "Command {cmd:?} ended with status {}.\nStdout:\n{}\n\nStderr:\n{}\n",
+            "Command {} ended with status {}.\nStdout:\n{}\n\nStderr:\n{}\n",
+            format_command(cmd),
             output.status,
             String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr),

--- a/src/ec2/mod.rs
+++ b/src/ec2/mod.rs
@@ -5,12 +5,12 @@ use crate::database::{RunId, WorkflowStatus};
 use crate::github::{CommitSha, GithubRepoName, PullRequestNumber};
 use anyhow::Context;
 use chrono::{DateTime, NaiveDateTime, Utc};
-use itertools::Itertools;
 use octocrab::models::JobId;
 use octocrab::models::workflows::Status;
 use regex::Regex;
 use serde::Deserialize;
 use std::collections::HashMap;
+use std::process::Command;
 use std::sync::{Arc, LazyLock};
 use std::time::Duration;
 
@@ -574,21 +574,22 @@ fn prepare_aws_cli(
 }
 
 async fn run_command(cmd: &mut tokio::process::Command) -> anyhow::Result<String> {
-    fn format_command(cmd: &tokio::process::Command) {
+    fn format_command(cmd: &Command) -> String {
         // The command probably has secrets in ENV, so only print the command-line arguments
-        let program = cmd
-            .as_std()
-            .get_program()
-            .to_str()
-            .unwrap_or_default()
-            .to_string();
-        let args = cmd
-            .as_std()
-            .get_args()
-            .into_iter()
-            .filter_map(|arg| arg.to_str())
-            .join(" ");
-        format!("{program} {args}")
+        let program = cmd.get_program().to_str().unwrap_or_default();
+        let mut args = vec![];
+        let mut iter = cmd.get_args();
+        while let Some(arg) = iter.next().and_then(|v| v.to_str()) {
+            if arg == "--user-data" {
+                // Skip the following argument, as it might be sensitive
+                iter.next();
+                args.push("--user-data");
+                args.push("<REDACTED>");
+            } else {
+                args.push(arg);
+            }
+        }
+        format!("{program} {}", args.join(" "))
     }
 
     let output = match tokio::time::timeout(AWS_COMMAND_TIMEOUT, cmd.output()).await {
@@ -596,14 +597,14 @@ async fn run_command(cmd: &mut tokio::process::Command) -> anyhow::Result<String
         Err(_) => {
             return Err(anyhow::anyhow!(
                 "Command {} has timeouted after one minute",
-                format_command(cmd)
+                format_command(cmd.as_std())
             ));
         }
     };
     if !output.status.success() {
         Err(anyhow::anyhow!(
             "Command {} ended with status {}.\nStdout:\n{}\n\nStderr:\n{}\n",
-            format_command(cmd),
+            format_command(cmd.as_std()),
             output.status,
             String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr),


### PR DESCRIPTION
And also do not log sensitive information.
