### PR TITLE
Make gha-runner startup non-blocking in user-data

### DIFF
--- a/src/ec2/ec2-runner-script.sh
+++ b/src/ec2/ec2-runner-script.sh
@@ -1,9 +1,18 @@
 #!/bin/bash
 
-# $JITCONFIG is replaced by bors with the actual JIT token.
+# JITCONFIG is *textually* replaced by bors with the actual JIT token.
+# The JIT token is base64 encoded by GitHub, so it shouldn't have any single quotes in the string.
+#
+# This is read by the gha-runner service started below.
 echo '$JITCONFIG' | sudo -u ubuntu tee /home/ubuntu/jit-token > /dev/null
 
 # Will terminate instance once it exits (either successfully or with failure).
+#
+# If no job is started in a few minutes after this runs, the instance will also
+# terminate.
+#
 # The unit itself is defined as part of the pre-built AMI, see
 # https://github.com/rust-lang/simpleinfra/blob/master/terragrunt/modules/ci-runners/lambda/ubuntu.pkr.hcl
-systemctl start gha-runner
+#
+# --no-block avoids blocking the remainder of cloud-init on this job starting. That keeps the journal and console tidier.
+systemctl start --no-block gha-runner


### PR DESCRIPTION
With changes in the AMIs (https://github.com/rust-lang/simpleinfra/pull/1170), this was showing up as two different units running:

```
[ ***  ] (2 of 2) Job gha-runner.service/start running (2min 59s / 3min)
[***   ] (1 of 2) Job cloud-final.service/start running (3min 13s / no limit)
```

which is needlessly verbose. It also might block some processing done by cloud-init after the user data (not sure).

If we ever added anything to run after the unit has started this might need tweaking but for now it seems pretty reasonable.

As a drive-by improvement this also adjusts the script to have a single JITCONFIG variable instance, we were replacing both previously.

I've confirmed the `--no-block` aspect works with my manual run scripts, but of course we should double check on staging after merging this. The output now has just a single unit:

```
[    **] Job gha-runner.service/start running (53s / 3min)
```