### PR TITLE
Add a sanity check for valid bors config before merging a PR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,6 +327,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -377,7 +383,7 @@ dependencies = [
  "askama",
  "axum",
  "axum-embed",
- "base64",
+ "base64 0.23.1",
  "bytes",
  "chrono",
  "clap",
@@ -1440,7 +1446,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1669,7 +1675,7 @@ version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "ed25519-dalek",
  "getrandom 0.2.17",
  "hmac 0.12.1",
@@ -1934,7 +1940,7 @@ checksum = "63f6687a23731011d0117f9f4c3cdabaa7b5e42ca671f42b5cc0657c492540e3"
 dependencies = [
  "arc-swap",
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "cargo_metadata",
  "cfg-if",
@@ -2046,7 +2052,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -2405,7 +2411,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "http",
@@ -2965,7 +2971,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "crc",
@@ -3041,7 +3047,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
- "base64",
+ "base64 0.22.1",
  "bitflags",
  "byteorder",
  "bytes",
@@ -3084,7 +3090,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
- "base64",
+ "base64 0.22.1",
  "bitflags",
  "byteorder",
  "chrono",
@@ -4208,7 +4214,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
 dependencies = [
  "assert-json-diff",
- "base64",
+ "base64 0.22.1",
  "deadpool",
  "futures",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,11 +71,11 @@ which = "8"
 # Text processing
 pulldown-cmark = "0.13"
 regex = "1"
+base64 = "0.23"
 
 [dev-dependencies]
 insta = "1.26"
 wiremock = "0.6"
-base64 = "0.22"
 tracing-test = "0.2"
 parking_lot = "0.12"
 thread_local = "1"

--- a/src/bors/merge_queue.rs
+++ b/src/bors/merge_queue.rs
@@ -21,6 +21,7 @@ use crate::bors::handlers::{
 use crate::bors::mergeability_queue::{MergeabilityQueueSender, update_pr_with_known_mergeability};
 use crate::bors::unroll_queue::UnrollQueueSender;
 use crate::bors::{AUTO_BRANCH_NAME, BuildKind, PullRequestStatus, RepositoryState};
+use crate::config::{CONFIG_FILE_PATH, deserialize_config};
 use crate::database::{
     ApprovalInfo, BuildModel, BuildStatus, ExclusiveLockProof, ExclusiveOperationOutcome,
     MergeableState, PullRequestModel, QueueStatus, UpdateBuildParams,
@@ -524,6 +525,41 @@ This rollup has been unapproved."#,
             );
             Ok(AutoBuildStartOutcome::PauseQueue)
         }
+        StartAutoBuildError::SanityCheckFailed {
+            error: SanityCheckError::ConfigMissing,
+            pr: gh_pr,
+        } => {
+            tracing::info!("Sanity check failed for PR {pr_num}: bors config is missing");
+
+            unapprove_pr(repo, &ctx.db, pr, &gh_pr.into()).await?;
+            let comment = format!(
+                "The bors config is missing in this PR. Ensure that the config exists at `{CONFIG_FILE_PATH}`."
+            );
+            repo.client
+                .post_comment(pr_num, Comment::new(comment), &ctx.db)
+                .await?;
+            Ok(AutoBuildStartOutcome::ContinueToNextPr)
+        }
+        StartAutoBuildError::SanityCheckFailed {
+            error: SanityCheckError::ConfigInvalid { error },
+            pr: gh_pr,
+        } => {
+            tracing::info!("Sanity check failed for PR {pr_num}: bors config is invalid");
+
+            unapprove_pr(repo, &ctx.db, pr, &gh_pr.into()).await?;
+            let comment = format!(
+                r#"The bors config at `{CONFIG_FILE_PATH}` is invalid in this PR. Parse error:
+
+```
+{error}
+```
+"#
+            );
+            repo.client
+                .post_comment(pr_num, Comment::new(comment), &ctx.db)
+                .await?;
+            Ok(AutoBuildStartOutcome::ContinueToNextPr)
+        }
     }
 }
 
@@ -557,6 +593,10 @@ enum SanityCheckError {
         status: PullRequestStatus,
     },
     RollupMemberMismatch(Vec<RollupMemberMismatch>),
+    ConfigMissing,
+    ConfigInvalid {
+        error: String,
+    },
 }
 
 async fn sanity_check_pr(
@@ -680,6 +720,25 @@ async fn start_auto_build(
         .map_err(StartAutoBuildError::GitHubError)?;
     let head_sha = gh_pr.head.sha.clone();
 
+    let result = sanity_check_config(repo, &head_sha)
+        .await
+        .map_err(StartAutoBuildError::GitHubError)?;
+    match result {
+        ConfigCheckResult::Ok => {}
+        ConfigCheckResult::Missing => {
+            return Err(StartAutoBuildError::SanityCheckFailed {
+                error: SanityCheckError::ConfigMissing,
+                pr: gh_pr,
+            });
+        }
+        ConfigCheckResult::Invalid { error } => {
+            return Err(StartAutoBuildError::SanityCheckFailed {
+                error: SanityCheckError::ConfigInvalid { error },
+                pr: gh_pr,
+            });
+        }
+    }
+
     let pr_data = super::handlers::PullRequestData {
         db: pr,
         github: &gh_pr,
@@ -734,6 +793,34 @@ async fn start_auto_build(
     };
 
     Ok(())
+}
+
+#[must_use]
+enum ConfigCheckResult {
+    Ok,
+    Missing,
+    Invalid { error: String },
+}
+
+/// Ensures that the commit that we are about to merge has a valid bors config.
+async fn sanity_check_config(
+    repo: &RepositoryState,
+    commit_sha: &CommitSha,
+) -> anyhow::Result<ConfigCheckResult> {
+    let config = repo
+        .client
+        .load_file_at(CONFIG_FILE_PATH, Some(commit_sha.clone()))
+        .await?;
+    let Some(config) = config else {
+        return Ok(ConfigCheckResult::Missing);
+    };
+    if let Err(error) = deserialize_config(&config) {
+        Ok(ConfigCheckResult::Invalid {
+            error: error.to_string(),
+        })
+    } else {
+        Ok(ConfigCheckResult::Ok)
+    }
 }
 
 /// Starts the background merge queue loop.
@@ -836,6 +923,7 @@ mod tests {
     use std::time::Duration;
 
     use crate::bors::with_mocked_time;
+    use crate::github::CommitSha;
     use crate::github::api::client::HideCommentReason;
     use crate::tests::{BorsBuilder, Commit, GitHub, run_test};
     use crate::tests::{default_branch_name, default_repo_name};
@@ -1524,6 +1612,54 @@ auto_build_failed = ["+foo", "+bar", "-baz"]
                 CheckRunStatus::Completed,
                 Some(CheckRunConclusion::Failure),
             );
+            Ok(())
+        })
+        .await;
+    }
+
+    #[sqlx::test(migrator = "crate::MIGRATOR")]
+    async fn auto_build_missing_config(pool: sqlx::PgPool) {
+        run_test(pool, async |ctx: &mut BorsTester| {
+            let pr = ctx.open_pr((), |_| {}).await?;
+            ctx.repo().lock().contents.insert(CommitSha(pr.head_sha()), None);
+            ctx.approve(pr.id()).await?;
+            ctx.run_merge_queue_now().await;
+            insta::assert_snapshot!(ctx.get_next_comment_text(pr.id()).await?, @"The bors config is missing in this PR. Ensure that the config exists at `rust-bors.toml`.");
+            ctx.pr(pr.id())
+                .await
+                .expect_no_auto_build()
+                .expect_unapproved();
+            Ok(())
+        })
+            .await;
+    }
+
+    #[sqlx::test(migrator = "crate::MIGRATOR")]
+    async fn auto_build_invalid_config(pool: sqlx::PgPool) {
+        run_test(pool, async |ctx: &mut BorsTester| {
+            let pr = ctx.open_pr((), |_| {}).await?;
+            ctx.repo().lock().contents.insert(
+                CommitSha(pr.head_sha()),
+                Some("[foo bar I am invalid toml!".to_string()),
+            );
+            ctx.approve(pr.id()).await?;
+            ctx.run_merge_queue_now().await;
+            insta::assert_snapshot!(ctx.get_next_comment_text(pr.id()).await?, @"
+            The bors config at `rust-bors.toml` is invalid in this PR. Parse error:
+
+            ```
+            TOML parse error at line 1, column 5
+              |
+            1 | [foo bar I am invalid toml!
+              |     ^
+            unclosed table, expected `]`
+
+            ```
+            ");
+            ctx.pr(pr.id())
+                .await
+                .expect_no_auto_build()
+                .expect_unapproved();
             Ok(())
         })
         .await;

--- a/src/github/api/client.rs
+++ b/src/github/api/client.rs
@@ -1,4 +1,5 @@
 use anyhow::Context;
+use base64::Engine;
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use octocrab::Octocrab;
@@ -158,46 +159,55 @@ impl GithubRepositoryClient {
     /// Loads repository configuration from a file located at `[CONFIG_FILE_PATH]` in the main
     /// branch.
     pub async fn load_config(&self) -> anyhow::Result<RepositoryConfig> {
-        let config = perform_retryable::<RepositoryConfig, anyhow::Error, _, _, _>(
-            "load_config",
+        let content = self.load_file_at(CONFIG_FILE_PATH, None).await?;
+        let Some(content) = content else {
+            return Err(anyhow::anyhow!("Bors configuration file not found"));
+        };
+        let config: RepositoryConfig = deserialize_config(&content).map_err(|error| {
+            anyhow::anyhow!("Could not deserialize repository config: {error:?}")
+        })?;
+        Ok(config)
+    }
+
+    /// Loads a file at the specified `path` and commit `sha`.
+    /// If the commit SHA is not specified, loads the file from the default branch.
+    pub async fn load_file_at(
+        &self,
+        path: &str,
+        sha: Option<CommitSha>,
+    ) -> anyhow::Result<Option<String>> {
+        use std::fmt::Write;
+
+        let content = perform_retryable::<Option<String>, anyhow::Error, _, _, _>(
+            "load_file_at",
             RetryMethod::default(),
             || async {
-                let mut response = self
-                    .client
-                    .repos(&self.repo_name.owner, &self.repo_name.name)
-                    .get_content()
-                    .path(CONFIG_FILE_PATH)
-                    .send()
+                let mut uri = format!("/repos/{}/contents/{path}", self.repository());
+                if let Some(sha) = &sha {
+                    write!(uri, "?ref={sha}").unwrap();
+                }
+
+                #[derive(serde::Deserialize)]
+                struct Response {
+                    content: String,
+                }
+
+                let response = self.client._get(&uri).await?;
+                let contents = get_optional::<Response>(&self.client, response)
                     .await
                     .map_err(|error| {
-                        anyhow::anyhow!(
-                            "Could not fetch {CONFIG_FILE_PATH} from {}: {error:?}",
-                            self.repo_name
-                        )
+                        anyhow::anyhow!("Could not fetch {path} from {}: {error:?}", self.repo_name)
                     })?;
-
-                response
-                    .take_items()
-                    .into_iter()
-                    .next()
-                    .and_then(|content| content.decoded_content())
-                    .ok_or_else(|| anyhow::anyhow!("Configuration file not found"))
-                    .and_then(|content| {
-                        let config: RepositoryConfig =
-                            deserialize_config(&content).map_err(|error| {
-                                anyhow::anyhow!(
-                                    "Could not deserialize repository config: {error:?}"
-                                )
-                            })?;
-                        Ok(config)
-                    })
-                    // If the config can't be found or parsed, there is no need for retrying at this
-                    // moment
-                    .map_err(ShouldRetry::No)
+                let Some(contents) = contents else {
+                    return Ok(None);
+                };
+                let content =
+                    base64::prelude::BASE64_STANDARD.decode(contents.content.as_bytes())?;
+                anyhow::Ok(Some(String::from_utf8_lossy(&content).into_owned()))
             },
         )
         .await?;
-        Ok(config)
+        Ok(content)
     }
 
     /// Return the current SHA of the given branch.
@@ -538,7 +548,7 @@ impl GithubRepositoryClient {
                     url: run.html_url.to_string(),
                     status,
                     created_at: run.created_at,
-                    duration
+                    duration,
                 };
                 runs.push(run);
             }

--- a/src/tests/github.rs
+++ b/src/tests/github.rs
@@ -388,6 +388,7 @@ pub struct Repo {
     pub push_behaviour: BranchPushBehaviour,
     pub fork_of: Option<Arc<Mutex<Repo>>>,
     pub merge_behavior: MergeBehavior,
+    pub contents: HashMap<CommitSha, Option<String>>,
 }
 
 impl Repo {
@@ -408,6 +409,7 @@ impl Repo {
             push_behaviour: BranchPushBehaviour::default(),
             fork_of: None,
             merge_behavior: MergeBehavior::default(),
+            contents: Default::default(),
         };
         repo.add_branch(Branch::default());
         repo

--- a/src/tests/mock/repository.rs
+++ b/src/tests/mock/repository.rs
@@ -2,6 +2,7 @@ use std::ops::Deref;
 use std::sync::Arc;
 
 use crate::database::WorkflowStatus;
+use crate::github::CommitSha;
 use crate::tests::BranchPushError;
 use crate::tests::github::{CheckRunData, Commit, GitUser, WorkflowRun};
 use crate::tests::mock::pull_request::mock_pull_requests;
@@ -69,7 +70,7 @@ pub async fn mock_repo(
     mock_check_runs(repo.clone(), mock_server).await;
     mock_workflow_runs(repo.clone(), mock_server).await;
     mock_workflow_jobs(repo.clone(), mock_server).await;
-    mock_config(repo.clone(), mock_server).await;
+    mock_contents(repo.clone(), mock_server).await;
 }
 
 async fn mock_branches_and_commits(repo: Arc<Mutex<Repo>>, mock_server: &MockServer) {
@@ -468,29 +469,48 @@ async fn mock_workflow_jobs(repo: Arc<Mutex<Repo>>, mock_server: &MockServer) {
 }
 
 fn get_query_param(req: &Request, key: &str) -> String {
+    get_query_param_opt(req, key)
+        .unwrap_or_else(|| panic!("Query parameter {key} not found in {}", req.url))
+}
+
+fn get_query_param_opt(req: &Request, key: &str) -> Option<String> {
     req.url
         .query_pairs()
         .find(|(k, _)| k == key)
         .map(|(_, v)| v.to_string())
-        .unwrap_or_else(|| panic!("Query parameter {key} not found in {}", req.url))
 }
 
-async fn mock_config(repo: Arc<Mutex<Repo>>, mock_server: &MockServer) {
-    // Extracted into a block to avoid holding the lock over an await point
-    let mock = {
-        let repo = repo.lock();
-        Mock::given(method("GET"))
-            .and(path(format!(
-                "/repos/{}/contents/rust-bors.toml",
-                repo.full_name()
-            )))
-            .respond_with(
-                ResponseTemplate::new(200)
-                    .set_body_json(GitHubContent::new("rust-bors.toml", &repo.config)),
-            )
-            .mount(mock_server)
-    };
-    mock.await;
+async fn mock_contents(repo: Arc<Mutex<Repo>>, mock_server: &MockServer) {
+    let repo_name = repo.lock().full_name();
+    dynamic_mock_req(
+        move |req: &Request, [path]: [&str; 1]| {
+            let sha = get_query_param_opt(req, "ref");
+            let repo = repo.lock();
+
+            // Request for overridden file content at a specific commit SHA
+            if let Some(sha) = sha {
+                let file = repo.contents.get(&CommitSha(sha));
+                if let Some(file) = file {
+                    return match file {
+                        Some(content) => ResponseTemplate::new(200)
+                            .set_body_json(GitHubContent::new(path, content)),
+                        None => ResponseTemplate::new(404),
+                    };
+                }
+            }
+
+            // Request for default config path
+            if path == "rust-bors.toml" {
+                ResponseTemplate::new(200).set_body_json(GitHubContent::new(path, &repo.config))
+            } else {
+                ResponseTemplate::new(404)
+            }
+        },
+        "GET",
+        format!("^/repos/{repo_name}/contents/(.*)$"),
+    )
+    .mount(mock_server)
+    .await;
 }
 
 #[derive(serde::Deserialize)]


### PR DESCRIPTION
Before starting an auto merge, we check that the PR to be merged has a valid (and present) bors config file.

Fixes: https://github.com/rust-lang/bors/issues/829
